### PR TITLE
refactor: unify SWLogger with @xiboplayer/utils Logger

### DIFF
--- a/packages/pwa/public/sw-pwa.js
+++ b/packages/pwa/public/sw-pwa.js
@@ -18,15 +18,15 @@ import { VERSION as CACHE_VERSION } from '@xiboplayer/cache';
 import {
   RequestHandler,
   MessageHandler,
-  calculateChunkConfig,
-  SWLogger
+  calculateChunkConfig
 } from '@xiboplayer/sw';
+import { createLogger } from '@xiboplayer/utils';
 import { BASE } from '@xiboplayer/sw/utils';
 
 // ── Configuration ──────────────────────────────────────────────────────────
 const SW_VERSION = __BUILD_DATE__;
 
-const log = new SWLogger('SW');
+const log = createLogger('SW');
 
 // ── Device-adaptive chunk config ───────────────────────────────────────────
 const CHUNK_CONFIG = calculateChunkConfig(log);

--- a/packages/sw/package.json
+++ b/packages/sw/package.json
@@ -14,7 +14,8 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@xiboplayer/cache": "workspace:*"
+    "@xiboplayer/cache": "workspace:*",
+    "@xiboplayer/utils": "workspace:*"
   },
   "devDependencies": {
     "vitest": "^2.0.0"

--- a/packages/sw/src/chunk-config.js
+++ b/packages/sw/src/chunk-config.js
@@ -1,38 +1,8 @@
 /**
- * Service Worker logger and chunk configuration
+ * Chunk configuration for Service Worker downloads
  */
 
-/**
- * Simple logger for Service Worker context.
- * Uses console but can be configured via self.swLogLevel.
- */
-export class SWLogger {
-  constructor(name) {
-    this.name = name;
-    // Default level: INFO (can be changed via self.swLogLevel = 'DEBUG')
-    this.level = (typeof self !== 'undefined' && self.swLogLevel) || 'INFO';
-  }
-
-  debug(...args) {
-    if (this.level === 'DEBUG') {
-      console.log(`[${this.name}] DEBUG:`, ...args);
-    }
-  }
-
-  info(...args) {
-    if (this.level === 'DEBUG' || this.level === 'INFO') {
-      console.log(`[${this.name}]`, ...args);
-    }
-  }
-
-  warn(...args) {
-    console.warn(`[${this.name}]`, ...args);
-  }
-
-  error(...args) {
-    console.error(`[${this.name}]`, ...args);
-  }
-}
+import { createLogger } from '@xiboplayer/utils';
 
 /**
  * Calculate optimal chunk size based on available device memory.
@@ -42,7 +12,7 @@ export class SWLogger {
  * @returns {{ chunkSize: number, blobCacheSize: number, threshold: number, concurrency: number }}
  */
 export function calculateChunkConfig(log) {
-  if (!log) log = new SWLogger('ChunkConfig');
+  if (!log) log = createLogger('ChunkConfig');
 
   // Try to detect device memory (Chrome only for now)
   const deviceMemoryGB = (typeof navigator !== 'undefined' && navigator.deviceMemory) || null;

--- a/packages/sw/src/index.js
+++ b/packages/sw/src/index.js
@@ -2,4 +2,4 @@
 export { RequestHandler } from './request-handler.js';
 export { MessageHandler } from './message-handler.js';
 export { extractMediaIdsFromXlf } from './xlf-parser.js';
-export { calculateChunkConfig, SWLogger } from './chunk-config.js';
+export { calculateChunkConfig } from './chunk-config.js';

--- a/packages/sw/src/message-handler.js
+++ b/packages/sw/src/message-handler.js
@@ -8,7 +8,7 @@
 
 import { LayoutTaskBuilder, BARRIER, toProxyUrl } from '@xiboplayer/cache/download-manager';
 import { formatBytes, BASE } from './sw-utils.js';
-import { SWLogger } from './chunk-config.js';
+import { createLogger } from '@xiboplayer/utils';
 import { extractMediaIdsFromXlf } from './xlf-parser.js';
 
 export class MessageHandler {
@@ -21,7 +21,7 @@ export class MessageHandler {
   constructor(downloadManager, config) {
     this.downloadManager = downloadManager;
     this.config = config;
-    this.log = new SWLogger('SW Message');
+    this.log = createLogger('SW Message');
   }
 
   /**

--- a/packages/sw/src/request-handler.js
+++ b/packages/sw/src/request-handler.js
@@ -7,7 +7,7 @@
  */
 
 import { BASE } from './sw-utils.js';
-import { SWLogger } from './chunk-config.js';
+import { createLogger } from '@xiboplayer/utils';
 
 export class RequestHandler {
   /**
@@ -16,7 +16,7 @@ export class RequestHandler {
   constructor(downloadManager) {
     this.downloadManager = downloadManager;
     this.pendingFetches = new Map(); // filename → Promise<Response> for deduplication
-    this.log = new SWLogger('SW');
+    this.log = createLogger('SW');
   }
 
   /**

--- a/packages/utils/src/logger.js
+++ b/packages/utils/src/logger.js
@@ -133,6 +133,9 @@ if (typeof window !== 'undefined') {
   } else {
     globalConfig.setGlobalLevel('WARNING');
   }
+} else if (typeof self !== 'undefined' && self.swLogLevel) {
+  // Service Worker context: use self.swLogLevel (set before importing this module)
+  globalConfig.setGlobalLevel(self.swLogLevel);
 }
 
 // Factory function — loggers follow global level by default (reactive)


### PR DESCRIPTION
## Summary

- Remove duplicate `SWLogger` class from `@xiboplayer/sw` (35 lines)
- Use shared `createLogger()` from `@xiboplayer/utils` in all SW code
- Make utils Logger environment-aware: detects Service Worker context via `self.swLogLevel` when `window` is unavailable

## Changes

| File | Change |
|------|--------|
| `packages/utils/src/logger.js` | Add `self.swLogLevel` fallback for SW context |
| `packages/sw/src/chunk-config.js` | Remove `SWLogger` class, import `createLogger` |
| `packages/sw/src/request-handler.js` | Replace `SWLogger` → `createLogger` |
| `packages/sw/src/message-handler.js` | Replace `SWLogger` → `createLogger` |
| `packages/sw/src/index.js` | Remove `SWLogger` from exports |
| `packages/sw/package.json` | Add explicit `@xiboplayer/utils` dependency |
| `packages/pwa/public/sw-pwa.js` | Replace `SWLogger` → `createLogger` |

## Test plan

- [x] All 1295 tests pass (7 skipped — same as baseline)
- [ ] Deploy to test display and verify SW logging works in browser DevTools
- [ ] Verify `self.swLogLevel = 'DEBUG'` still enables debug logging in SW

Closes #132