### PR TITLE
fix: parse recurrence attributes and spec-format audio nodes

### DIFF
--- a/packages/renderer/src/renderer-lite.js
+++ b/packages/renderer/src/renderer-lite.js
@@ -522,15 +522,29 @@ export class RendererLite {
     const actions = this.parseActions(mediaEl);
 
     // Parse audio overlay nodes (<audio> child elements on the widget)
+    // Spec format: <audio><uri volume="" loop="" mediaId="">filename.mp3</uri></audio>
+    // Also supports flat format: <audio mediaId="" uri="" volume="" loop="">
     const audioNodes = [];
     for (const child of mediaEl.children) {
       if (child.tagName.toLowerCase() === 'audio') {
-        audioNodes.push({
-          mediaId: child.getAttribute('mediaId') || null,
-          uri: child.getAttribute('uri') || '',
-          volume: parseInt(child.getAttribute('volume') || '100'),
-          loop: child.getAttribute('loop') === '1'
-        });
+        const uriEl = child.querySelector('uri');
+        if (uriEl) {
+          // Spec format: attributes on <uri>, filename as text content
+          audioNodes.push({
+            mediaId: uriEl.getAttribute('mediaId') || null,
+            uri: uriEl.textContent || '',
+            volume: parseInt(uriEl.getAttribute('volume') || '100'),
+            loop: uriEl.getAttribute('loop') === '1'
+          });
+        } else {
+          // Flat format fallback: attributes directly on <audio>
+          audioNodes.push({
+            mediaId: child.getAttribute('mediaId') || null,
+            uri: child.getAttribute('uri') || '',
+            volume: parseInt(child.getAttribute('volume') || '100'),
+            loop: child.getAttribute('loop') === '1'
+          });
+        }
       }
     }
 

--- a/packages/renderer/src/renderer-lite.test.js
+++ b/packages/renderer/src/renderer-lite.test.js
@@ -1359,6 +1359,63 @@ describe('RendererLite', () => {
       expect(widget.audioNodes[1].volume).toBe(40);
     });
 
+    it('should parse spec-format audio nodes with <uri> child element', () => {
+      const xlf = `
+        <layout>
+          <region id="r1">
+            <media id="m1" type="image" duration="10" fileId="1">
+              <audio>
+                <uri volume="80" loop="1" mediaId="50">bgmusic.mp3</uri>
+              </audio>
+              <options><uri>test.png</uri></options>
+            </media>
+          </region>
+        </layout>
+      `;
+
+      const layout = renderer.parseXlf(xlf);
+      const widget = layout.regions[0].widgets[0];
+
+      expect(widget.audioNodes).toHaveLength(1);
+      expect(widget.audioNodes[0]).toEqual({
+        mediaId: '50',
+        uri: 'bgmusic.mp3',
+        volume: 80,
+        loop: true
+      });
+    });
+
+    it('should handle mixed audio formats (spec + flat)', () => {
+      const xlf = `
+        <layout>
+          <region id="r1">
+            <media id="m1" type="image" duration="10" fileId="1">
+              <audio>
+                <uri volume="60" loop="0" mediaId="51">track1.mp3</uri>
+              </audio>
+              <audio mediaId="52" uri="track2.mp3" volume="40" loop="1"/>
+              <options><uri>test.png</uri></options>
+            </media>
+          </region>
+        </layout>
+      `;
+
+      const layout = renderer.parseXlf(xlf);
+      const widget = layout.regions[0].widgets[0];
+
+      expect(widget.audioNodes).toHaveLength(2);
+      // Spec format
+      expect(widget.audioNodes[0].uri).toBe('track1.mp3');
+      expect(widget.audioNodes[0].mediaId).toBe('51');
+      expect(widget.audioNodes[0].volume).toBe(60);
+      expect(widget.audioNodes[0].loop).toBe(false);
+      // Flat format
+      expect(widget.audioNodes[1].uri).toBe('track2.mp3');
+      expect(widget.audioNodes[1].mediaId).toBe('52');
+      expect(widget.audioNodes[1].volume).toBe(40);
+      expect(widget.audioNodes[1].loop).toBe(true);
+    });
+
     it('should have empty audioNodes when widget has no audio children', () => {
       const xlf = `
         <layout>

--- a/packages/xmds/src/schedule-parser.js
+++ b/packages/xmds/src/schedule-parser.js
@@ -60,6 +60,9 @@ export function parseScheduleResponse(xml) {
       fromdt: campaignEl.getAttribute('fromdt'),
       todt: campaignEl.getAttribute('todt'),
       scheduleid: campaignEl.getAttribute('scheduleid'),
+      recurrenceType: campaignEl.getAttribute('recurrenceType') || null,
+      recurrenceRepeatsOn: campaignEl.getAttribute('recurrenceRepeatsOn') || null,
+      recurrenceRange: campaignEl.getAttribute('recurrenceRange') || null,
       layouts: []
     };
 
@@ -103,6 +106,9 @@ export function parseScheduleResponse(xml) {
       geoLocation: layoutEl.getAttribute('geoLocation') || '',
       syncEvent: layoutEl.getAttribute('syncEvent') === '1',
       shareOfVoice: parseInt(layoutEl.getAttribute('shareOfVoice') || '0'),
+      recurrenceType: layoutEl.getAttribute('recurrenceType') || null,
+      recurrenceRepeatsOn: layoutEl.getAttribute('recurrenceRepeatsOn') || null,
+      recurrenceRange: layoutEl.getAttribute('recurrenceRange') || null,
       criteria: parseCriteria(layoutEl)
     });
   }
@@ -124,6 +130,9 @@ export function parseScheduleResponse(xml) {
         geoLocation: overlayEl.getAttribute('geoLocation') || '',
         syncEvent: overlayEl.getAttribute('syncEvent') === '1',
         maxPlaysPerHour: parseInt(overlayEl.getAttribute('maxPlaysPerHour') || '0'),
+        recurrenceType: overlayEl.getAttribute('recurrenceType') || null,
+        recurrenceRepeatsOn: overlayEl.getAttribute('recurrenceRepeatsOn') || null,
+        recurrenceRange: overlayEl.getAttribute('recurrenceRange') || null,
         criteria: parseCriteria(overlayEl)
       });
     }

--- a/packages/xmds/src/schedule-parser.test.js
+++ b/packages/xmds/src/schedule-parser.test.js
@@ -1,0 +1,112 @@
+/**
+ * Schedule Parser Tests
+ *
+ * Tests for XML parsing of schedule responses, ensuring all attributes
+ * are correctly extracted — especially recurrence/dayparting fields.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseScheduleResponse } from './schedule-parser.js';
+
+describe('parseScheduleResponse', () => {
+  it('should parse default layout', () => {
+    const xml = '<schedule><default file="100.xlf"/></schedule>';
+    const result = parseScheduleResponse(xml);
+    expect(result.default).toBe('100.xlf');
+  });
+
+  it('should parse standalone layout with basic attributes', () => {
+    const xml = `<schedule>
+      <layout file="200.xlf" fromdt="2025-01-01 09:00:00" todt="2025-12-31 17:00:00"
+              scheduleid="5" priority="3"/>
+    </schedule>`;
+    const result = parseScheduleResponse(xml);
+    expect(result.layouts).toHaveLength(1);
+    expect(result.layouts[0].file).toBe('200.xlf');
+    expect(result.layouts[0].priority).toBe(3);
+    expect(result.layouts[0].scheduleid).toBe('5');
+  });
+
+  it('should parse recurrence attributes on standalone layouts', () => {
+    const xml = `<schedule>
+      <layout file="300.xlf" fromdt="2025-01-06 09:00:00" todt="2025-01-06 17:00:00"
+              scheduleid="10" priority="1"
+              recurrenceType="Week"
+              recurrenceRepeatsOn="1,2,3,4,5"
+              recurrenceRange="2025-12-31 23:59:59"/>
+    </schedule>`;
+    const result = parseScheduleResponse(xml);
+    const layout = result.layouts[0];
+
+    expect(layout.recurrenceType).toBe('Week');
+    expect(layout.recurrenceRepeatsOn).toBe('1,2,3,4,5');
+    expect(layout.recurrenceRange).toBe('2025-12-31 23:59:59');
+  });
+
+  it('should set recurrence fields to null when absent', () => {
+    const xml = `<schedule>
+      <layout file="400.xlf" fromdt="2025-01-01 00:00:00" todt="2025-12-31 23:59:59"
+              scheduleid="20" priority="0"/>
+    </schedule>`;
+    const result = parseScheduleResponse(xml);
+    const layout = result.layouts[0];
+
+    expect(layout.recurrenceType).toBeNull();
+    expect(layout.recurrenceRepeatsOn).toBeNull();
+    expect(layout.recurrenceRange).toBeNull();
+  });
+
+  it('should parse recurrence attributes on campaigns', () => {
+    const xml = `<schedule>
+      <campaign id="c1" priority="5" fromdt="2025-01-06 08:00:00" todt="2025-01-06 18:00:00"
+                scheduleid="30"
+                recurrenceType="Week"
+                recurrenceRepeatsOn="6,7">
+        <layout file="500.xlf"/>
+        <layout file="501.xlf"/>
+      </campaign>
+    </schedule>`;
+    const result = parseScheduleResponse(xml);
+
+    expect(result.campaigns).toHaveLength(1);
+    const campaign = result.campaigns[0];
+    expect(campaign.recurrenceType).toBe('Week');
+    expect(campaign.recurrenceRepeatsOn).toBe('6,7');
+    expect(campaign.recurrenceRange).toBeNull();
+    expect(campaign.layouts).toHaveLength(2);
+  });
+
+  it('should parse recurrence attributes on overlays', () => {
+    const xml = `<schedule>
+      <overlays>
+        <overlay file="600.xlf" fromdt="2025-01-01 12:00:00" todt="2025-01-01 13:00:00"
+                 scheduleid="40" priority="2" duration="30"
+                 recurrenceType="Week"
+                 recurrenceRepeatsOn="1,3,5"/>
+      </overlays>
+    </schedule>`;
+    const result = parseScheduleResponse(xml);
+
+    expect(result.overlays).toHaveLength(1);
+    const overlay = result.overlays[0];
+    expect(overlay.recurrenceType).toBe('Week');
+    expect(overlay.recurrenceRepeatsOn).toBe('1,3,5');
+    expect(overlay.recurrenceRange).toBeNull();
+  });
+
+  it('should parse criteria on layouts', () => {
+    const xml = `<schedule>
+      <layout file="700.xlf" fromdt="2025-01-01 00:00:00" todt="2025-12-31 23:59:59"
+              scheduleid="50" priority="1">
+        <criteria metric="dayOfWeek" condition="equals" type="string">Monday</criteria>
+      </layout>
+    </schedule>`;
+    const result = parseScheduleResponse(xml);
+    const layout = result.layouts[0];
+
+    expect(layout.criteria).toHaveLength(1);
+    expect(layout.criteria[0].metric).toBe('dayOfWeek');
+    expect(layout.criteria[0].condition).toBe('equals');
+    expect(layout.criteria[0].value).toBe('Monday');
+  });
+});


### PR DESCRIPTION
## Summary
- **Dayparting fix:** Schedule parser now extracts `recurrenceType`, `recurrenceRepeatsOn`, and `recurrenceRange` from standalone layouts, campaigns, and overlays. The `ScheduleManager.isRecurringScheduleActive()` logic already worked — but the parser never fed it the data from real CMS XML responses.
- **Audio format fix:** XLF audio overlay parser now supports the Xibo spec format (`<audio><uri volume="" loop="" mediaId="">filename</uri></audio>`) alongside the flat format. Detects which format is used per `<audio>` element.

## Test plan
- [x] 7 new schedule-parser tests (recurrence on layouts/campaigns/overlays, criteria, null defaults)
- [x] 2 new renderer tests (spec-format audio, mixed format)
- [x] All 1105 tests pass
- [x] PWA builds clean