### PR TITLE
fix: pre-fetch widget data for RSS/dataset widgets (#101)

### DIFF
--- a/packages/renderer/src/layout.js
+++ b/packages/renderer/src/layout.js
@@ -132,7 +132,8 @@ export class LayoutTranslator {
           log.info(`Got resource HTML (${raw.length} chars)`);
 
           // Store widget HTML in cache and save cache key for iframe src generation
-          const widgetCacheKey = await cacheWidgetHtml(layoutId, regionId, id, raw);
+          const cmsUrl = this.xmds?.config?.cmsAddress || this.xmds?.config?.restApiUrl;
+          const widgetCacheKey = await cacheWidgetHtml(layoutId, regionId, id, raw, { cmsUrl });
           options.widgetCacheKey = widgetCacheKey;
 
           // Success - break retry loop

--- a/packages/sw/src/request-handler.js
+++ b/packages/sw/src/request-handler.js
@@ -235,6 +235,25 @@ export class RequestHandler {
 
     this.log.info('IS a cache request, proceeding...', url.pathname);
 
+    // Handle widget data requests (pre-fetched JSON for RSS, dataset, etc.)
+    if (url.pathname.startsWith(BASE + '/cache/data/')) {
+      this.log.info('Widget data request:', url.pathname);
+      const cached = await this.cacheManager.get(url.pathname);
+      if (cached) {
+        return new Response(cached.clone().body, {
+          headers: {
+            'Content-Type': 'application/json',
+            'Access-Control-Allow-Origin': '*',
+            'Cache-Control': 'public, max-age=300'
+          }
+        });
+      }
+      return new Response('{"data":[],"meta":{}}', {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
     // Handle widget HTML requests
     if (url.pathname.startsWith(BASE + '/cache/widget/')) {
       this.log.info('Widget HTML request:', url.pathname);


### PR DESCRIPTION
## Summary
- Rewrite `/pwa/getData?widgetId=X&auth...` URLs in widget HTML to local cache paths (`/cache/data/X.json`)
- Pre-fetch JSON data from CMS during `cacheWidgetHtml()` and store in Cache API
- Add SW handler to serve cached widget data at `/cache/data/` paths
- Pass `cmsUrl` option through call chain to construct absolute CMS URLs for data fetching

## Root Cause
Data widgets (RSS ticker, dataset, currencies, etc.) embed a `currentWidget.url` pointing to `/pwa/getData?widgetId=X&serverKey=...&hardwareKey=...`. This is a relative path that the CMS sets during HTML rendering (`WidgetHtmlRenderer.php:438`).

When the widget HTML runs in an iframe served from the Service Worker origin, this relative URL resolves to the SW's host (e.g., `localhost:8765/pwa/getData...`) instead of the CMS. The SW doesn't handle `/pwa/` routes → 404 → `isDataReady: false` → widget expires in 1500ms.

## Architecture
```
Before (broken):
  iframe → $.ajax("/pwa/getData?...") → SW origin → 404

After (fixed):
  cacheWidgetHtml() → rewrites URL to /player/pwa/cache/data/184.json
                     → pre-fetches data from CMS
                     → stores JSON in Cache API
  iframe → $.ajax("/player/pwa/cache/data/184.json") → SW → cached JSON ✓
```

## Test plan
- [x] All 1263 SDK tests pass
- [x] PWA builds successfully
- [ ] RSS ticker widget loads data and renders content
- [ ] Dataset widget loads data
- [ ] Data refreshes on next collection cycle

Closes #101