### PR TITLE
fix: route widget static resource fetches through proxy

### DIFF
--- a/packages/cache/src/widget-html.js
+++ b/packages/cache/src/widget-html.js
@@ -13,6 +13,7 @@
  */
 
 import { createLogger } from '@xiboplayer/utils';
+import { rewriteUrlForProxy } from './download-manager.js';
 
 const log = createLogger('Cache');
 const CACHE_NAME = 'xibo-media-v1';
@@ -110,7 +111,7 @@ export async function cacheWidgetHtml(layoutId, regionId, mediaId, html) {
       if (existing) return; // Already cached
 
       try {
-        const resp = await fetch(originalUrl);
+        const resp = await fetch(rewriteUrlForProxy(originalUrl));
         if (!resp.ok) {
           log.warn(`Failed to fetch static resource: ${filename} (HTTP ${resp.status})`);
           return;
@@ -149,7 +150,7 @@ export async function cacheWidgetHtml(layoutId, regionId, mediaId, html) {
             if (existingFont) return; // Already cached (by SW or previous widget)
 
             try {
-              const fontResp = await fetch(fontUrl);
+              const fontResp = await fetch(rewriteUrlForProxy(fontUrl));
               if (!fontResp.ok) {
                 log.warn(`Failed to fetch font: ${fontFile} (HTTP ${fontResp.status})`);
                 return;


### PR DESCRIPTION
## Summary
- Route all CMS URL fetches in `widget-html.js` through `rewriteUrlForProxy()` — eliminates CORS failures for fonts.css, pdf.worker.js, images
- Await `_cacheStaticResource()` in message-handler before sending `FILE_CACHED` notification — prevents race where widgets request static resources before they're cached
- Convert `_cacheStaticResource()` from fire-and-forget to proper async

Fixes #125

## Test plan
- [ ] Run Chromium kiosk player, check execution.log for zero CORS/ERR_FAILED errors
- [ ] Verify fonts.css served with `text/css` MIME type (not `text/html`)
- [ ] Verify pdf.worker.js loads correctly for PDF widgets
- [ ] Verify font files (.otf, .ttf) cached with correct MIME types