### PR TITLE
feat: LCM-based deterministic schedule queue with priority fallback

### DIFF
--- a/packages/schedule/src/index.js
+++ b/packages/schedule/src/index.js
@@ -25,4 +25,4 @@ export { OverlayScheduler } from './overlays.js';
  * Offline timeline calculator — duration parser + timeline simulator
  * @module @xiboplayer/schedule/timeline
  */
-export { calculateTimeline, parseLayoutDuration } from './timeline.js';
+export { calculateTimeline, parseLayoutDuration, buildScheduleQueue } from './timeline.js';


### PR DESCRIPTION
## Summary

- Replace reactive interleave+index scheduling with a pre-computed LCM-based repeating queue
- `buildScheduleQueue()` simulates one LCM period using `getPlayableLayouts()` — the same priority-fallback + rate-limit logic that `calculateTimeline()` uses
- Queue now matches the timeline overlay exactly: all scheduled layouts participate

## Problem

The old `buildScheduleQueue()` used **strict priority filtering** — only max-priority layouts survived (`Math.max(priority) → filter`). Rate-limited high-priority layouts starved all lower priority tiers.

**Before**: Queue = `472(219s) → 1(60s) × 16` — only layout 472 + default. Layouts 362, 364, 366 never played.

## Fix

Rewrite `buildScheduleQueue()` to simulate playback for one LCM period using `getPlayableLayouts()` (already correct in `calculateTimeline()`):

1. Calculate LCM period from rate-limited layout intervals (unchanged)
2. Simulate playback: at each step, call `getPlayableLayouts()` which filters rate-limited exhausted layouts, then picks highest remaining priority
3. This naturally cascades: prio 3 → prio 2 → prio 0 → default as each tier exhausts

**After**: Queue = `472 → 364 → 366 → 362 → 1 → 364 → 472 → 366 → ...` — all layouts play, distributed by priority and rate limits.

## Files changed

| File | Change |
|------|--------|
| `packages/schedule/src/timeline.js` | Rewrite `buildScheduleQueue()`: simulation loop replaces static slot allocation + strict priority filter |
| `packages/schedule/src/schedule.js` | Add `getScheduleQueue()`, `popNextFromQueue()`, `peekNextInQueue()`, `peekAfterNext()`, queue caching + invalidation |
| `packages/schedule/src/index.js` | Export `buildScheduleQueue` |
| `packages/core/src/player-core.js` | Switch `getNextLayout()` from reactive interleave to queue-based (`popNextFromQueue`) |
| `packages/schedule/src/schedule.test.js` | Tests for queue building, priority fallback, rate limiting |
| `packages/core/src/player-core.test.js` | Tests for queue-based layout selection |

## Verified

- All 1283 SDK tests pass
- Live test with Electron: all 5 layouts playing (472, 364, 366, 362, 1) with correct priority distribution
- Timeline overlay and actual playback queue produce matching sequences

## Test plan

- [x] `pnpm test` — 1283 tests pass
- [x] `ansible-playbook playbooks/services/pwa-local-test.yml -e player=electron`
- [x] `/tmp/electron-pwa.log` — queue shows all layouts
- [x] `~/Downloads/execution.log` — layout transitions match timeline overlay