### PR TITLE
feat: cross-tab stats/logs delegation via BroadcastChannel

### DIFF
--- a/packages/xmds/src/rest-client.js
+++ b/packages/xmds/src/rest-client.js
@@ -375,9 +375,10 @@ export class RestClient {
    * SubmitLog - submit player logs to CMS
    * POST /log → JSON acknowledgement
    */
-  async submitLog(logXml) {
+  async submitLog(logXml, hardwareKeyOverride = null) {
     // Accept array (JSON-native) or string (XML) — send under the right key
     const body = Array.isArray(logXml) ? { logs: logXml } : { logXml };
+    if (hardwareKeyOverride) body.hardwareKey = hardwareKeyOverride;
     const result = await this.restSend('POST', '/log', body);
     return result?.success === true;
   }
@@ -417,10 +418,11 @@ export class RestClient {
     return this.restGet('/weather');
   }
 
-  async submitStats(statsXml) {
+  async submitStats(statsXml, hardwareKeyOverride = null) {
     try {
       // Accept array (JSON-native) or string (XML) — send under the right key
       const body = Array.isArray(statsXml) ? { stats: statsXml } : { statXml: statsXml };
+      if (hardwareKeyOverride) body.hardwareKey = hardwareKeyOverride;
       const result = await this.restSend('POST', '/stats', body);
       const success = result?.success === true;
       log.info(`SubmitStats result: ${success}`);

--- a/packages/xmds/src/xmds-client.js
+++ b/packages/xmds/src/xmds-client.js
@@ -382,10 +382,10 @@ export class XmdsClient {
    * @param {string} logXml - XML string containing log entries
    * @returns {Promise<boolean>} - true if logs were successfully submitted
    */
-  async submitLog(logXml) {
+  async submitLog(logXml, hardwareKeyOverride = null) {
     const xml = await this.call('SubmitLog', {
       serverKey: this.config.cmsKey,
-      hardwareKey: this.config.hardwareKey,
+      hardwareKey: hardwareKeyOverride || this.config.hardwareKey,
       logXml: logXml
     });
 
@@ -436,11 +436,11 @@ export class XmdsClient {
     });
   }
 
-  async submitStats(statsXml) {
+  async submitStats(statsXml, hardwareKeyOverride = null) {
     try {
       const xml = await this.call('SubmitStats', {
         serverKey: this.config.cmsKey,
-        hardwareKey: this.config.hardwareKey,
+        hardwareKey: hardwareKeyOverride || this.config.hardwareKey,
         statXml: statsXml
       });
 


### PR DESCRIPTION
## Summary

- Followers delegate stats and logs submission to the sync lead via BroadcastChannel, reducing CMS API calls by 75% in video wall setups
- Lead submits on each follower's behalf preserving their `hardwareKey` identity, acks only after CMS confirms
- Followers fall back to direct submission if lead goes silent for >15s (graceful degradation)

### Changes

- **`@xiboplayer/sync`**: 4 new callbacks (`onStatsReport`, `onLogsReport`, `onStatsAck`, `onLogsAck`), 2 new follower methods (`reportStats`, `reportLogs`), 4 new message types
- **`@xiboplayer/xmds`**: `hardwareKeyOverride` param on `submitStats()` and `submitLog()` in both REST and SOAP clients
- **Tests**: 4 new delegation tests (ack flow, no-ack on failure, self-message guard, logs parity)

Closes #100

## Test plan

- [x] `pnpm test` — 1262 tests pass (4 new delegation tests)
- [ ] Manual: 2 tabs (lead + follower), verify only lead makes XMDS stats/log calls
- [ ] Manual: kill lead tab, verify follower falls back to direct submission