### PR TITLE
feat: XMDS method= param, reportFaults, enableStat (#7 #8 #9)

### DIFF
--- a/packages/renderer/src/renderer-lite.js
+++ b/packages/renderer/src/renderer-lite.js
@@ -378,6 +378,7 @@ export class RendererLite {
       duration: layoutDurationAttr ? parseInt(layoutDurationAttr) : 0, // 0 = calculate from widgets
       bgcolor: layoutEl.getAttribute('bgcolor') || '#000000',
       background: layoutEl.getAttribute('background') || null, // Background image fileId
+      enableStat: layoutEl.getAttribute('enableStat') !== '0', // absent or "1" = enabled
       regions: []
     };
 
@@ -495,6 +496,7 @@ export class RendererLite {
       useDuration, // Whether to use specified duration (1) or media length (0)
       id,
       fileId, // Media library file ID for cache lookup
+      enableStat: mediaEl.getAttribute('enableStat') !== '0', // absent or "1" = enabled
       options,
       raw,
       transitions,
@@ -1318,7 +1320,8 @@ export class RendererLite {
         this.emit('widgetStart', {
           widgetId: widget.id, regionId, layoutId: this.currentLayoutId,
           mediaId: parseInt(widget.fileId || widget.id) || null,
-          type: widget.type, duration: widget.duration
+          type: widget.type, duration: widget.duration,
+          enableStat: widget.enableStat
         });
       }
     } catch (error) {
@@ -1342,7 +1345,8 @@ export class RendererLite {
       this.emit('widgetEnd', {
         widgetId: widget.id, regionId, layoutId: this.currentLayoutId,
         mediaId: parseInt(widget.fileId || widget.id) || null,
-        type: widget.type
+        type: widget.type,
+        enableStat: widget.enableStat
       });
     }
   }

--- a/packages/renderer/src/renderer-lite.test.js
+++ b/packages/renderer/src/renderer-lite.test.js
@@ -157,6 +157,86 @@ describe('RendererLite', () => {
     });
   });
 
+  describe('enableStat parsing', () => {
+    it('should parse enableStat="1" as true on layout', () => {
+      const xlf = `
+        <layout enableStat="1">
+          <region id="r1">
+            <media id="m1" type="image" duration="10"></media>
+          </region>
+        </layout>
+      `;
+      const layout = renderer.parseXlf(xlf);
+      expect(layout.enableStat).toBe(true);
+    });
+
+    it('should parse enableStat="0" as false on layout', () => {
+      const xlf = `
+        <layout enableStat="0">
+          <region id="r1">
+            <media id="m1" type="image" duration="10"></media>
+          </region>
+        </layout>
+      `;
+      const layout = renderer.parseXlf(xlf);
+      expect(layout.enableStat).toBe(false);
+    });
+
+    it('should default enableStat to true when absent on layout', () => {
+      const xlf = `
+        <layout>
+          <region id="r1">
+            <media id="m1" type="image" duration="10"></media>
+          </region>
+        </layout>
+      `;
+      const layout = renderer.parseXlf(xlf);
+      expect(layout.enableStat).toBe(true);
+    });
+
+    it('should parse enableStat="0" as false on widget', () => {
+      const xlf = `
+        <layout>
+          <region id="r1">
+            <media id="m1" type="image" duration="10" enableStat="0">
+              <options><uri>test.png</uri></options>
+            </media>
+          </region>
+        </layout>
+      `;
+      const layout = renderer.parseXlf(xlf);
+      expect(layout.regions[0].widgets[0].enableStat).toBe(false);
+    });
+
+    it('should parse enableStat="1" as true on widget', () => {
+      const xlf = `
+        <layout>
+          <region id="r1">
+            <media id="m1" type="image" duration="10" enableStat="1">
+              <options><uri>test.png</uri></options>
+            </media>
+          </region>
+        </layout>
+      `;
+      const layout = renderer.parseXlf(xlf);
+      expect(layout.regions[0].widgets[0].enableStat).toBe(true);
+    });
+
+    it('should default enableStat to true when absent on widget', () => {
+      const xlf = `
+        <layout>
+          <region id="r1">
+            <media id="m1" type="image" duration="10">
+              <options><uri>test.png</uri></options>
+            </media>
+          </region>
+        </layout>
+      `;
+      const layout = renderer.parseXlf(xlf);
+      expect(layout.regions[0].widgets[0].enableStat).toBe(true);
+    });
+  });
+
   describe('Region Creation', () => {
     it('should create region element with correct positioning', async () => {
       const regionConfig = {

--- a/packages/xmds/src/rest-client.js
+++ b/packages/xmds/src/rest-client.js
@@ -326,6 +326,17 @@ export class RestClient {
    * SubmitStats - submit proof of play statistics
    * POST /stats → JSON acknowledgement
    */
+  /**
+   * ReportFaults - submit fault data to CMS for dashboard alerts
+   * POST /fault → JSON acknowledgement
+   * @param {string} faultJson - JSON-encoded fault data
+   * @returns {Promise<boolean>}
+   */
+  async reportFaults(faultJson) {
+    const result = await this.restSend('POST', '/fault', { fault: faultJson });
+    return result?.success === true;
+  }
+
   async submitStats(statsXml) {
     try {
       // Accept array (JSON-native) or string (XML) — send under the right key

--- a/packages/xmds/src/xmds-client.js
+++ b/packages/xmds/src/xmds-client.js
@@ -73,7 +73,7 @@ export class XmdsClient {
    */
   async call(method, params = {}) {
     const xmdsUrl = this.rewriteXmdsUrl(this.config.cmsAddress);
-    const url = `${xmdsUrl}${xmdsUrl.includes('?') ? '&' : '?'}v=${this.schemaVersion}`;
+    const url = `${xmdsUrl}${xmdsUrl.includes('?') ? '&' : '?'}v=${this.schemaVersion}&method=${method}`;
     const body = this.buildEnvelope(method, params);
 
     log.debug(`${method}`, params);
@@ -354,6 +354,19 @@ export class XmdsClient {
    * @param {string} statsXml - XML-encoded stats string
    * @returns {Promise<boolean>} - true if stats were successfully submitted
    */
+  /**
+   * ReportFaults - submit fault data to CMS for dashboard alerts
+   * @param {string} faultJson - JSON-encoded fault data
+   * @returns {Promise<boolean>}
+   */
+  async reportFaults(faultJson) {
+    return this.call('ReportFaults', {
+      serverKey: this.config.cmsKey,
+      hardwareKey: this.config.hardwareKey,
+      fault: faultJson
+    });
+  }
+
   async submitStats(statsXml) {
     try {
       const xml = await this.call('SubmitStats', {


### PR DESCRIPTION
## Summary

Three critical upstream-compatibility features for full XMDS protocol compliance:

- **#7**: Add `&method=MethodName` query param to all SOAP calls — avoids CMS rate limiting
- **#8**: Add `reportFaults()` to both XmdsClient (SOAP) and RestClient (REST) — enables player fault dashboard alerts via `player_faults` table
- **#9**: Parse `enableStat` attribute from XLF layout/widget elements, pass through `widgetStart`/`widgetEnd` events — allows stats gating per CMS configuration

## Test plan

- [x] All 1041 tests pass (`pnpm test`)
- [ ] Verify XMDS URLs contain `&method=RegisterDisplay` etc. in browser network tab
- [ ] Verify `ReportFaults` SOAP envelope includes JSON fault string
- [ ] Verify stats NOT recorded when `enableStat="0"` in XLF