### PR TITLE
feat: emit widgetAction event on widget duration completion (#16)

### DIFF
--- a/packages/renderer/src/renderer-lite.js
+++ b/packages/renderer/src/renderer-lite.js
@@ -1422,6 +1422,17 @@ export class RendererLite {
 
       const duration = widget.duration * 1000;
       region.timer = setTimeout(() => {
+        // Emit widgetAction if widget has a webhook URL configured
+        if (widget.webhookUrl) {
+          this.emit('widgetAction', {
+            type: 'durationEnd',
+            widgetId: widget.id,
+            layoutId: this.currentLayoutId,
+            regionId,
+            url: widget.webhookUrl
+          });
+        }
+
         hideFn(regionId, widgetIndex);
 
         const nextIndex = (region.currentIndex + 1) % region.widgets.length;


### PR DESCRIPTION
## Summary
- Parse `webhookUrl` from widget options in `parseWidget()`
- Emit `widgetAction` event with type `durationEnd` when widget timer fires and `webhookUrl` is set
- Event includes widgetId, layoutId, regionId, url for the player layer to handle

## Test plan
- [x] 4 new tests (2 parsing + 2 event emission)
- [x] All tests pass on this branch