### PR TITLE
feat: support image scaleType and align/valign options (#14)

### DIFF
--- a/packages/renderer/src/renderer-lite.js
+++ b/packages/renderer/src/renderer-lite.js
@@ -1359,7 +1359,17 @@ export class RendererLite {
     img.className = 'renderer-lite-widget';
     img.style.width = '100%';
     img.style.height = '100%';
-    img.style.objectFit = 'contain';
+    // Scale type: 'center' (default) → contain, 'stretch' → fill
+    const scaleType = widget.options.scaleType;
+    img.style.objectFit = scaleType === 'stretch' ? 'fill' : 'contain';
+
+    // Alignment: map align/valign to CSS object-position
+    const alignMap = { left: 'left', center: 'center', right: 'right' };
+    const valignMap = { top: 'top', middle: 'center', bottom: 'bottom' };
+    const hPos = alignMap[widget.options.align] || 'center';
+    const vPos = valignMap[widget.options.valign] || 'center';
+    img.style.objectPosition = `${hPos} ${vPos}`;
+
     img.style.opacity = '0';
 
     // Get media URL from cache (already pre-fetched!) or fetch on-demand

--- a/packages/renderer/src/renderer-lite.test.js
+++ b/packages/renderer/src/renderer-lite.test.js
@@ -303,6 +303,120 @@ describe('RendererLite', () => {
       expect(mockGetMediaUrl).toHaveBeenCalledWith(1);
     });
 
+    it('should default to objectFit contain and objectPosition center center', async () => {
+      const widget = {
+        type: 'image',
+        id: 'm1',
+        fileId: '1',
+        options: { uri: 'test.png' },
+        duration: 10,
+        transitions: { in: null, out: null }
+      };
+
+      const region = { width: 1920, height: 1080 };
+      const element = await renderer.renderImage(widget, region);
+
+      expect(element.style.objectFit).toBe('contain');
+      expect(element.style.objectPosition).toBe('center center');
+    });
+
+    it('should apply objectFit fill when scaleType is stretch', async () => {
+      const widget = {
+        type: 'image',
+        id: 'm1',
+        fileId: '1',
+        options: { uri: 'test.png', scaleType: 'stretch' },
+        duration: 10,
+        transitions: { in: null, out: null }
+      };
+
+      const region = { width: 1920, height: 1080 };
+      const element = await renderer.renderImage(widget, region);
+
+      expect(element.style.objectFit).toBe('fill');
+    });
+
+    it('should apply objectFit contain when scaleType is center', async () => {
+      const widget = {
+        type: 'image',
+        id: 'm1',
+        fileId: '1',
+        options: { uri: 'test.png', scaleType: 'center' },
+        duration: 10,
+        transitions: { in: null, out: null }
+      };
+
+      const region = { width: 1920, height: 1080 };
+      const element = await renderer.renderImage(widget, region);
+
+      expect(element.style.objectFit).toBe('contain');
+    });
+
+    it('should map align and valign to objectPosition', async () => {
+      const widget = {
+        type: 'image',
+        id: 'm1',
+        fileId: '1',
+        options: { uri: 'test.png', align: 'left', valign: 'top' },
+        duration: 10,
+        transitions: { in: null, out: null }
+      };
+
+      const region = { width: 1920, height: 1080 };
+      const element = await renderer.renderImage(widget, region);
+
+      expect(element.style.objectPosition).toBe('left top');
+    });
+
+    it('should map align right and valign bottom to objectPosition', async () => {
+      const widget = {
+        type: 'image',
+        id: 'm1',
+        fileId: '1',
+        options: { uri: 'test.png', align: 'right', valign: 'bottom' },
+        duration: 10,
+        transitions: { in: null, out: null }
+      };
+
+      const region = { width: 1920, height: 1080 };
+      const element = await renderer.renderImage(widget, region);
+
+      expect(element.style.objectPosition).toBe('right bottom');
+    });
+
+    it('should map valign middle to center in objectPosition', async () => {
+      const widget = {
+        type: 'image',
+        id: 'm1',
+        fileId: '1',
+        options: { uri: 'test.png', align: 'center', valign: 'middle' },
+        duration: 10,
+        transitions: { in: null, out: null }
+      };
+
+      const region = { width: 1920, height: 1080 };
+      const element = await renderer.renderImage(widget, region);
+
+      expect(element.style.objectPosition).toBe('center center');
+    });
+
+    it('should combine scaleType stretch with alignment options', async () => {
+      const widget = {
+        type: 'image',
+        id: 'm1',
+        fileId: '1',
+        options: { uri: 'test.png', scaleType: 'stretch', align: 'left', valign: 'bottom' },
+        duration: 10,
+        transitions: { in: null, out: null }
+      };
+
+      const region = { width: 1920, height: 1080 };
+      const element = await renderer.renderImage(widget, region);
+
+      expect(element.style.objectFit).toBe('fill');
+      expect(element.style.objectPosition).toBe('left bottom');
+    });
+
     it('should create video widget element', async () => {
       const widget = {
         type: 'video',


### PR DESCRIPTION
## Summary
- Map `scaleType` option to CSS `object-fit` (center→contain, stretch→fill)
- Map `align`/`valign` options to CSS `object-position`
- Defaults to contain + center center when not specified

## Test plan
- [x] 7 new tests for scale and alignment combinations
- [x] All tests pass on this branch