### PR TITLE
docs: update test count to 1258, all audit gaps resolved

### DIFF
--- a/packages/docs/AUDIT.md
+++ b/packages/docs/AUDIT.md
@@ -14,7 +14,7 @@
 | Schedule Spec | ~95% | Recurrence + weather done; adspace stub only |
 | Stats Spec | ~95% | Engagement tracking exists; BroadcastChannel not needed |
 | Interactive Control | 100% | Full IC server via postMessage |
-| Overall | **~98%** | 14/15 gaps resolved (PRs #86–#90), 1 remaining (#84 adspace) |
+| Overall | **~98%** | 15/15 gaps resolved (PRs #86–#90), #84 closed as not needed |
 
 ## Feature Compliance Matrix
 
@@ -134,11 +134,11 @@ All handlers implemented: `collectNow`, `screenShot`, `licenceCheck`, `changeLay
 | Renderer | Browser DOM | GTK4/WebView | Different approach |
 | Offline mode | ✅ (IndexedDB) | ✅ (SQLite) | Both robust |
 | Package system | npm monorepo | Single binary | Different trade-offs |
-| Test coverage | 1179 tests | ~200 tests | SDK more tested |
+| Test coverage | 1258 tests | ~200 tests | SDK more tested |
 
 ## Prioritized Gap List — Resolution Status
 
-14 of 15 issues resolved. 8 implemented via PRs #86–#90, 5 already existed, 1 closed as not needed.
+All 15 issues resolved. 8 implemented via PRs #86–#90, 5 already existed, 2 closed as not needed.
 
 ### Critical — All Resolved
 
@@ -168,7 +168,7 @@ All handlers implemented: `collectNow`, `screenShot`, `licenceCheck`, `changeLay
 | 12 | [#81](https://github.com/xibo-players/xiboplayer/issues/81) | ✅ Download window enforcement in PlayerCore | #90 |
 | 13 | [#82](https://github.com/xibo-players/xiboplayer/issues/82) | ✅ Closed — fire-and-forget pattern sufficient | — |
 | 14 | [#83](https://github.com/xibo-players/xiboplayer/issues/83) | ✅ Already implemented (instant opacity fallback) | — |
-| 15 | [#84](https://github.com/xibo-players/xiboplayer/issues/84) | ❌ **Open** — Adspace/SSP (stub only) | — |
+| 15 | [#84](https://github.com/xibo-players/xiboplayer/issues/84) | ✅ Closed — CMS API undocumented/unstable; stub sufficient | — |
 
 ## renderer-lite Advantages
 

--- a/packages/docs/STATUS.md
+++ b/packages/docs/STATUS.md
@@ -110,12 +110,12 @@
 - Android - WebView wrapper
 - webOS - Cordova wrapper
 
-## Known Gaps (1 remaining of 15 tracked)
+## Known Gaps (0 remaining of 15 tracked)
 
-14 of 15 audit issues resolved (PRs #86–#90). 8 implemented, 5 closed as already done, 1 closed as not needed.
+All 15 audit issues resolved (PRs #86–#90). 8 implemented, 5 closed as already done, 2 closed as not needed.
 
-### Remaining
-- [#84](https://github.com/xibo-players/xiboplayer/issues/84) Adspace exchange / SSP ad rotation (stub `isSspEnabled` flag exists, no ad logic)
+### Closed
+- [#84](https://github.com/xibo-players/xiboplayer/issues/84) Adspace exchange / SSP ad rotation — closed, CMS API undocumented/unstable; `isSspEnabled` stub sufficient
 
 ### Not Applicable (Browser Sandbox)
 - Shell commands (use HTTP commands instead)
@@ -124,7 +124,7 @@
 ## Test Suite
 
 ```
-Tests:  1179 passed | 7 skipped (1186 total)
+Tests:  1258 passed | 7 skipped (1265 total)
 Files:  31 test files (all passed)
 Time:   ~9s
 ```


### PR DESCRIPTION
## Summary
- Merges audit docs (`AUDIT.md`, `STATUS.md`) from `docs/audit-final-status` into main
- Updates test count: 1179 → 1258 (after CMS API batches)
- Marks #84 (adspace/SSP) as closed — all 15 audit gaps now resolved

## Test plan
- [x] No code changes, docs only