### PR TITLE
fix: correct image scaleType alignment and fit mode (#103)

### DIFF
--- a/packages/renderer/src/renderer-lite.js
+++ b/packages/renderer/src/renderer-lite.js
@@ -1818,16 +1818,18 @@ export class RendererLite {
     img.className = 'renderer-lite-widget';
     img.style.width = '100%';
     img.style.height = '100%';
-    // Scale type: stretch → fill, center → none (natural size), default → contain
+    // Scale type: stretch → fill (ignore ratio), center → none (natural size), fit → cover (fill region, crop excess)
+    // Matches CMS xibo-layout-renderer behavior: fit uses background-size:cover
     const scaleType = widget.options.scaleType;
-    const fitMap = { stretch: 'fill', center: 'none', fit: 'contain' };
+    const fitMap = { stretch: 'fill', center: 'none', fit: 'cover' };
     img.style.objectFit = fitMap[scaleType] || 'contain';
 
-    // Alignment: map align/valign to CSS object-position
+    // Alignment: map alignId/valignId to CSS object-position
+    // XLF tags are <alignId> and <valignId> (from CMS image.xml property ids)
     const alignMap = { left: 'left', center: 'center', right: 'right' };
     const valignMap = { top: 'top', middle: 'center', bottom: 'bottom' };
-    const hPos = alignMap[widget.options.align] || 'center';
-    const vPos = valignMap[widget.options.valign] || 'center';
+    const hPos = alignMap[widget.options.alignId] || 'center';
+    const vPos = valignMap[widget.options.valignId] || 'center';
     img.style.objectPosition = `${hPos} ${vPos}`;
 
     img.style.opacity = '0';

--- a/packages/renderer/src/renderer-lite.test.js
+++ b/packages/renderer/src/renderer-lite.test.js
@@ -467,7 +467,7 @@ describe('RendererLite', () => {
       expect(element.style.objectFit).toBe('none');
     });
 
-    it('should apply objectFit contain when scaleType is fit', async () => {
+    it('should apply objectFit cover when scaleType is fit', async () => {
       const widget = {
         type: 'image',
         id: 'm1',
@@ -480,15 +480,15 @@ describe('RendererLite', () => {
       const region = { width: 1920, height: 1080 };
       const element = await renderer.renderImage(widget, region);
 
-      expect(element.style.objectFit).toBe('contain');
+      expect(element.style.objectFit).toBe('cover');
     });
 
-    it('should map align and valign to objectPosition', async () => {
+    it('should map alignId and valignId to objectPosition', async () => {
       const widget = {
         type: 'image',
         id: 'm1',
         fileId: '1',
-        options: { uri: 'test.png', align: 'left', valign: 'top' },
+        options: { uri: 'test.png', alignId: 'left', valignId: 'top' },
         duration: 10,
         transitions: { in: null, out: null }
       };
@@ -499,12 +499,12 @@ describe('RendererLite', () => {
       expect(element.style.objectPosition).toBe('left top');
     });
 
-    it('should map align right and valign bottom to objectPosition', async () => {
+    it('should map alignId right and valignId bottom to objectPosition', async () => {
       const widget = {
         type: 'image',
         id: 'm1',
         fileId: '1',
-        options: { uri: 'test.png', align: 'right', valign: 'bottom' },
+        options: { uri: 'test.png', alignId: 'right', valignId: 'bottom' },
         duration: 10,
         transitions: { in: null, out: null }
       };
@@ -515,12 +515,12 @@ describe('RendererLite', () => {
       expect(element.style.objectPosition).toBe('right bottom');
     });
 
-    it('should map valign middle to center in objectPosition', async () => {
+    it('should map valignId middle to center in objectPosition', async () => {
       const widget = {
         type: 'image',
         id: 'm1',
         fileId: '1',
-        options: { uri: 'test.png', align: 'center', valign: 'middle' },
+        options: { uri: 'test.png', alignId: 'center', valignId: 'middle' },
         duration: 10,
         transitions: { in: null, out: null }
       };
@@ -536,7 +536,7 @@ describe('RendererLite', () => {
         type: 'image',
         id: 'm1',
         fileId: '1',
-        options: { uri: 'test.png', scaleType: 'stretch', align: 'left', valign: 'bottom' },
+        options: { uri: 'test.png', scaleType: 'stretch', alignId: 'left', valignId: 'bottom' },
         duration: 10,
         transitions: { in: null, out: null }
       };


### PR DESCRIPTION
## Summary
- Read `alignId`/`valignId` from widget options (not `align`/`valign`) to match CMS `image.xml` property ids exported in XLF
- Map `fit` scaleType to `object-fit: cover` instead of `contain`, matching `xibo-layout-renderer` behavior (`background-size: cover`)

## Root Cause
The CMS image module defines properties with ids `alignId` and `valignId`, which become `<alignId>` and `<valignId>` XML tags in XLF. The renderer was reading `options.align` / `options.valign` — always falling back to center.

Additionally, the official `xibo-layout-renderer` maps `fit` to `background-size: cover` (fill region, crop excess), but we were using `object-fit: contain` (letterbox within region).

## Test plan
- [x] All 1263 tests pass
- [ ] Visual test: image with `scaleType=fit` fills region without letterboxing
- [ ] Visual test: image with `scaleType=center` + `alignId=left` positions correctly

Closes #103