### PR TITLE
feat: parse syncConfig in XMDS SOAP RegisterDisplay

### DIFF
--- a/packages/xmds/src/xmds-client.js
+++ b/packages/xmds/src/xmds-client.js
@@ -199,7 +199,17 @@ export class XmdsClient {
     const checkRf = display.getAttribute('checkRf') || '';
     const checkSchedule = display.getAttribute('checkSchedule') || '';
 
-    return { code, message, settings, tags, checkRf, checkSchedule };
+    // Extract sync group config if present (multi-display sync coordination)
+    const syncGroupVal = settings.syncGroup || null;
+    const syncConfig = syncGroupVal ? {
+      syncGroup: syncGroupVal,
+      syncPublisherPort: parseInt(settings.syncPublisherPort || '9590', 10),
+      syncSwitchDelay: parseInt(settings.syncSwitchDelay || '750', 10),
+      syncVideoPauseDelay: parseInt(settings.syncVideoPauseDelay || '100', 10),
+      isLead: syncGroupVal === 'lead',
+    } : null;
+
+    return { code, message, settings, tags, checkRf, checkSchedule, syncConfig };
   }
 
   /**


### PR DESCRIPTION
## Summary
- Extract syncGroup, syncPublisherPort, syncSwitchDelay, syncVideoPauseDelay from SOAP XML RegisterDisplay response
- Matches the existing REST client parsing (rest-client.js already had this)
- Without this fix, displays using SOAP transport never received sync configuration

Closes #4 (SDK side)

## Test plan
- [ ] SOAP RegisterDisplay with syncGroup returns syncConfig object
- [ ] SOAP RegisterDisplay without syncGroup returns syncConfig: null
- [ ] All 1086 SDK tests pass