### PR TITLE
Fix download overlay showing completed downloads at 100%

### DIFF
--- a/packages/cache/src/download-manager.js
+++ b/packages/cache/src/download-manager.js
@@ -935,6 +935,8 @@ export class DownloadQueue {
   getProgress() {
     const progress = {};
     for (const [key, file] of this.active.entries()) {
+      // Skip completed/failed — they stay in active until removeCompleted() runs
+      if (file.state === 'complete' || file.state === 'failed') continue;
       progress[key] = {
         downloaded: file.downloadedBytes,
         total: file.totalBytes,

--- a/packages/pwa/src/download-overlay.ts
+++ b/packages/pwa/src/download-overlay.ts
@@ -70,16 +70,15 @@ export class DownloadOverlay {
     const hasDownloads = !!html;
 
     if (hasDownloads) {
+      // Active downloads — show overlay (auto or user-toggled)
       this.overlay.innerHTML = html;
-      if (this._visible) {
-        this.overlay.style.display = 'block';
-      }
+      this.overlay.style.display = 'block';
     } else if (this._visible) {
-      // User toggled on but no downloads — show idle status, keep polling
+      // User toggled on (D key) but no downloads — show idle status
       this.overlay.innerHTML = '<div style="color: #6c6; font-size: 1.4vw;">✓ All downloads complete</div>';
       this.overlay.style.display = 'block';
     } else {
-      // Auto-triggered but no downloads left — stop polling, hide
+      // No downloads and not user-toggled — stop polling, hide
       this.stopUpdating();
       this.overlay.style.display = 'none';
     }
@@ -154,13 +153,15 @@ export class DownloadOverlay {
   /**
    * Start polling for download progress.
    * Safe to call multiple times — won't create duplicate timers.
+   * Does NOT set _visible — the overlay auto-shows when downloads are active
+   * and auto-hides when they finish. Use toggle() for user-controlled visibility.
    */
   public startUpdating() {
-    this._visible = true;
     if (this.updateTimer) return; // Already polling
     this.updateTimer = window.setInterval(() => {
       this.updateOverlay();
     }, this.config.updateInterval);
+    this.updateOverlay(); // Immediate first update
   }
 
   /**


### PR DESCRIPTION
## Summary
- `getProgress()` now filters out completed/failed downloads from the active map
- `startUpdating()` no longer sets `_visible` (reserved for D key toggle), so the overlay auto-hides when downloads finish

Closes #152