### PR TITLE
feat: add TypeScript type declarations for SDK packages

### DIFF
--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -4,6 +4,7 @@
   "description": "Offline caching and download management with parallel chunk downloads",
   "type": "module",
   "main": "./src/index.js",
+  "types": "./src/index.d.ts",
   "exports": {
     ".": "./src/index.js",
     "./cache": "./src/cache.js",

--- a/packages/cache/src/index.d.ts
+++ b/packages/cache/src/index.d.ts
@@ -1,0 +1,40 @@
+export const VERSION: string;
+
+export class StoreClient {
+  has(type: string, id: string | number): Promise<boolean>;
+  get(type: string, id: string | number): Promise<Blob | null>;
+  put(type: string, id: string | number, body: Blob | ArrayBuffer | string, contentType?: string): Promise<boolean>;
+  remove(files: Array<{ type: string; id: string | number }>): Promise<{ deleted: number; total: number }>;
+  list(): Promise<Array<{ id: string; type: string; size: number }>>;
+}
+
+export class DownloadClient {
+  controller: ServiceWorker | null;
+  fetchReady: boolean;
+  init(): Promise<void>;
+  download(payload: object | any[]): Promise<void>;
+  prioritize(fileType: string, fileId: string): Promise<void>;
+  prioritizeLayout(mediaIds: string[]): Promise<void>;
+  getProgress(): Promise<Record<string, any>>;
+  cleanup(): void;
+}
+
+export class DownloadManager {
+  constructor(options?: { concurrency?: number; chunkSize?: number; maxChunksPerFile?: number });
+  enqueue(fileInfo: any): any;
+  prioritizeLayoutFiles(mediaIds: string[]): void;
+}
+
+export class FileDownload {}
+export class LayoutTaskBuilder {}
+export class CacheManager {}
+export class CacheAnalyzer {
+  constructor(store: StoreClient);
+}
+
+export const cacheManager: CacheManager;
+
+export function isUrlExpired(url: string): boolean;
+export function toProxyUrl(url: string): string;
+export function setCmsOrigin(origin: string): void;
+export function cacheWidgetHtml(...args: any[]): any;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,6 +4,7 @@
   "description": "Xibo Player core orchestration and lifecycle management",
   "type": "module",
   "main": "./src/index.js",
+  "types": "./src/index.d.ts",
   "exports": {
     ".": "./src/index.js",
     "./player-core": "./src/player-core.js"

--- a/packages/core/src/index.d.ts
+++ b/packages/core/src/index.d.ts
@@ -1,0 +1,96 @@
+export const VERSION: string;
+
+export interface PlayerCoreOptions {
+  config: any;
+  xmds: any;
+  cache: any;
+  schedule: any;
+  renderer: any;
+  xmrWrapper: any;
+  statsCollector?: any;
+  displaySettings?: any;
+}
+
+export class PlayerCore {
+  constructor(options: PlayerCoreOptions);
+
+  config: any;
+  xmds: any;
+  cache: any;
+  schedule: any;
+  renderer: any;
+  statsCollector: any;
+  displaySettings: any;
+  xmr: any;
+  currentLayoutId: number | null;
+  collecting: boolean;
+  offlineMode: boolean;
+  syncConfig: any;
+  syncManager: any;
+  displayCommands: Record<string, string> | null;
+  dataConnectorManager: any;
+
+  on(event: string, callback: (...args: any[]) => void): void;
+  once(event: string, callback: (...args: any[]) => void): void;
+  off(event: string, callback: (...args: any[]) => void): void;
+  emit(event: string, ...args: any[]): void;
+
+  collect(): Promise<void>;
+  collectNow(): Promise<void>;
+  collectOffline(): void;
+
+  getNextLayout(): { layoutId: number; layoutFile: string } | null;
+  peekNextLayout(): { layoutId: number; layoutFile: string } | null;
+  advanceToNextLayout(): void;
+  advanceToPreviousLayout(): void;
+  setCurrentLayout(layoutId: number): void;
+  clearCurrentLayout(): void;
+  getCurrentLayoutId(): number | null;
+  getPendingLayouts(): number[];
+  setPendingLayout(layoutId: number, requiredMediaIds: number[]): void;
+  isLayoutOverridden(): boolean;
+  changeLayout(layoutId: number | string, options?: { duration?: number; changeMode?: string }): Promise<void>;
+  overlayLayout(layoutId: number | string, options?: { duration?: number }): Promise<void>;
+  revertToSchedule(): Promise<void>;
+  requestLayoutChange(layoutId: number): Promise<void>;
+
+  notifyMediaReady(fileId: number, fileType?: string): void;
+  notifyLayoutStatus(layoutId: number): Promise<void>;
+  checkSchedule(): void;
+  isCollecting(): boolean;
+  hasCachedData(): boolean;
+  isOffline(): boolean;
+  isInOfflineMode(): boolean;
+
+  executeCommand(commandCode: string, commands?: Record<string, string>): Promise<void>;
+  handleTrigger(triggerCode: string): void;
+  purgeAll(): Promise<void>;
+  captureScreenshot(): Promise<void>;
+
+  requestGeoLocation(): Promise<{ latitude: number; longitude: number } | null>;
+  reportGeoLocation(data: { latitude: number | string; longitude: number | string }): void;
+
+  submitMediaInventory(files: any[]): Promise<void>;
+  blackList(mediaId: number, type: string, reason: string): Promise<void>;
+
+  reportLayoutFailure(layoutId: number, reason: string): void;
+  reportLayoutSuccess(layoutId: number): void;
+  isLayoutBlacklisted(layoutId: number): boolean;
+  getBlacklistedLayouts(): number[];
+  resetBlacklist(): void;
+
+  getDataConnectorManager(): any;
+  updateDataConnectors(): void;
+  refreshDataConnectors(): void;
+
+  setSyncManager(syncManager: any): void;
+  isInSyncGroup(): boolean;
+  isSyncLead(): boolean;
+  getSyncConfig(): any;
+
+  recordLayoutDuration(file: string, duration: number): void;
+  setupCollectionInterval(settings: any): void;
+  updateCollectionInterval(newIntervalSeconds: number): void;
+
+  cleanup(): void;
+}

--- a/packages/pwa/src/main.ts
+++ b/packages/pwa/src/main.ts
@@ -5,13 +5,9 @@
  * Platform layer handles UI, DOM manipulation, and platform-specific features.
  */
 
-// @ts-ignore - JavaScript module
 import { RendererLite } from '@xiboplayer/renderer';
-// @ts-ignore - JavaScript module
 import { StoreClient, DownloadClient } from '@xiboplayer/cache';
-// @ts-ignore - JavaScript module
 import { PlayerCore } from '@xiboplayer/core';
-// @ts-ignore - JavaScript module
 import { createLogger, registerLogSink } from '@xiboplayer/utils';
 import { DownloadOverlay, getDefaultOverlayConfig } from './download-overlay.js';
 import { TimelineOverlay, isTimelineVisible } from './timeline-overlay.js';
@@ -112,7 +108,6 @@ class PwaPlayer {
     // Tell toProxyUrl() and the SW which origin is the CMS so external URLs aren't proxied
     if (config.cmsUrl) {
       const cmsOrigin = new URL(config.cmsUrl).origin;
-      // @ts-ignore - JavaScript module
       const { setCmsOrigin } = await import('@xiboplayer/cache');
       setCmsOrigin(cmsOrigin);
       navigator.serviceWorker?.controller?.postMessage({
@@ -291,25 +286,15 @@ class PwaPlayer {
    */
   private async loadCoreModules() {
     try {
-      // @ts-ignore - JavaScript modules
       const cacheModule = await import('@xiboplayer/cache');
-      // @ts-ignore
       const xmdsModule = await import('@xiboplayer/xmds');
-      // @ts-ignore
       const scheduleModule = await import('@xiboplayer/schedule');
-      // @ts-ignore
       const configModule = await import('@xiboplayer/utils');
-      // @ts-ignore
       const xmrModule = await import('@xiboplayer/xmr');
-      // @ts-ignore
       const statsModule = await import('@xiboplayer/stats');
-      // @ts-ignore
       const displaySettingsModule = await import('@xiboplayer/settings');
-      // @ts-ignore
       const coreModule = await import('@xiboplayer/core');
-      // @ts-ignore
       const rendererModule = await import('@xiboplayer/renderer');
-      // @ts-ignore
       const syncModule = await import('@xiboplayer/sync');
 
       cacheWidgetHtml = cacheModule.cacheWidgetHtml;

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -4,6 +4,7 @@
   "description": "RendererLite - Fast, efficient XLF layout rendering engine",
   "type": "module",
   "main": "./src/index.js",
+  "types": "./src/index.d.ts",
   "exports": {
     ".": "./src/index.js",
     "./renderer-lite": "./src/renderer-lite.js",

--- a/packages/renderer/src/index.d.ts
+++ b/packages/renderer/src/index.d.ts
@@ -1,0 +1,74 @@
+export const VERSION: string;
+
+export interface RendererConfig {
+  cmsUrl: string;
+  hardwareKey: string;
+}
+
+export interface RendererOptions {
+  getMediaUrl?: (fileId: number) => Promise<string>;
+  getWidgetHtml?: (widget: any) => Promise<string | { url: string; fallback?: string }>;
+  logLevel?: string;
+}
+
+export class LayoutPool {
+  layouts: Map<number, any>;
+  maxSize: number;
+  hotLayoutId: number | null;
+  has(layoutId: number): boolean;
+  get(layoutId: number): any | undefined;
+  add(layoutId: number, entry: any): void;
+  clearWarmNotIn(keepIds: Set<number>): number;
+  makeHot(layoutId: number): void;
+  remove(layoutId: number): void;
+  clear(): void;
+}
+
+export class RendererLite {
+  constructor(config: RendererConfig, container: HTMLElement, options?: RendererOptions);
+
+  config: RendererConfig;
+  container: HTMLElement;
+  options: RendererOptions;
+  currentLayout: any;
+  currentLayoutId: number | null;
+  regions: Map<string, any>;
+  layoutPool: LayoutPool;
+  activeOverlays: Map<number, any>;
+  scaleFactor: number;
+  offsetX: number;
+  offsetY: number;
+
+  on(event: string, callback: (...args: any[]) => void): () => void;
+  emit(event: string, ...args: any[]): void;
+
+  renderLayout(xlfXml: string, layoutId: number): Promise<void>;
+  stopCurrentLayout(): void;
+  preloadLayout(xlfXml: string, layoutId: number): Promise<boolean>;
+  hasPreloadedLayout(layoutId: number): boolean;
+
+  renderOverlay(xlfXml: string, layoutId: number, priority?: number): Promise<void>;
+  stopOverlay(layoutId: number): void;
+  stopAllOverlays(): void;
+  getActiveOverlays(): number[];
+
+  navigateToWidget(targetWidgetId: string): void;
+  nextWidget(regionId?: string): void;
+  previousWidget(regionId?: string): void;
+
+  pause(): void;
+  resume(): void;
+  isPaused(): boolean;
+  resumeRegionMedia?(regionId: string): void;
+
+  parseXlf(xlfXml: string): any;
+  parseWidget(mediaEl: Element): any;
+
+  calculateScale(layout: any): void;
+  rescaleRegions(): void;
+
+  updateLayoutDuration(): void;
+  checkLayoutComplete(): void;
+
+  cleanup(): void;
+}

--- a/packages/schedule/package.json
+++ b/packages/schedule/package.json
@@ -4,6 +4,7 @@
   "description": "Complete scheduling solution: campaigns, dayparting, interrupts, and overlays",
   "type": "module",
   "main": "./src/index.js",
+  "types": "./src/index.d.ts",
   "exports": {
     ".": "./src/index.js",
     "./schedule": "./src/schedule.js",

--- a/packages/schedule/src/index.d.ts
+++ b/packages/schedule/src/index.d.ts
@@ -1,0 +1,19 @@
+export const VERSION: string;
+
+export class ScheduleManager {
+  schedule: any;
+  setSchedule(schedule: any): void;
+  getCurrentLayouts(): string[];
+  getLayoutsAtTime?(date: Date): any[];
+  setLocation(lat: number, lng: number): void;
+  setDisplayProperties(settings: any): void;
+  recordPlay(layoutId: string | number): void;
+  isSyncEvent(layoutFile: string): boolean;
+  getCommands?(): any[];
+}
+
+export const scheduleManager: ScheduleManager;
+
+export function calculateTimeline(layouts: any[], durations: Map<string, number>, options?: any): any[];
+export function parseLayoutDuration(xlf: string): number;
+export function buildScheduleQueue(schedule: any, durations: Map<string, number>): any[];

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -4,6 +4,7 @@
   "description": "CMS settings management and application for Xibo Player",
   "type": "module",
   "main": "./src/index.js",
+  "types": "./src/index.d.ts",
   "exports": {
     ".": "./src/index.js",
     "./manager": "./src/settings.js"

--- a/packages/settings/src/index.d.ts
+++ b/packages/settings/src/index.d.ts
@@ -1,0 +1,30 @@
+export const VERSION: string;
+
+export interface DisplaySettingsData {
+  collectInterval: number;
+  displayName: string;
+  sizeX: number;
+  sizeY: number;
+  statsEnabled: boolean;
+  aggregationLevel: 'Individual' | 'Aggregate';
+  logLevel: string;
+  xmrNetworkAddress: string | null;
+  xmrWebSocketAddress: string | null;
+  xmrCmsKey: string | null;
+  preventSleep: boolean;
+  screenshotInterval: number;
+}
+
+export class DisplaySettings {
+  settings: DisplaySettingsData;
+  on(event: string, callback: (...args: any[]) => void): void;
+  applySettings(settings: Record<string, any>): { changed: string[]; settings: DisplaySettingsData };
+  getCollectInterval(): number;
+  getDisplayName(): string;
+  getDisplaySize(): { width: number; height: number };
+  isStatsEnabled(): boolean;
+  isInDownloadWindow(): boolean;
+  shouldTakeScreenshot(lastScreenshot: Date | null): boolean;
+  getAllSettings(): DisplaySettingsData;
+  getSetting(key: string, defaultValue?: any): any;
+}

--- a/packages/stats/package.json
+++ b/packages/stats/package.json
@@ -4,6 +4,7 @@
   "description": "Proof of play tracking, stats reporting, and CMS logging",
   "type": "module",
   "main": "./src/index.js",
+  "types": "./src/index.d.ts",
   "exports": {
     ".": "./src/index.js",
     "./collector": "./src/stats-collector.js"

--- a/packages/stats/src/index.d.ts
+++ b/packages/stats/src/index.d.ts
@@ -1,0 +1,61 @@
+export const VERSION: string;
+
+export interface StatEntry {
+  id?: number;
+  type: 'layout' | 'media' | 'event';
+  layoutId: number;
+  scheduleId: number;
+  start: Date;
+  end: Date | null;
+  duration: number;
+  count: number;
+  submitted: 0 | 1;
+  mediaId?: number;
+  widgetId?: string | number | null;
+  tag?: string;
+}
+
+export class StatsCollector {
+  db: IDBDatabase | null;
+  init(): Promise<void>;
+  startLayout(layoutId: number, scheduleId: number, options?: { enableStat?: boolean }): Promise<void>;
+  endLayout(layoutId: number, scheduleId: number): Promise<void>;
+  startWidget(mediaId: number, layoutId: number, scheduleId: number, widgetId?: string | number, options?: { enableStat?: boolean }): Promise<void>;
+  endWidget(mediaId: number, layoutId: number, scheduleId: number): Promise<void>;
+  recordEvent(tag: string, layoutId: number, widgetId: number, scheduleId: number): Promise<void>;
+  getStatsForSubmission(limit?: number): Promise<StatEntry[]>;
+  getAggregatedStatsForSubmission(limit?: number): Promise<StatEntry[]>;
+  clearSubmittedStats(stats: StatEntry[]): Promise<void>;
+  getAllStats(): Promise<StatEntry[]>;
+  clearAllStats(): Promise<void>;
+}
+
+export function formatStats(stats: StatEntry[]): string;
+
+export interface LogEntry {
+  id?: number;
+  level: string;
+  message: string;
+  category: string;
+  timestamp: Date;
+  submitted: 0 | 1;
+}
+
+export class LogReporter {
+  db: IDBDatabase | null;
+  init(): Promise<void>;
+  log(level: string, message: string, category?: string, extra?: any): Promise<void>;
+  reportFault(code: string, reason: string, cooldownMs?: number): Promise<void>;
+  getFaultsForSubmission(limit?: number): Promise<LogEntry[]>;
+  error(message: string, category?: string): Promise<void>;
+  audit(message: string, category?: string): Promise<void>;
+  info(message: string, category?: string): Promise<void>;
+  debug(message: string, category?: string): Promise<void>;
+  getLogsForSubmission(limit?: number): Promise<LogEntry[]>;
+  clearSubmittedLogs(logs: LogEntry[]): Promise<void>;
+  getAllLogs(): Promise<LogEntry[]>;
+  clearAllLogs(): Promise<void>;
+}
+
+export function formatLogs(logs: LogEntry[]): string;
+export function formatFaults(faults: LogEntry[]): string;

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -4,8 +4,12 @@
   "description": "Multi-display synchronization for Xibo Player",
   "type": "module",
   "main": "src/sync-manager.js",
+  "types": "src/index.d.ts",
   "exports": {
-    ".": "./src/sync-manager.js"
+    ".": {
+      "types": "./src/index.d.ts",
+      "default": "./src/sync-manager.js"
+    }
   },
   "scripts": {
     "test": "vitest run",

--- a/packages/sync/src/index.d.ts
+++ b/packages/sync/src/index.d.ts
@@ -1,0 +1,22 @@
+export const VERSION: string;
+
+export interface SyncConfig {
+  syncGroup: string;
+  syncPublisherPort: number;
+  syncSwitchDelay: number;
+  syncVideoPauseDelay: number;
+  isLead: boolean;
+}
+
+export class SyncManager {
+  constructor(config: SyncConfig, displayId: string);
+  config: SyncConfig;
+  isLead: boolean;
+
+  start(): void;
+  stop(): void;
+  requestLayoutChange(layoutId: number, showDelay?: number): void;
+  notifyLayoutReady(layoutId: number): void;
+  onLayoutShow(callback: (layoutId: number) => void): void;
+  onLayoutChange(callback: (layoutId: number) => void): void;
+}

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -4,6 +4,7 @@
   "description": "Shared utilities for Xibo Player packages",
   "type": "module",
   "main": "./src/index.js",
+  "types": "./src/index.d.ts",
   "exports": {
     ".": "./src/index.js",
     "./logger": "./src/logger.js",

--- a/packages/utils/src/index.d.ts
+++ b/packages/utils/src/index.d.ts
@@ -1,0 +1,71 @@
+export const VERSION: string;
+
+export interface Logger {
+  debug(...args: any[]): void;
+  info(...args: any[]): void;
+  warn(...args: any[]): void;
+  error(...args: any[]): void;
+  setLevel(level: string): void;
+  getEffectiveLevel(): number;
+}
+
+export interface LogSinkEntry {
+  level: string;
+  name: string;
+  args: any[];
+}
+
+export function createLogger(name: string, level?: string | null): Logger;
+export function setLogLevel(level: string): void;
+export function getLogLevel(): string;
+export function isDebug(): boolean;
+export function applyCmsLogLevel(cmsLevel: string): boolean;
+export function registerLogSink(fn: (entry: LogSinkEntry) => void): void;
+export function unregisterLogSink(fn: (entry: LogSinkEntry) => void): void;
+
+export class EventEmitter {
+  on(event: string, callback: (...args: any[]) => void): void;
+  once(event: string, callback: (...args: any[]) => void): void;
+  off(event: string, callback: (...args: any[]) => void): void;
+  emit(event: string, ...args: any[]): void;
+  removeAllListeners(event?: string): void;
+}
+
+export class Config {
+  load(): Record<string, string>;
+  save(): void;
+  isConfigured(): boolean;
+  generateStableHardwareKey(): string;
+  generateXmrChannel(): string;
+  ensureXmrKeyPair(): Promise<void>;
+  hash(str: string): string;
+  get cmsUrl(): string;
+  set cmsUrl(val: string);
+  get cmsKey(): string;
+  set cmsKey(val: string);
+  get displayName(): string;
+  set displayName(val: string);
+  get hardwareKey(): string;
+  get xmrChannel(): string;
+  get xmrPubKey(): string;
+  get xmrPrivKey(): string;
+  get googleGeoApiKey(): string;
+  set googleGeoApiKey(val: string);
+  macAddress?: string;
+}
+
+export const config: Config;
+
+export function fetchWithRetry(
+  url: string,
+  options?: RequestInit,
+  retryOptions?: { maxRetries?: number; baseDelayMs?: number }
+): Promise<Response>;
+
+export class CmsApiClient {
+  constructor(baseUrl: string, apiKey?: string);
+  get(path: string, params?: Record<string, string>): Promise<any>;
+  post(path: string, body?: any): Promise<any>;
+  put(path: string, body?: any): Promise<any>;
+  delete(path: string): Promise<any>;
+}

--- a/packages/xmds/package.json
+++ b/packages/xmds/package.json
@@ -4,6 +4,7 @@
   "description": "XMDS SOAP client for Xibo CMS communication",
   "type": "module",
   "main": "./src/index.js",
+  "types": "./src/index.d.ts",
   "exports": {
     ".": "./src/index.js",
     "./xmds-client": "./src/xmds-client.js",

--- a/packages/xmds/src/index.d.ts
+++ b/packages/xmds/src/index.d.ts
@@ -1,0 +1,35 @@
+export const VERSION: string;
+
+export class RestClient {
+  constructor(config: any);
+  config: any;
+  schemaVersion: number;
+
+  registerDisplay(): Promise<any>;
+  getSchedule(): Promise<any>;
+  getRequiredFiles(): Promise<any>;
+  getFile(fileId: number, fileType: string): Promise<any>;
+  notifyStatus(status: any): Promise<any>;
+  submitStats(statsXml: string, hardwareKey?: string): Promise<boolean>;
+  submitLog(logsXml: string, hardwareKey?: string): Promise<boolean>;
+  reportFaults(faultsJson: string): Promise<boolean>;
+  mediaInventory(inventoryXml: string): Promise<boolean>;
+  submitGeoLocation?(data: any): Promise<void>;
+}
+
+export class XmdsClient {
+  constructor(config: any);
+  config: any;
+
+  registerDisplay(): Promise<any>;
+  getSchedule(): Promise<any>;
+  getRequiredFiles(): Promise<any>;
+  getFile(fileId: number, fileType: string): Promise<any>;
+  notifyStatus(status: any): Promise<any>;
+  submitStats(statsXml: string, hardwareKey?: string): Promise<boolean>;
+  submitLog(logsXml: string, hardwareKey?: string): Promise<boolean>;
+  reportFaults(faultsJson: string): Promise<boolean>;
+  mediaInventory(inventoryXml: string): Promise<boolean>;
+}
+
+export function parseScheduleResponse(data: any): any;

--- a/packages/xmr/package.json
+++ b/packages/xmr/package.json
@@ -4,6 +4,7 @@
   "description": "XMR WebSocket client for real-time Xibo CMS commands",
   "type": "module",
   "main": "./src/index.js",
+  "types": "./src/index.d.ts",
   "exports": {
     ".": "./src/index.js"
   },

--- a/packages/xmr/src/index.d.ts
+++ b/packages/xmr/src/index.d.ts
@@ -1,0 +1,11 @@
+export const VERSION: string;
+
+export class XmrWrapper {
+  constructor(config: any, player: any);
+  config: any;
+  player: any;
+  connected: boolean;
+
+  start(xmrUrl: string, cmsKey: string): Promise<boolean>;
+  stop(): void;
+}


### PR DESCRIPTION
## Summary

- Add `index.d.ts` type declarations to 10 SDK packages: cache, core, renderer, utils, xmds, schedule, xmr, stats, settings, sync
- Add `"types"` field to each `package.json`
- Remove all 15 `// @ts-ignore` lines from `packages/pwa/src/main.ts`

The PWA now has full type checking at SDK boundaries — autocomplete, compile-time error detection, and no more suppressed type errors.

Resolves #143

## Test plan

- [x] `pnpm test` — 1295 tests pass
- [x] `pnpm --filter @xiboplayer/pwa build` — builds with zero `@ts-ignore` and zero type errors
- [ ] Verify autocomplete works in IDE for SDK imports