### PR TITLE
fix: critical spec compliance (8 bugs from audit)

### DIFF
--- a/packages/core/src/player-core.js
+++ b/packages/core/src/player-core.js
@@ -402,19 +402,19 @@ export class PlayerCore extends EventEmitter {
       // Get required files (skip if CRC unchanged)
       if (!this._lastCheckRf || this._lastCheckRf !== checkRf) {
         log.debug('Collection step: requiredFiles');
-        const allFiles = await this.xmds.requiredFiles();
-        // Separate purge entries from download entries
-        const purgeFiles = allFiles.filter(f => f.type === 'purge');
-        const files = allFiles.filter(f => f.type !== 'purge');
-        log.info('Required files:', files.length, purgeFiles.length > 0 ? `(+ ${purgeFiles.length} purge)` : '');
+        const rfResult = await this.xmds.requiredFiles();
+        // RequiredFiles returns { files, purge } — files to download, items to delete
+        const files = rfResult.files || rfResult;
+        const purgeItems = rfResult.purge || [];
+        log.info('Required files:', files.length, purgeItems.length > 0 ? `(+ ${purgeItems.length} purge)` : '');
         this._lastCheckRf = checkRf;
         this.emit('files-received', files);
 
         // Cache required files for offline use
-        this._offlineSave('requiredFiles', allFiles);
+        this._offlineSave('requiredFiles', rfResult);
 
-        if (purgeFiles.length > 0) {
-          this.emit('purge-request', purgeFiles);
+        if (purgeItems.length > 0) {
+          this.emit('purge-request', purgeItems);
         }
 
         // Get schedule (skip if CRC unchanged)

--- a/packages/core/src/xmds.test.js
+++ b/packages/core/src/xmds.test.js
@@ -256,7 +256,7 @@ describe('Schedule Parsing', () => {
       const xml = `
         <schedule>
           <default file="0"/>
-          <command command="collectNow" date="2026-01-01"/>
+          <command code="collectNow" date="2026-01-01"/>
         </schedule>
       `;
 
@@ -271,8 +271,8 @@ describe('Schedule Parsing', () => {
       const xml = `
         <schedule>
           <default file="0"/>
-          <command command="collectNow" date="2026-02-11"/>
-          <command command="reboot" date="2026-02-12"/>
+          <command code="collectNow" date="2026-02-11"/>
+          <command code="reboot" date="2026-02-12"/>
         </schedule>
       `;
 
@@ -498,7 +498,7 @@ describe('Schedule Parsing', () => {
           <actions>
             <action actionType="navLayout" triggerCode="tc1" layoutCode="42" fromdt="2026-01-01 00:00:00" todt="2030-12-31 23:59:59" priority="1" scheduleid="10"/>
           </actions>
-          <command command="collectNow" date="2026-02-11"/>
+          <command code="collectNow" date="2026-02-11"/>
         </schedule>
       `;
 

--- a/packages/renderer/src/renderer-lite.test.js
+++ b/packages/renderer/src/renderer-lite.test.js
@@ -2147,4 +2147,88 @@ describe('RendererLite', () => {
       expect(layout.actions).toEqual([]);
     });
   });
+
+  describe('Region loop option', () => {
+    it('should default loop to true when no loop option present', () => {
+      const xlf = `
+        <layout width="1920" height="1080">
+          <region id="r1" width="1920" height="1080" top="0" left="0">
+            <media id="m1" type="image" duration="10" fileId="1">
+              <options><uri>test.png</uri></options>
+            </media>
+          </region>
+        </layout>
+      `;
+      const layout = renderer.parseXlf(xlf);
+      expect(layout.regions[0].loop).toBe(true);
+    });
+
+    it('should set loop to false when loop option is 0', () => {
+      const xlf = `
+        <layout width="1920" height="1080">
+          <region id="r1" width="1920" height="1080" top="0" left="0">
+            <options><loop>0</loop></options>
+            <media id="m1" type="image" duration="10" fileId="1">
+              <options><uri>test.png</uri></options>
+            </media>
+          </region>
+        </layout>
+      `;
+      const layout = renderer.parseXlf(xlf);
+      expect(layout.regions[0].loop).toBe(false);
+    });
+
+    it('should set loop to true when loop option is 1', () => {
+      const xlf = `
+        <layout width="1920" height="1080">
+          <region id="r1" width="1920" height="1080" top="0" left="0">
+            <options><loop>1</loop></options>
+            <media id="m1" type="image" duration="10" fileId="1">
+              <options><uri>test.png</uri></options>
+            </media>
+          </region>
+        </layout>
+      `;
+      const layout = renderer.parseXlf(xlf);
+      expect(layout.regions[0].loop).toBe(true);
+    });
+  });
+
+  describe('Widget commands parsing', () => {
+    it('should parse commands on media elements', () => {
+      const xlf = `
+        <layout width="1920" height="1080">
+          <region id="r1" width="1920" height="1080" top="0" left="0">
+            <media id="m1" type="image" duration="10" fileId="1">
+              <options><uri>test.png</uri></options>
+              <commands>
+                <command commandCode="shellCommand" commandString="echo hello"/>
+                <command commandCode="reboot" commandString=""/>
+              </commands>
+            </media>
+          </region>
+        </layout>
+      `;
+      const layout = renderer.parseXlf(xlf);
+      const widget = layout.regions[0].widgets[0];
+      expect(widget.commands).toHaveLength(2);
+      expect(widget.commands[0].commandCode).toBe('shellCommand');
+      expect(widget.commands[0].commandString).toBe('echo hello');
+      expect(widget.commands[1].commandCode).toBe('reboot');
+    });
+
+    it('should return empty commands array when no commands element', () => {
+      const xlf = `
+        <layout width="1920" height="1080">
+          <region id="r1" width="1920" height="1080" top="0" left="0">
+            <media id="m1" type="image" duration="10" fileId="1">
+              <options><uri>test.png</uri></options>
+            </media>
+          </region>
+        </layout>
+      `;
+      const layout = renderer.parseXlf(xlf);
+      expect(layout.regions[0].widgets[0].commands).toEqual([]);
+    });
+  });
 });

--- a/packages/xmds/src/rest-client.js
+++ b/packages/xmds/src/rest-client.js
@@ -230,6 +230,8 @@ export class RestClient {
         md5: attrs.md5 || null,
         download: attrs.download || null,
         path,
+        saveAs: attrs.saveAs || null,
+        fileType: attrs.fileType || null,
         code: attrs.code || null,
         layoutid: attrs.layoutid || null,
         regionid: attrs.regionid || null,
@@ -237,7 +239,19 @@ export class RestClient {
       });
     }
 
-    return files;
+    // Parse purge items — files CMS wants the player to delete
+    const purgeItems = [];
+    let purgeList = json.purge?.item || [];
+    if (!Array.isArray(purgeList)) purgeList = [purgeList];
+    for (const p of purgeList) {
+      const pAttrs = p['@attributes'] || p;
+      purgeItems.push({
+        id: pAttrs.id || null,
+        storedAs: pAttrs.storedAs || null,
+      });
+    }
+
+    return { files, purge: purgeItems };
   }
 
   /**

--- a/packages/xmds/src/schedule-parser.js
+++ b/packages/xmds/src/schedule-parser.js
@@ -174,20 +174,27 @@ export function parseScheduleResponse(xml) {
   // Parse server commands (remote control)
   for (const cmdEl of doc.querySelectorAll('schedule > command')) {
     schedule.commands.push({
-      code: cmdEl.getAttribute('command') || '',
+      code: cmdEl.getAttribute('code') || '',
       date: cmdEl.getAttribute('date') || ''
     });
   }
 
   // Parse data connectors (real-time data sources for widgets)
-  for (const dcEl of doc.querySelectorAll('dataconnector')) {
-    schedule.dataConnectors.push({
-      id: dcEl.getAttribute('id') || '',
-      dataConnectorId: dcEl.getAttribute('dataConnectorId') || '',
-      dataKey: dcEl.getAttribute('dataKey') || '',
-      url: dcEl.getAttribute('url') || '',
-      updateInterval: parseInt(dcEl.getAttribute('updateInterval') || '300', 10)
-    });
+  // Spec: <dataConnectors><connector dataSetId="" dataParams="" js=""/></dataConnectors>
+  const dataConnectorsContainer = doc.querySelector('dataConnectors');
+  if (dataConnectorsContainer) {
+    for (const dcEl of dataConnectorsContainer.querySelectorAll('connector')) {
+      schedule.dataConnectors.push({
+        id: dcEl.getAttribute('id') || '',
+        dataConnectorId: dcEl.getAttribute('dataConnectorId') || '',
+        dataSetId: dcEl.getAttribute('dataSetId') || '',
+        dataKey: dcEl.getAttribute('dataKey') || '',
+        dataParams: dcEl.getAttribute('dataParams') || '',
+        js: dcEl.getAttribute('js') || '',
+        url: dcEl.getAttribute('url') || '',
+        updateInterval: parseInt(dcEl.getAttribute('updateInterval') || '300', 10)
+      });
+    }
   }
 
   return schedule;

--- a/packages/xmds/src/schedule-parser.test.js
+++ b/packages/xmds/src/schedule-parser.test.js
@@ -167,4 +167,38 @@ describe('parseScheduleResponse', () => {
     expect(layout.groupKey).toBe('group-A');
     expect(layout.playCount).toBe(3);
   });
+
+  it('should parse command code attribute correctly', () => {
+    const xml = `<schedule>
+      <command code="collectNow" date="2026-01-01"/>
+      <command code="reboot" date="2026-01-02"/>
+    </schedule>`;
+    const result = parseScheduleResponse(xml);
+    expect(result.commands).toHaveLength(2);
+    expect(result.commands[0].code).toBe('collectNow');
+    expect(result.commands[1].code).toBe('reboot');
+  });
+
+  it('should parse dataConnectors with connector child elements', () => {
+    const xml = `<schedule>
+      <dataConnectors>
+        <connector id="dc1" dataSetId="42" dataParams="limit=10" js="render.js"
+                   url="http://cms.example.com/data" updateInterval="60"/>
+      </dataConnectors>
+    </schedule>`;
+    const result = parseScheduleResponse(xml);
+    expect(result.dataConnectors).toHaveLength(1);
+    expect(result.dataConnectors[0].id).toBe('dc1');
+    expect(result.dataConnectors[0].dataSetId).toBe('42');
+    expect(result.dataConnectors[0].dataParams).toBe('limit=10');
+    expect(result.dataConnectors[0].js).toBe('render.js');
+    expect(result.dataConnectors[0].url).toBe('http://cms.example.com/data');
+    expect(result.dataConnectors[0].updateInterval).toBe(60);
+  });
+
+  it('should return empty dataConnectors when no dataConnectors element', () => {
+    const xml = '<schedule><default file="0"/></schedule>';
+    const result = parseScheduleResponse(xml);
+    expect(result.dataConnectors).toEqual([]);
+  });
 });

--- a/packages/xmds/src/xmds-client.js
+++ b/packages/xmds/src/xmds-client.js
@@ -240,6 +240,8 @@ export class XmdsClient {
         md5: fileEl.getAttribute('md5'),
         download: fileEl.getAttribute('download'),
         path: fileEl.getAttribute('path'),
+        saveAs: fileEl.getAttribute('saveAs') || null,
+        fileType: fileEl.getAttribute('fileType') || null,
         code: fileEl.getAttribute('code'),
         layoutid: fileEl.getAttribute('layoutid'),
         regionid: fileEl.getAttribute('regionid'),
@@ -247,7 +249,19 @@ export class XmdsClient {
       });
     }
 
-    return files;
+    // Parse purge block — files CMS wants the player to delete
+    const purgeItems = [];
+    const purgeEl = doc.querySelector('purge');
+    if (purgeEl) {
+      for (const itemEl of purgeEl.querySelectorAll('item')) {
+        purgeItems.push({
+          id: itemEl.getAttribute('id'),
+          storedAs: itemEl.getAttribute('storedAs')
+        });
+      }
+    }
+
+    return { files, purge: purgeItems };
   }
 
   /**

--- a/packages/xmds/src/xmds.rest.test.js
+++ b/packages/xmds/src/xmds.rest.test.js
@@ -353,17 +353,18 @@ describe('RestClient - RequiredFiles', () => {
       ]
     }, { etag: '"files-v1"' }));
 
-    const files = await client.requiredFiles();
+    const result = await client.requiredFiles();
 
-    expect(files).toHaveLength(3);
-    expect(files[0]).toEqual({
+    expect(result.files).toHaveLength(3);
+    expect(result.files[0]).toEqual(expect.objectContaining({
       type: 'media', id: '42', size: 1024, md5: 'abc', download: 'http',
       path: '/media/42.jpg', code: null, layoutid: null, regionid: null, mediaid: null,
-    });
-    expect(files[1].type).toBe('layout');
-    expect(files[2].layoutid).toBe('10');
-    expect(files[2].regionid).toBe('5');
-    expect(files[2].mediaid).toBe('99');
+    }));
+    expect(result.files[1].type).toBe('layout');
+    expect(result.files[2].layoutid).toBe('10');
+    expect(result.files[2].regionid).toBe('5');
+    expect(result.files[2].mediaid).toBe('99');
+    expect(result.purge).toEqual([]);
   });
 
   it('should handle single file (not array)', async () => {
@@ -371,16 +372,16 @@ describe('RestClient - RequiredFiles', () => {
       file: { '@attributes': { type: 'media', id: '1', size: '100', md5: 'x' } }
     }));
 
-    const files = await client.requiredFiles();
-    expect(files).toHaveLength(1);
-    expect(files[0].id).toBe('1');
+    const result = await client.requiredFiles();
+    expect(result.files).toHaveLength(1);
+    expect(result.files[0].id).toBe('1');
   });
 
   it('should handle empty file list', async () => {
     mockFetch.mockResolvedValue(jsonResponse({}));
 
-    const files = await client.requiredFiles();
-    expect(files).toHaveLength(0);
+    const result = await client.requiredFiles();
+    expect(result.files).toHaveLength(0);
   });
 
   it('should use ETag caching', async () => {
@@ -407,12 +408,12 @@ describe('RestClient - RequiredFiles', () => {
 
     const result = client._parseRequiredFilesJson(json);
 
-    expect(result[0].type).toBe('media');
-    expect(result[0].id).toBe('42');
-    expect(result[0].size).toBe(1024);
-    expect(result[0].md5).toBe('abc');
-    expect(result[0].download).toBe('http');
-    expect(result[0].path).toBe('/media/42.jpg');
+    expect(result.files[0].type).toBe('media');
+    expect(result.files[0].id).toBe('42');
+    expect(result.files[0].size).toBe(1024);
+    expect(result.files[0].md5).toBe('abc');
+    expect(result.files[0].download).toBe('http');
+    expect(result.files[0].path).toBe('/media/42.jpg');
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes 8 critical spec compliance gaps identified during the comprehensive audit against Xibo developer docs.

### Bug fixes
- **schedule-parser**: `<command>` element reads `code` attribute (was incorrectly reading `command`) — all scheduled commands were silently empty
- **schedule-parser**: `<dataConnectors>` now queries `<connector>` child elements inside `<dataConnectors>` container (was `querySelectorAll('dataconnector')` matching nothing) — all data connector config was lost
- **renderer**: Region `<loop>0</loop>` option parsed and enforced — `loop=0` means single media stays visible after expiry instead of cycling
- **renderer**: `<commands>` child elements on `<media>` parsed and emitted as `widgetCommand` events — shell commands attached to widgets were silently dropped
- **xmds-client + rest-client**: `<purge>` block from RequiredFiles now parsed — files CMS wants deleted were never removed
- **xmds-client + rest-client**: RequiredFiles returns `{ files, purge }` instead of flat array; also parses `saveAs` and `fileType` attributes
- **fetch-retry**: HTTP 429 (Too Many Requests) now respects `Retry-After` header instead of returning immediately — players were spamming rate-limited CMS
- **log-reporter**: SubmitLog XML uses spec-compliant format with child elements (`<thread>`, `<method>`, `<message>`, `<scheduleID>`) instead of `message` attribute; category restricted to `error`/`audit` per spec

### Files changed (14)
- `packages/xmds/src/schedule-parser.js` — command attr, dataConnectors selector
- `packages/renderer/src/renderer-lite.js` — loop option, commands parsing
- `packages/xmds/src/xmds-client.js` — purge block, saveAs/fileType
- `packages/xmds/src/rest-client.js` — purge block, saveAs/fileType
- `packages/utils/src/fetch-retry.js` — 429 handling
- `packages/stats/src/log-reporter.js` — spec XML format
- `packages/core/src/player-core.js` — consume new RequiredFiles format
- 7 test files updated + 12 new tests

## Test plan
- [x] All 1138 SDK tests pass (`pnpm test`)
- [x] PWA builds cleanly (`pnpm run build`)
- [ ] Verify `<command code="collectNow">` triggers correctly in schedule
- [ ] Verify `<dataConnectors>` populated from real CMS schedule
- [ ] Verify 429 retry with CMS rate limiting enabled
- [ ] Verify SubmitLog accepted by CMS