### PR TITLE
feat: forward renderer console logs to proxy stdout

### DIFF
--- a/packages/proxy/src/proxy.js
+++ b/packages/proxy/src/proxy.js
@@ -257,6 +257,23 @@ export function createProxyApp({ pwaPath, appVersion = '0.0.0', pwaConfig, confi
     res.json({ success: true });
   });
 
+  // ─── Console Log Forwarding ──────────────────────────────────────
+  // Receive batched log entries from the PWA renderer and write them to
+  // stdout. Controlled by debug.consoleLogs in config.json.
+  // journald or shell redirect captures the output.
+  const _consoleLogsEnabled = !!currentPwaConfig?.debug?.consoleLogs;
+  if (_consoleLogsEnabled) logProxy.info('Console log forwarding enabled');
+
+  app.post('/debug/log', (req, res) => {
+    if (!_consoleLogsEnabled) return res.status(204).end();
+    const entries = Array.isArray(req.body) ? req.body : [req.body];
+    for (const { level, name, message } of entries) {
+      const tag = level === 'error' ? '[R ERROR]' : level === 'warning' ? '[R WARN]' : '[R]';
+      console.log(`${tag} [${name}] ${message}`);
+    }
+    res.status(204).end();
+  });
+
   // ─── Cache-through helper ─────────────────────────────────────────
   // Serve from store on hit. On miss, fetch from CMS and tee-stream to
   // disk + client simultaneously — zero buffering.

--- a/packages/pwa/src/main.ts
+++ b/packages/pwa/src/main.ts
@@ -429,6 +429,39 @@ class PwaPlayer {
         this.logReporter.log(level, `[${name}] ${message}`, 'PLAYER').catch(() => {});
       });
 
+      // Forward console logs to proxy stdout (for journald/log analysis).
+      // Controlled by debug.consoleLogs in config.json.
+      // Optional debug.consoleLogsInterval (seconds) sets the batch flush interval (default 10s).
+      const debugConfig = JSON.parse(localStorage.getItem('xibo_config') || '{}')?.debug;
+      if (debugConfig?.consoleLogs) {
+        const flushIntervalMs = (debugConfig.consoleLogsInterval || 10) * 1000;
+        let batch: Array<{ level: string; name: string; message: string; ts: string }> = [];
+        let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+        const flushLogs = () => {
+          if (batch.length === 0) return;
+          const payload = batch;
+          batch = [];
+          flushTimer = null;
+          // Fire-and-forget POST — log forwarding must never block the player
+          fetch('/debug/log', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+          }).catch(() => {});
+        };
+
+        registerLogSink(({ level, name, args }: { level: string; name: string; args: any[] }) => {
+          const message = args.map((a: any) => typeof a === 'string' ? a : JSON.stringify(a)).join(' ');
+          batch.push({ level, name, message, ts: new Date().toISOString() });
+          if (!flushTimer) {
+            flushTimer = setTimeout(flushLogs, flushIntervalMs);
+          }
+        });
+
+        log.info(`Console log forwarding to proxy enabled (flush every ${flushIntervalMs / 1000}s)`);
+      }
+
       // Initialize display settings manager
       this.displaySettings = new DisplaySettings();
       log.info('Display settings manager initialized');


### PR DESCRIPTION
Closes #163

## Summary

- Add `POST /debug/log` endpoint to the proxy that writes received log entries to stdout with `[R]` prefix
- Add batched `registerLogSink` in the PWA renderer that forwards logs via fire-and-forget fetch
- Controlled by `debug.consoleLogs` (boolean) and `debug.consoleLogsInterval` (seconds, default 10) in config.json

Enables Chromium kiosk log capture via journald — Electron's `webContents.on('console-message')` is unaffected.

## Test plan

- [ ] Set `"debug": { "consoleLogs": true }` in Electron config, run `pwa-local-test.yml`, verify `[R] [PWA] ...` lines in `/tmp/electron-pwa.log`
- [ ] For Chromium: check `journalctl --user -u xiboplayer-server` for renderer logs
- [ ] Run `player-debug-stats.yml` — all sections should populate
- [ ] Verify `pnpm test` passes with no regressions