### PR TITLE
feat: add GetWeather XMDS/REST methods and weather criteria (#15)

### DIFF
--- a/packages/xmds/src/rest-client.js
+++ b/packages/xmds/src/rest-client.js
@@ -337,6 +337,15 @@ export class RestClient {
     return result?.success === true;
   }
 
+  /**
+   * GetWeather - get current weather data for schedule criteria
+   * GET /weather → JSON weather data
+   * @returns {Promise<Object>} Weather data from CMS
+   */
+  async getWeather() {
+    return this.restGet('/weather');
+  }
+
   async submitStats(statsXml) {
     try {
       // Accept array (JSON-native) or string (XML) — send under the right key

--- a/packages/xmds/src/xmds-client.js
+++ b/packages/xmds/src/xmds-client.js
@@ -367,6 +367,17 @@ export class XmdsClient {
     });
   }
 
+  /**
+   * GetWeather - get current weather data for schedule criteria
+   * @returns {Promise<string>} Weather data XML from CMS
+   */
+  async getWeather() {
+    return this.call('GetWeather', {
+      serverKey: this.config.cmsKey,
+      hardwareKey: this.config.hardwareKey
+    });
+  }
+
   async submitStats(statsXml) {
     try {
       const xml = await this.call('SubmitStats', {


### PR DESCRIPTION
## Summary
- Add `getWeather()` to both SOAP `XmdsClient` and `RestClient`
- Add weather metric mapping in `criteria.js` (temp, humidity, windSpeed, condition, cloudCover)
- Extend `evaluateCriteria()` to accept and resolve weather data

## Test plan
- [x] 5 new tests for GetWeather SOAP envelope and error handling
- [x] All tests pass on this branch