### PR TITLE
feat: periodic fault reporting agent for faster CMS alerts

### DIFF
--- a/packages/stats/src/index.js
+++ b/packages/stats/src/index.js
@@ -12,4 +12,4 @@ export { StatsCollector, formatStats } from './stats-collector.js';
  * Log reporter for CMS logging
  * @module @xiboplayer/stats/logger
  */
-export { LogReporter, formatLogs } from './log-reporter.js';
+export { LogReporter, formatLogs, formatFaults } from './log-reporter.js';


### PR DESCRIPTION
## Summary

- Add `getFaultsForSubmission()` to LogReporter — queries IndexedDB for unsubmitted fault entries (`alertType='Player Fault'`)
- Add `formatFaults()` helper — produces JSON format for `xmds.reportFaults()`
- Add independent 60s fault reporting timer in PlayerCore (vs 300s collection cycle)
- Emit `submit-faults-request` event for platform layer to wire up submission

## Architecture

Faults share storage with logs (they're log entries with `alertType` metadata) but get their own submission path:
- **Collection cycle (300s):** emits `submit-logs-request` + `submit-faults-request`
- **Fault agent (60s):** emits `submit-faults-request` independently
- Platform wires: `core.on('submit-faults-request', () => submitFaults())`

## Test plan

- [x] 5 new tests for `getFaultsForSubmission` (filtering, limits, empty, cleared, uninitialized)
- [x] 4 new tests for `formatFaults` (empty, single, defaults, multiple)
- [x] All 1157 tests pass (31 files)

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)