### PR TITLE
fix: simplify duration recording and revert timeline interleaving

### DIFF
--- a/packages/schedule/src/timeline.js
+++ b/packages/schedule/src/timeline.js
@@ -216,9 +216,7 @@ export function calculateTimeline(schedule, durations, options = {}) {
       continue;
     }
 
-    // Round-robin through playable layouts, interleaving default layout between them
-    // (mirrors getInterleavedLayouts() in the actual player)
-    const defaultFile = schedule.schedule?.default;
+    // Round-robin through playable layouts
     for (let i = 0; i < playable.length && currentTime < to && timeline.length < maxEntries; i++) {
       const file = playable[i];
       let dur = durations.get(file) || defaultDuration;
@@ -252,20 +250,6 @@ export function calculateTimeline(schedule, durations, options = {}) {
       }
 
       currentTime = new Date(endMs);
-
-      // Interleave default layout between scheduled layouts (player does A, D, B, D, C, D)
-      if (defaultFile && playable.length > 1 && currentTime < to && timeline.length < maxEntries) {
-        const defDur = durations.get(defaultFile) || defaultDuration;
-        const defEndMs = currentTime.getTime() + defDur * 1000;
-        timeline.push({
-          layoutFile: defaultFile,
-          startTime: new Date(currentTime),
-          endTime: new Date(defEndMs),
-          duration: defDur,
-          isDefault: true,
-        });
-        currentTime = new Date(defEndMs);
-      }
 
       // Re-evaluate: if playable set changed, re-enter outer loop
       if (hasFullApi) {


### PR DESCRIPTION
## Summary
- Remove elapsed-time recording from `clearCurrentLayout()` — elapsed time is unreliable (layouts evacuated early by schedule changes caused `60s → 25s` clobbering)
- Add downgrade guard in `recordLayoutDuration()` — never replace a known duration (>60s) with a smaller value (prevents `166s → 60s` clobbering on layout replay)
- Revert default layout interleaving in `calculateTimeline()` — `getNextLayout()` uses `getCurrentLayouts()` (no interleaving), default only fills rate-limit gaps

Closes #120

## Test plan
- [x] Layout 472 (video): duration corrected `60s → 219s`, never clobbered back
- [x] Layout 366 (video): duration `166s` preserved across replays
- [x] Layout 1 (default): `60s` preserved even when evacuated early
- [x] Timeline shows default only when rate-limiting blocks all scheduled layouts