### PR TITLE
fix: video not visible after PDF in multi-widget region

### DIFF
--- a/packages/renderer/src/renderer-lite.js
+++ b/packages/renderer/src/renderer-lite.js
@@ -1446,14 +1446,17 @@ export class RendererLite {
     }
 
     // Hide all other widgets in region
+    // Cancel fill:forwards animations first — they override inline styles
     for (const [widgetId, widgetEl] of region.widgetElements) {
       if (widgetId !== widget.id) {
+        widgetEl.getAnimations?.().forEach(a => a.cancel());
         widgetEl.style.visibility = 'hidden';
         widgetEl.style.opacity = '0';
       }
     }
 
     this.updateMediaElement(element, widget);
+    element.getAnimations?.().forEach(a => a.cancel());
     element.style.visibility = 'visible';
 
     if (widget.transitions.in) {


### PR DESCRIPTION
## Summary

Video plays but is invisible when a region cycles from a PDF widget to a video widget.

### Root cause

Widget elements within a region were in **normal DOM flow** (no `position: absolute`). When the PDF widget was hidden with `visibility: hidden`, it still occupied its full height in the layout flow, pushing the video element below the region's `overflow: hidden` boundary. The video was playing but clipped off-screen.

### Fix (3 commits)

1. **Cancel `fill:forwards` animations** (PR #110) — CSS animations with `fill: forwards` override inline styles, so `_showWidget()` now cancels them on siblings before hiding
2. **`position: absolute` on all widget elements** (`8a020dd`) — widgets now stack as layers within the region instead of flowing vertically, so `visibility: hidden` elements don't push visible ones out of view
3. **Fix image scaleType mapping** (`1e9a92f`) — CMS `center` mode means "scale proportionally to fit" (`object-fit: contain`), not "show at natural size" (`object-fit: none`)

### Also includes (issue #101 fixes)

- `d6092f0` — fix `<base>` tag to use dynamic SW scope path
- `42dd186` — download unclaimed media files (widget data)
- `2aaa8af` — extract data widget IDs from XLF for priority download

Fixes #102

## Test plan

- [x] `pnpm test` — 1263 tests pass
- [x] `pnpm run build` (PWA) — builds
- [x] Manual: layout 470 with PDF + video in region 213, video visible after PDF ends
- [x] Image in region 214 scales correctly (matches CMS preview)