### PR TITLE
fix: medium-priority spec compliance (16 gaps)

### DIFF
--- a/packages/core/src/player-core.test.js
+++ b/packages/core/src/player-core.test.js
@@ -926,7 +926,7 @@ describe('PlayerCore', () => {
     it('should set _layoutOverride with overlay type', async () => {
       await core.overlayLayout('123');
 
-      expect(core._layoutOverride).toEqual({ layoutId: 123, type: 'overlay' });
+      expect(core._layoutOverride).toEqual({ layoutId: 123, type: 'overlay', duration: 0 });
     });
 
     it('should parse string layoutId to integer', async () => {
@@ -940,10 +940,10 @@ describe('PlayerCore', () => {
 
     it('should overwrite previous layout override', async () => {
       await core.overlayLayout('100');
-      expect(core._layoutOverride).toEqual({ layoutId: 100, type: 'overlay' });
+      expect(core._layoutOverride).toEqual({ layoutId: 100, type: 'overlay', duration: 0 });
 
       await core.overlayLayout('200');
-      expect(core._layoutOverride).toEqual({ layoutId: 200, type: 'overlay' });
+      expect(core._layoutOverride).toEqual({ layoutId: 200, type: 'overlay', duration: 0 });
     });
   });
 

--- a/packages/core/src/xmds.test.js
+++ b/packages/core/src/xmds.test.js
@@ -194,10 +194,10 @@ describe('Schedule Parsing', () => {
       expect(schedule.actions[0].actionType).toBe('navLayout');
       expect(schedule.actions[0].triggerCode).toBe('tc1');
       expect(schedule.actions[0].layoutCode).toBe('42');
-      expect(schedule.actions[0].fromDt).toBe('2026-01-01 00:00:00');
-      expect(schedule.actions[0].toDt).toBe('2030-12-31 23:59:59');
+      expect(schedule.actions[0].fromdt).toBe('2026-01-01 00:00:00');
+      expect(schedule.actions[0].todt).toBe('2030-12-31 23:59:59');
       expect(schedule.actions[0].priority).toBe(5);
-      expect(schedule.actions[0].scheduleId).toBe('10');
+      expect(schedule.actions[0].scheduleid).toBe('10');
     });
 
     it('should parse multiple actions', () => {

--- a/packages/schedule/src/overlays.js
+++ b/packages/schedule/src/overlays.js
@@ -115,8 +115,8 @@ export class OverlayScheduler {
    * @returns {boolean}
    */
   isTimeActive(overlay, now) {
-    const from = overlay.fromDt ? new Date(overlay.fromDt) : null;
-    const to = overlay.toDt ? new Date(overlay.toDt) : null;
+    const from = (overlay.fromdt || overlay.fromDt) ? new Date(overlay.fromdt || overlay.fromDt) : null;
+    const to = (overlay.todt || overlay.toDt) ? new Date(overlay.todt || overlay.toDt) : null;
 
     // Check time bounds
     if (from && now < from) {

--- a/packages/stats/src/log-reporter.js
+++ b/packages/stats/src/log-reporter.js
@@ -234,24 +234,15 @@ export class LogReporter {
   /**
    * Get logs ready for submission to CMS
    *
-   * Returns unsubmitted logs up to a limit determined by backlog size:
-   * - Normal: up to 50 logs per submission
-   * - Backlog (> 50 pending): up to 300 logs per submission
-   * Aligns with upstream Xibo player spec limits.
+   * Returns unsubmitted logs up to the spec limit of 50 per batch.
    *
-   * @param {number} [limit] - Override limit (omit for auto-detection)
+   * @param {number} [limit=50] - Maximum number of logs to return (spec max: 50)
    * @returns {Promise<Array>} Array of log objects
    */
-  async getLogsForSubmission(limit) {
+  async getLogsForSubmission(limit = 50) {
     if (!this.db) {
       log.warn('Logs database not initialized');
       return [];
-    }
-
-    // Auto-detect limit based on backlog size if not explicitly provided
-    if (limit === undefined) {
-      const pending = await this._countUnsubmitted();
-      limit = pending > 50 ? 300 : 50;
     }
 
     return new Promise((resolve, reject) => {

--- a/packages/stats/src/stats-collector.js
+++ b/packages/stats/src/stats-collector.js
@@ -109,11 +109,19 @@ export class StatsCollector {
    *
    * @param {number} layoutId - Layout ID from CMS
    * @param {number} scheduleId - Schedule ID that triggered this layout
+   * @param {Object} [options] - Options
+   * @param {boolean} [options.enableStat=true] - Whether stats are enabled for this layout
    * @returns {Promise<void>}
    */
-  async startLayout(layoutId, scheduleId) {
+  async startLayout(layoutId, scheduleId, options) {
     if (!this.db) {
       log.warn('Stats database not initialized');
+      return;
+    }
+
+    // Respect enableStat flag from XLF (layout/widget level stat suppression)
+    if (options?.enableStat === false) {
+      log.debug(`Stats disabled for layout ${layoutId} (enableStat=false)`);
       return;
     }
 
@@ -196,11 +204,19 @@ export class StatsCollector {
    * @param {number} layoutId - Parent layout ID
    * @param {number} scheduleId - Schedule ID
    * @param {string|number} [widgetId] - Widget ID (for non-library widgets with no mediaId)
+   * @param {Object} [options] - Options
+   * @param {boolean} [options.enableStat=true] - Whether stats are enabled for this widget
    * @returns {Promise<void>}
    */
-  async startWidget(mediaId, layoutId, scheduleId, widgetId) {
+  async startWidget(mediaId, layoutId, scheduleId, widgetId, options) {
     if (!this.db) {
       log.warn('Stats database not initialized');
+      return;
+    }
+
+    // Respect enableStat flag from XLF (layout/widget level stat suppression)
+    if (options?.enableStat === false) {
+      log.debug(`Stats disabled for widget ${mediaId} (enableStat=false)`);
       return;
     }
 

--- a/packages/xmds/src/rest-client.js
+++ b/packages/xmds/src/rest-client.js
@@ -315,6 +315,11 @@ export class RestClient {
       status.timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
     }
 
+    // Add statusDialog (summary for CMS display status page) if not provided
+    if (!status.statusDialog) {
+      status.statusDialog = `Current Layout: ${status.currentLayoutId || 'None'}`;
+    }
+
     return this.restSend('PUT', '/status', {
       statusData: status,
     });

--- a/packages/xmds/src/schedule-parser.js
+++ b/packages/xmds/src/schedule-parser.js
@@ -113,6 +113,10 @@ export function parseScheduleResponse(xml) {
         geoLocation: layoutEl.getAttribute('geoLocation') || '',
         syncEvent: layoutEl.getAttribute('syncEvent') === '1',
         shareOfVoice: parseInt(layoutEl.getAttribute('shareOfVoice') || '0'),
+        duration: parseInt(layoutEl.getAttribute('duration') || '0'),
+        cyclePlayback: layoutEl.getAttribute('cyclePlayback') === '1',
+        groupKey: layoutEl.getAttribute('groupKey') || null,
+        playCount: parseInt(layoutEl.getAttribute('playCount') || '0'),
         dependants: depEls.length > 0 ? [...depEls].map(el => el.textContent) : [],
         criteria: parseCriteria(layoutEl)
       });
@@ -159,10 +163,10 @@ export function parseScheduleResponse(xml) {
         id: String(fileId), // Normalized string ID for consistent type usage
         duration: parseInt(overlayEl.getAttribute('duration') || '60'),
         file: fileId,
-        fromDt: overlayEl.getAttribute('fromdt'),
-        toDt: overlayEl.getAttribute('todt'),
+        fromdt: overlayEl.getAttribute('fromdt'),
+        todt: overlayEl.getAttribute('todt'),
         priority: parseInt(overlayEl.getAttribute('priority') || '0'),
-        scheduleId: overlayEl.getAttribute('scheduleid'),
+        scheduleid: overlayEl.getAttribute('scheduleid'),
         isGeoAware: overlayEl.getAttribute('isGeoAware') === '1',
         geoLocation: overlayEl.getAttribute('geoLocation') || '',
         syncEvent: overlayEl.getAttribute('syncEvent') === '1',
@@ -185,10 +189,10 @@ export function parseScheduleResponse(xml) {
         layoutCode: actionEl.getAttribute('layoutCode') || '',
         commandCode: actionEl.getAttribute('commandCode') || '',
         duration: parseInt(actionEl.getAttribute('duration') || '0'),
-        fromDt: actionEl.getAttribute('fromdt'),
-        toDt: actionEl.getAttribute('todt'),
+        fromdt: actionEl.getAttribute('fromdt'),
+        todt: actionEl.getAttribute('todt'),
         priority: parseInt(actionEl.getAttribute('priority') || '0'),
-        scheduleId: actionEl.getAttribute('scheduleid'),
+        scheduleid: actionEl.getAttribute('scheduleid'),
         isGeoAware: actionEl.getAttribute('isGeoAware') === '1',
         geoLocation: actionEl.getAttribute('geoLocation') || ''
       });

--- a/packages/xmds/src/schedule-parser.test.js
+++ b/packages/xmds/src/schedule-parser.test.js
@@ -246,4 +246,37 @@ describe('parseScheduleResponse', () => {
     expect(result.campaigns[0].criteria[0].metric).toBe('temperature');
     expect(result.campaigns[0].criteria[0].value).toBe('25');
   });
+
+  it('should parse duration, cyclePlayback, groupKey, playCount on campaign layouts', () => {
+    const xml = `<schedule>
+      <campaign id="c1" priority="5" fromdt="2025-01-01 00:00:00" todt="2025-12-31 23:59:59"
+                scheduleid="30">
+        <layout file="500.xlf" duration="90" cyclePlayback="1" groupKey="group-B" playCount="2"/>
+      </campaign>
+    </schedule>`;
+    const result = parseScheduleResponse(xml);
+    const layout = result.campaigns[0].layouts[0];
+    expect(layout.duration).toBe(90);
+    expect(layout.cyclePlayback).toBe(true);
+    expect(layout.groupKey).toBe('group-B');
+    expect(layout.playCount).toBe(2);
+  });
+
+  it('should use consistent lowercase casing for fromdt/todt/scheduleid on overlays', () => {
+    const xml = `<schedule>
+      <overlays>
+        <overlay file="600.xlf" fromdt="2025-01-01 12:00:00" todt="2025-01-01 13:00:00"
+                 scheduleid="40" priority="2"/>
+      </overlays>
+    </schedule>`;
+    const result = parseScheduleResponse(xml);
+    const overlay = result.overlays[0];
+    expect(overlay.fromdt).toBe('2025-01-01 12:00:00');
+    expect(overlay.todt).toBe('2025-01-01 13:00:00');
+    expect(overlay.scheduleid).toBe('40');
+    // Verify old camelCase properties are NOT present
+    expect(overlay.fromDt).toBeUndefined();
+    expect(overlay.toDt).toBeUndefined();
+    expect(overlay.scheduleId).toBeUndefined();
+  });
 });

--- a/packages/xmds/src/xmds-client.js
+++ b/packages/xmds/src/xmds-client.js
@@ -330,6 +330,11 @@ export class XmdsClient {
       status.timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
     }
 
+    // Add statusDialog (summary for CMS display status page) if not provided
+    if (!status.statusDialog) {
+      status.statusDialog = `Current Layout: ${status.currentLayoutId || 'None'}`;
+    }
+
     return await this.call('NotifyStatus', {
       serverKey: this.config.cmsKey,
       hardwareKey: this.config.hardwareKey,

--- a/packages/xmds/src/xmds.overlays.test.js
+++ b/packages/xmds/src/xmds.overlays.test.js
@@ -25,8 +25,8 @@ describe('Schedule Parsing - Overlays', () => {
       expect(schedule.overlays[0].file).toBe('101.xlf');
       expect(schedule.overlays[0].duration).toBe(60);
       expect(schedule.overlays[0].priority).toBe(10);
-      expect(schedule.overlays[0].fromDt).toBe('2026-01-01 00:00:00');
-      expect(schedule.overlays[0].toDt).toBe('2026-12-31 23:59:59');
+      expect(schedule.overlays[0].fromdt).toBe('2026-01-01 00:00:00');
+      expect(schedule.overlays[0].todt).toBe('2026-12-31 23:59:59');
     });
 
     it('should parse multiple overlays', () => {

--- a/packages/xmr/src/xmr-wrapper.test.js
+++ b/packages/xmr/src/xmr-wrapper.test.js
@@ -287,7 +287,7 @@ describe('XmrWrapper', () => {
         xmrInstance.simulateCommand('changeLayout', 'layout-123');
         await vi.runAllTimersAsync();
 
-        expect(mockPlayer.changeLayout).toHaveBeenCalledWith('layout-123');
+        expect(mockPlayer.changeLayout).toHaveBeenCalledWith('layout-123', { duration: 0, changeMode: 'replace' });
       });
 
       it('should handle changeLayout failure gracefully', async () => {
@@ -435,7 +435,7 @@ describe('XmrWrapper', () => {
         xmrInstance.simulateCommand('overlayLayout', 'overlay-layout-456');
         await vi.runAllTimersAsync();
 
-        expect(mockPlayer.overlayLayout).toHaveBeenCalledWith('overlay-layout-456');
+        expect(mockPlayer.overlayLayout).toHaveBeenCalledWith('overlay-layout-456', { duration: 0 });
       });
 
       it('should handle overlayLayout failure gracefully', async () => {
@@ -745,7 +745,7 @@ describe('XmrWrapper', () => {
 
       expect(mockPlayer.collect).toHaveBeenCalled();
       expect(mockPlayer.captureScreenshot).toHaveBeenCalled();
-      expect(mockPlayer.changeLayout).toHaveBeenCalledWith('layout-123');
+      expect(mockPlayer.changeLayout).toHaveBeenCalledWith('layout-123', { duration: 0, changeMode: 'replace' });
     });
 
     it('should handle rapid connect/disconnect cycles', async () => {


### PR DESCRIPTION
## Summary

Fixes 16 medium-priority gaps identified in the spec compliance audit:

**Schedule parser**
- Campaign layouts now parse `duration`, `cyclePlayback`, `groupKey`, `playCount` (were only on standalone layouts)
- Normalized `fromdt`/`todt`/`scheduleid` casing across overlays and actions (was mixed camelCase/lowercase)

**Renderer**
- Action elements parse `id`, `source`, `sourceId`, `target`, `widgetId` attributes (were missing, reducing action routing fidelity)
- Webpage widget `modeId=0` (GetResource mode) routes through `renderGenericWidget` instead of direct URL
- Text/ticker widgets now apply `NUMITEMS`/`DURATION` HTML comments from GetResource

**Stats & logging**
- `enableStat` flag enforced in `startLayout()`/`startWidget()` — accepts `{ enableStat: false }` options
- Log batch limit capped at 50 per spec (was auto-escalating to 300 on backlog)

**XMR**
- `changeLayout`/`overlayLayout` handlers accept `duration`, `downloadRequired`, `changeMode` from payload
- `commandAction` resolves commands from local display settings (RegisterDisplay) instead of XMR payload

**Player core**
- Stores display commands from RegisterDisplay for XMR `commandAction` resolution
- `changeLayout`/`overlayLayout` auto-revert to schedule when `duration` expires
- `statusDialog` field added to NotifyStatus enrichment

## Test plan

- [x] All 1144 tests pass (2 new schedule-parser tests)
- [x] No regressions in existing test suite
- [x] GPG-signed commit