### PR TITLE
fix: longer retry backoff for getData/widget-data downloads

### DIFF
--- a/packages/sw/src/message-handler.js
+++ b/packages/sw/src/message-handler.js
@@ -227,6 +227,11 @@ export class MessageHandler {
           || (f.path && (f.path.includes('bundle.min') || f.path.includes('fonts')))) {
         resources.push(f);
       } else {
+        // Flag widget data files (getData) for longer retry backoff.
+        // CMS returns HTTP 500 "cache not ready" until the XTR task runs.
+        if (f.path && f.path.includes('getData')) {
+          f.isGetData = true;
+        }
         mediaFiles.set(String(f.id), f);
       }
     }


### PR DESCRIPTION
## Summary
- getData (RSS, weather) downloads now retry with 15s/30s/60s/120s backoff instead of 0.5s/1s/1.5s
- After all retries fail, the task is re-enqueued after 60s instead of being permanently marked as failed
- Fixes cold-start issue where CMS returns 500 "Cache not ready" until XTR task populates widget data cache

Closes #116