### PR TITLE
feat: add isPaused() to renderer for playback control

### DIFF
--- a/packages/renderer/src/renderer-lite.js
+++ b/packages/renderer/src/renderer-lite.js
@@ -2735,6 +2735,13 @@ export class RendererLite {
   }
 
   /**
+   * Check if playback is currently paused.
+   */
+  isPaused() {
+    return this._paused;
+  }
+
+  /**
    * Resume playback: restart layout timer with remaining time, resume media and widget cycling.
    */
   resume() {


### PR DESCRIPTION
## Summary
- Adds `isPaused()` method to `RendererLite` exposing the `_paused` state
- Used by the PWA to toggle pause/resume with Space key

Closes #2 (partial — SDK side)

## Test plan
- [ ] Verify `isPaused()` returns false initially
- [ ] Verify returns true after `pause()`, false after `resume()`
- [ ] PWA build clean with the new method

🤖 Generated with [Claude Code](https://claude.com/claude-code)