### PR TITLE
fix: don't mark widget HTML as orphaned when parent layout is required

### DIFF
--- a/packages/cache/src/cache-analyzer.js
+++ b/packages/cache/src/cache-analyzer.js
@@ -56,6 +56,14 @@ export class CacheAnalyzer {
     for (const file of cachedFiles) {
       if (requiredIds.has(String(file.id))) {
         required.push(file);
+      } else if (file.type === 'widget') {
+        // Widget HTML IDs are "layoutId/regionId/widgetId" — check parent layout
+        const parentLayoutId = String(file.id).split('/')[0];
+        if (requiredIds.has(parentLayoutId)) {
+          required.push(file);
+        } else {
+          orphaned.push(file);
+        }
       } else {
         orphaned.push(file);
       }

--- a/packages/cache/src/cache-analyzer.test.js
+++ b/packages/cache/src/cache-analyzer.test.js
@@ -170,6 +170,20 @@ describe('CacheAnalyzer', () => {
       vi.unstubAllGlobals();
     });
 
+    it('should treat widget HTML as required when parent layout is required', async () => {
+      mockCache._addFile({ id: '470', type: 'layout', size: 500, cachedAt: 100 });
+      mockCache._addFile({ id: '470/213/182', type: 'widget', size: 0, cachedAt: 0 });
+      mockCache._addFile({ id: '470/215/184', type: 'widget', size: 0, cachedAt: 0 });
+      mockCache._addFile({ id: '99/10/5', type: 'widget', size: 0, cachedAt: 0 });
+
+      const report = await analyzer.analyze([{ id: '470', type: 'layout' }]);
+
+      // Layout 470 + its 2 widgets = 3 required; widget for layout 99 = orphaned
+      expect(report.files.required).toBe(3);
+      expect(report.files.orphaned).toBe(1);
+      expect(report.orphaned[0].id).toBe('99/10/5');
+    });
+
     it('should handle files with missing size or cachedAt', async () => {
       mockCache._addFile({ id: '1', type: 'media' }); // no size, no cachedAt
 


### PR DESCRIPTION
## Summary

- Widget HTML files (`widget/470/213/182`) were always marked orphaned because their composite IDs never match RequiredFiles entries (which only contain layout/media IDs)
- Extract the parent layout ID from the widget path and check if it's still required
- Widgets whose parent layout is no longer required are still correctly orphaned and evicted under storage pressure

Fixes #106

## Test plan

- [x] `pnpm test` — 1263 tests pass (1 new)
- [x] New test verifies widgets with required parent layout are kept, widgets with missing parent are orphaned