### PR TITLE
feat: send licenceResult in RegisterDisplay (#22)

### DIFF
--- a/packages/xmds/src/rest-client.js
+++ b/packages/xmds/src/rest-client.js
@@ -149,6 +149,7 @@ export class RestClient {
       macAddress: this.config.macAddress || 'n/a',
       xmrChannel: this.config.xmrChannel,
       xmrPubKey: this.config.xmrPubKey || '',
+      licenceResult: 'licensed',
     });
 
     return this._parseRegisterDisplayJson(json);

--- a/packages/xmds/src/xmds-client.js
+++ b/packages/xmds/src/xmds-client.js
@@ -155,7 +155,8 @@ export class XmdsClient {
       operatingSystem: os,
       macAddress: this.config.macAddress || 'n/a',
       xmrChannel: this.config.xmrChannel,
-      xmrPubKey: this.config.xmrPubKey || ''
+      xmrPubKey: this.config.xmrPubKey || '',
+      licenceResult: 'licensed'
     });
 
     return this.parseRegisterDisplayResponse(xml);


### PR DESCRIPTION
## Summary
- Add `licenceResult: 'licensed'` to SOAP `RegisterDisplay` call
- Add `licenceResult: 'licensed'` to REST `/register` POST body
- Required by v7 XMDS spec for CMS license validation tracking

Closes #22

## Test plan
- [x] All 1069 tests pass
- [x] SOAP envelope now includes `<licenceResult>licensed</licenceResult>`
- [x] REST body now includes `licenceResult: 'licensed'`