### PR TITLE
feat: annotate timeline entries with missing media status

### DIFF
--- a/packages/core/src/index.d.ts
+++ b/packages/core/src/index.d.ts
@@ -88,6 +88,7 @@ export class PlayerCore {
   isSyncLead(): boolean;
   getSyncConfig(): any;
 
+  setLayoutMediaStatus(layoutFile: string, ready: boolean, missing?: string[]): void;
   recordLayoutDuration(file: string, duration: number): void;
   setupCollectionInterval(settings: any): void;
   updateCollectionInterval(newIntervalSeconds: number): void;

--- a/packages/core/src/player-core.js
+++ b/packages/core/src/player-core.js
@@ -97,6 +97,7 @@ export class PlayerCore extends EventEmitter {
     this.collecting = false;
     this.collectionInterval = null;
     this.pendingLayouts = new Map(); // layoutId -> required media IDs
+    this._layoutMediaStatus = new Map(); // layoutFile → { ready: boolean, missing: string[] }
     this.offlineMode = false; // Track whether we're currently in offline mode
     this._normalCollectInterval = null; // Saved interval to restore after offline retry
     this._offlineRetrySeconds = 0; // Current backoff interval (0 = not retrying)
@@ -701,6 +702,8 @@ export class PlayerCore extends EventEmitter {
     this._lastLayoutChangeTime = new Date().toISOString();
     this._statusCode = 1; // Running
     this.pendingLayouts.delete(layoutId);
+    // Layout proved playable — clear media status (no longer missing)
+    this._layoutMediaStatus.delete(`${layoutId}.xlf`);
     this.emit('layout-current', layoutId);
     // Force timeline recalc on layout change (fingerprint reset)
     this._lastTimelineFingerprint = null;
@@ -1645,14 +1648,19 @@ export class PlayerCore extends EventEmitter {
     if (this._layoutDurations.size === 0) return;
     if (!this.schedule.getLayoutsAtTime) return; // Schedule doesn't support time queries
 
-    // Fingerprint inputs: schedule CRC + sorted durations + current layout.
+    // Fingerprint inputs: schedule CRC + sorted durations + current layout + media status.
     // When unchanged, re-emit the cached timeline — avoids time drift from
     // re-simulating with a new Date.now() anchor on every collection cycle.
     const durationEntries = [...this._layoutDurations.entries()]
       .sort(([a], [b]) => a.localeCompare(b))
       .map(([k, v]) => `${k}:${v}`)
       .join('|');
-    const fingerprint = `${this._lastCheckSchedule}|${durationEntries}|${this.currentLayoutId}`;
+    const mediaStatusEntries = [...this._layoutMediaStatus.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([k, v]) => `${k}:${v.ready}:${v.missingKey}`)
+      .join('|');
+    const pendingEntries = [...this.pendingLayouts.keys()].sort().join(',');
+    const fingerprint = `${this._lastCheckSchedule}|${durationEntries}|${this.currentLayoutId}|${mediaStatusEntries}|${pendingEntries}`;
 
     if (fingerprint === this._lastTimelineFingerprint && this._lastTimeline) {
       this.emit('timeline-updated', this._lastTimeline);
@@ -1664,16 +1672,58 @@ export class PlayerCore extends EventEmitter {
     });
     if (timeline.length === 0) return;
 
+    // Annotate entries with missingMedia from pendingLayouts (high authority)
+    // and _layoutMediaStatus (proactive check, lower authority)
+    for (const entry of timeline) {
+      const layoutId = parseInt(entry.layoutFile.replace('.xlf', ''), 10);
+      const pendingMedia = this.pendingLayouts.get(layoutId);
+      if (pendingMedia && pendingMedia.length > 0) {
+        // pendingLayouts takes priority — definitively missing
+        entry.missingMedia = pendingMedia.map(String);
+      } else {
+        const status = this._layoutMediaStatus.get(entry.layoutFile);
+        if (status && !status.ready && status.missing.length > 0) {
+          entry.missingMedia = status.missing.map(String);
+        }
+      }
+    }
+
     this._lastTimelineFingerprint = fingerprint;
     this._lastTimeline = timeline;
 
     const lines = timeline.slice(0, 20).map(e => {
       const s = e.startTime.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
       const end = e.endTime.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
-      return `  ${s}-${end}  Layout ${e.layoutFile} (${e.duration}s)${e.isDefault ? ' [default]' : ''}`;
+      const missingTag = e.missingMedia ? ` [MISSING: ${e.missingMedia.length} files]` : '';
+      return `  ${s}-${end}  Layout ${e.layoutFile} (${e.duration}s)${e.isDefault ? ' [default]' : ''}${missingTag}`;
     });
+
+    // Log warnings for layouts with missing media
+    for (const entry of timeline) {
+      if (entry.missingMedia) {
+        log.warn(`[Timeline] Layout ${entry.layoutFile}: ${entry.missingMedia.length} files missing`);
+      }
+    }
+
     log.info(`[Timeline] Next ${timeline.length} plays:\n${lines.join('\n')}`);
     this.emit('timeline-updated', timeline);
+  }
+
+  /**
+   * Set media readiness status for a layout (proactive async check from platform layer).
+   * No-ops if value is unchanged to avoid fingerprint churn.
+   * @param {string} layoutFile - Layout file (e.g. '100.xlf')
+   * @param {boolean} ready - Whether all media is cached
+   * @param {string[]} [missing] - Array of missing media IDs/filenames
+   */
+  setLayoutMediaStatus(layoutFile, ready, missing = []) {
+    const existing = this._layoutMediaStatus.get(layoutFile);
+    const missingKey = missing.slice().sort().join(',');
+    if (existing && existing.ready === ready && existing.missingKey === missingKey) return;
+
+    this._layoutMediaStatus.set(layoutFile, { ready, missing, missingKey });
+    // Invalidate fingerprint to force timeline recalculation
+    this._lastTimelineFingerprint = null;
   }
 
   /**

--- a/packages/core/src/player-core.test.js
+++ b/packages/core/src/player-core.test.js
@@ -2212,4 +2212,270 @@ describe('PlayerCore', () => {
     });
   });
 
+  // ── Timeline stability ────────────────────────────────────────────
+  // Behavioral tests for the fingerprinting/caching contract:
+  // "timeline is stable when nothing changes, and updates when something does"
+
+  describe('Timeline stability', () => {
+    /** Set up mockSchedule with timeline support methods */
+    function setupTimelineSupport() {
+      mockSchedule.getLayoutsAtTime = vi.fn(() => ['100.xlf']);
+      mockSchedule.getAllLayoutsAtTime = vi.fn(() => [
+        { file: '100.xlf', priority: 10, maxPlaysPerHour: 0 },
+      ]);
+      mockSchedule.playHistory = new Map();
+    }
+
+    it('should reuse cached timeline when inputs are unchanged', () => {
+      setupTimelineSupport();
+      core._layoutDurations.set('100.xlf', 30);
+      core._lastCheckSchedule = 'crc-aaa';
+      core.currentLayoutId = 100;
+
+      const spy = createSpy();
+      core.on('timeline-updated', spy);
+
+      core.logUpcomingTimeline();
+      core.logUpcomingTimeline();
+
+      expect(spy).toHaveBeenCalledTimes(2);
+      // Both calls emit the same array reference (cached, not recalculated)
+      expect(spy.mock.calls[0][0]).toBe(spy.mock.calls[1][0]);
+    });
+
+    it('should recalculate when schedule CRC changes', () => {
+      setupTimelineSupport();
+      core._layoutDurations.set('100.xlf', 30);
+      core._lastCheckSchedule = 'crc-aaa';
+      core.currentLayoutId = 100;
+
+      const spy = createSpy();
+      core.on('timeline-updated', spy);
+
+      core.logUpcomingTimeline();
+
+      // Schedule CRC changes (new collection fetched a different schedule)
+      core._lastCheckSchedule = 'crc-bbb';
+      core.logUpcomingTimeline();
+
+      expect(spy).toHaveBeenCalledTimes(2);
+      // Second call produces a NEW array (different reference)
+      expect(spy.mock.calls[0][0]).not.toBe(spy.mock.calls[1][0]);
+    });
+
+    it('should recalculate when a layout duration is corrected', () => {
+      setupTimelineSupport();
+      core._layoutDurations.set('100.xlf', 30);
+      core._lastCheckSchedule = 'crc-aaa';
+      core.currentLayoutId = 100;
+
+      const spy = createSpy();
+      core.on('timeline-updated', spy);
+
+      core.logUpcomingTimeline();
+
+      // Duration correction (video metadata arrived)
+      core._layoutDurations.set('100.xlf', 90);
+      core.logUpcomingTimeline();
+
+      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy.mock.calls[0][0]).not.toBe(spy.mock.calls[1][0]);
+    });
+
+    it('should recalculate timeline on layout change', () => {
+      setupTimelineSupport();
+      core._layoutDurations.set('100.xlf', 30);
+      core._lastCheckSchedule = 'crc-aaa';
+      core.currentLayoutId = 100;
+
+      const spy = createSpy();
+      core.on('timeline-updated', spy);
+
+      // Prime the cache
+      core.logUpcomingTimeline();
+      const firstFingerprint = core._lastTimelineFingerprint;
+
+      // Layout change nullifies fingerprint then recalculates
+      core.setCurrentLayout(200);
+
+      expect(spy).toHaveBeenCalledTimes(2);
+      // Fingerprint changed because layout ID changed
+      expect(core._lastTimelineFingerprint).not.toBe(firstFingerprint);
+    });
+
+    it('should not emit timeline-updated when durations are empty', () => {
+      setupTimelineSupport();
+      // _layoutDurations is empty (default state)
+      expect(core._layoutDurations.size).toBe(0);
+
+      const spy = createSpy();
+      core.on('timeline-updated', spy);
+
+      core.logUpcomingTimeline();
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('should not emit timeline-updated when schedule lacks time queries', () => {
+      // mockSchedule does NOT have getLayoutsAtTime (default mock)
+      expect(mockSchedule.getLayoutsAtTime).toBeUndefined();
+      core._layoutDurations.set('100.xlf', 30);
+
+      const spy = createSpy();
+      core.on('timeline-updated', spy);
+
+      core.logUpcomingTimeline();
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('should produce stable timeline across multiple collection cycles', () => {
+      setupTimelineSupport();
+      core._layoutDurations.set('100.xlf', 30);
+      core._lastCheckSchedule = 'crc-aaa';
+      core.currentLayoutId = 100;
+
+      const spy = createSpy();
+      core.on('timeline-updated', spy);
+
+      // Simulate 5 collection cycles with no changes
+      for (let i = 0; i < 5; i++) {
+        core.logUpcomingTimeline();
+      }
+
+      expect(spy).toHaveBeenCalledTimes(5);
+      // All 5 emissions carry the same cached timeline reference
+      const first = spy.mock.calls[0][0];
+      for (let i = 1; i < 5; i++) {
+        expect(spy.mock.calls[i][0]).toBe(first);
+      }
+    });
+
+    it('should recalculate once on duration correction then cache again', () => {
+      setupTimelineSupport();
+      core._layoutDurations.set('100.xlf', 30);
+      core._lastCheckSchedule = 'crc-aaa';
+      core.currentLayoutId = 100;
+
+      const spy = createSpy();
+      core.on('timeline-updated', spy);
+
+      // Initial calculation
+      core.logUpcomingTimeline();
+
+      // Duration correction → new timeline
+      core._layoutDurations.set('100.xlf', 90);
+      core.logUpcomingTimeline();
+
+      // Same inputs again → cached
+      core.logUpcomingTimeline();
+
+      expect(spy).toHaveBeenCalledTimes(3);
+      // Call 1 vs call 2: different (recalculated)
+      expect(spy.mock.calls[0][0]).not.toBe(spy.mock.calls[1][0]);
+      // Call 2 vs call 3: same (cached)
+      expect(spy.mock.calls[1][0]).toBe(spy.mock.calls[2][0]);
+    });
+
+    // ── Missing media annotation ───────────────────────────────────────
+
+    it('should annotate entry from pendingLayouts', () => {
+      setupTimelineSupport();
+      core._layoutDurations.set('100.xlf', 30);
+      core._lastCheckSchedule = 'crc-aaa';
+      core.currentLayoutId = 100;
+
+      // Layout 100 has pending media (definitively missing)
+      core.pendingLayouts.set(100, [201, 202]);
+
+      const spy = createSpy();
+      core.on('timeline-updated', spy);
+      core.logUpcomingTimeline();
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      const entry = spy.mock.calls[0][0].find(e => e.layoutFile === '100.xlf');
+      expect(entry).toBeDefined();
+      expect(entry.missingMedia).toEqual(['201', '202']);
+    });
+
+    it('should annotate entry from _layoutMediaStatus', () => {
+      setupTimelineSupport();
+      core._layoutDurations.set('100.xlf', 30);
+      core._lastCheckSchedule = 'crc-aaa';
+      core.currentLayoutId = 100;
+
+      // Proactive check found missing media
+      core.setLayoutMediaStatus('100.xlf', false, ['55', '66']);
+
+      const spy = createSpy();
+      core.on('timeline-updated', spy);
+      core.logUpcomingTimeline();
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      const entry = spy.mock.calls[0][0].find(e => e.layoutFile === '100.xlf');
+      expect(entry).toBeDefined();
+      expect(entry.missingMedia).toEqual(['55', '66']);
+    });
+
+    it('should recalculate on media status change', () => {
+      setupTimelineSupport();
+      core._layoutDurations.set('100.xlf', 30);
+      core._lastCheckSchedule = 'crc-aaa';
+      core.currentLayoutId = 100;
+
+      const spy = createSpy();
+      core.on('timeline-updated', spy);
+
+      core.logUpcomingTimeline();
+
+      // Media status change → fingerprint invalidated
+      core.setLayoutMediaStatus('100.xlf', false, ['55']);
+      core.logUpcomingTimeline();
+
+      expect(spy).toHaveBeenCalledTimes(2);
+      // Different timeline objects (recalculated)
+      expect(spy.mock.calls[0][0]).not.toBe(spy.mock.calls[1][0]);
+    });
+
+    it('should not annotate when media is ready', () => {
+      setupTimelineSupport();
+      core._layoutDurations.set('100.xlf', 30);
+      core._lastCheckSchedule = 'crc-aaa';
+      core.currentLayoutId = 100;
+
+      // Media status: ready (no missing files)
+      core.setLayoutMediaStatus('100.xlf', true);
+
+      const spy = createSpy();
+      core.on('timeline-updated', spy);
+      core.logUpcomingTimeline();
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      const entry = spy.mock.calls[0][0].find(e => e.layoutFile === '100.xlf');
+      expect(entry).toBeDefined();
+      expect(entry.missingMedia).toBeUndefined();
+    });
+
+    it('should prioritize pendingLayouts over _layoutMediaStatus', () => {
+      setupTimelineSupport();
+      core._layoutDurations.set('100.xlf', 30);
+      core._lastCheckSchedule = 'crc-aaa';
+      core.currentLayoutId = 100;
+
+      // Both sources disagree: pendingLayouts says missing, _layoutMediaStatus says ready
+      core.pendingLayouts.set(100, [301, 302]);
+      core.setLayoutMediaStatus('100.xlf', true);
+
+      const spy = createSpy();
+      core.on('timeline-updated', spy);
+      core.logUpcomingTimeline();
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      const entry = spy.mock.calls[0][0].find(e => e.layoutFile === '100.xlf');
+      expect(entry).toBeDefined();
+      // pendingLayouts takes priority
+      expect(entry.missingMedia).toEqual(['301', '302']);
+    });
+  });
+
 });


### PR DESCRIPTION
## Summary

- Add `_layoutMediaStatus` Map + `setLayoutMediaStatus()` to PlayerCore for proactive cache checks
- Extend timeline fingerprint to include media status + pending layouts
- Annotate timeline entries with `missingMedia: string[]` (pendingLayouts takes priority)
- Log `[Timeline] Layout X: N files missing` warnings
- Clear status in `setCurrentLayout()` when layout proves playable
- 5 new tests covering annotation, fingerprint invalidation, and priority

## Test plan

- [x] All 228 core tests pass (including 5 new)
- [x] Full monorepo: 1271 passed, 7 skipped
- [ ] Manual: verify `[MISSING: N files]` appears in timeline log when media not cached

Closes #173