### PR TITLE
feat: show missing media in timeline overlay with red highlight

### DIFF
--- a/packages/pwa/src/main.ts
+++ b/packages/pwa/src/main.ts
@@ -62,6 +62,7 @@ class PwaPlayer {
   private syncManager: any = null; // Multi-display sync coordinator
   private _currentLayoutEnableStat: boolean = true; // enableStat from current layout XLF
   private _probeTimer: any = null; // Debounce timer for duration probing
+  private _mediaStatusTimer: ReturnType<typeof setTimeout> | null = null; // Debounce timer for media status check
   private _pendingFollowerStats: any[] | null = null; // In-flight stats delegated to lead
   private _pendingFollowerLogs: any[] | null = null; // In-flight logs delegated to lead
   private _iframeObserver: MutationObserver | null = null; // Iframe key-forwarding observer
@@ -1139,6 +1140,13 @@ class PwaPlayer {
       this._probeTimer = null;
       this.probeLayoutDurations().catch(() => {});
     }, 3000);
+
+    // Debounced media status check — update timeline missing-media annotations
+    if (this._mediaStatusTimer) clearTimeout(this._mediaStatusTimer);
+    this._mediaStatusTimer = setTimeout(() => {
+      this._mediaStatusTimer = null;
+      this.checkTimelineMediaStatus().catch(() => {});
+    }, 2000);
   }
 
   /**
@@ -1817,6 +1825,48 @@ class PwaPlayer {
   }
 
   /**
+   * Check media cache status for all scheduled layouts.
+   * For each layout: load XLF from cache, extract media IDs, check each with store.has().
+   * Feeds results into PlayerCore.setLayoutMediaStatus() for timeline annotation.
+   */
+  private async checkTimelineMediaStatus() {
+    if (this.scheduledLayoutIds.size === 0) return;
+
+    for (const layoutId of this.scheduledLayoutIds) {
+      const layoutFile = `${layoutId}.xlf`;
+      try {
+        const xlfBlob = await store.get('api/v2/player/layouts', layoutId);
+        if (!xlfBlob) continue;
+
+        const xlfXml = await xlfBlob.text();
+        const { allMedia } = this.getMediaIds(xlfXml);
+
+        if (allMedia.length === 0) {
+          this.core.setLayoutMediaStatus(layoutFile, true);
+          continue;
+        }
+
+        const missing: string[] = [];
+        for (const mediaId of allMedia) {
+          try {
+            const cached = await store.has('api/v2/player', `media/${mediaId}`);
+            if (!cached) missing.push(String(mediaId));
+          } catch {
+            // Assume cached on error (offline mode)
+          }
+        }
+
+        this.core.setLayoutMediaStatus(layoutFile, missing.length === 0, missing);
+      } catch {
+        // Skip layouts we can't load
+      }
+    }
+
+    // Re-emit annotated timeline
+    this.core.logUpcomingTimeline();
+  }
+
+  /**
    * Probe video durations for all scheduled layouts.
    * Uses preload="metadata" — only fetches headers (~50KB), not the full video.
    * Feeds discovered durations into PlayerCore for accurate timeline calculation.
@@ -2476,6 +2526,11 @@ class PwaPlayer {
     if (this._probeTimer) {
       clearTimeout(this._probeTimer);
       this._probeTimer = null;
+    }
+
+    if (this._mediaStatusTimer) {
+      clearTimeout(this._mediaStatusTimer);
+      this._mediaStatusTimer = null;
     }
   }
 }

--- a/packages/pwa/src/timeline-overlay.ts
+++ b/packages/pwa/src/timeline-overlay.ts
@@ -18,6 +18,7 @@ interface TimelineEntry {
   duration: number;
   isDefault: boolean;
   hidden?: HiddenLayout[];
+  missingMedia?: string[];
 }
 
 export class TimelineOverlay {
@@ -157,13 +158,24 @@ export class TimelineOverlay {
     for (const entry of visible) {
       const layoutId = parseInt(entry.layoutFile.replace('.xlf', ''), 10);
       const isCurrent = entry === effectiveCurrent;
+      const hasMissing = entry.missingMedia && entry.missingMedia.length > 0;
 
       const startStr = this.formatTime(entry.startTime);
       const endStr = this.formatTime(entry.endTime);
       const durStr = this.formatDuration(entry.duration);
 
-      const borderLeft = isCurrent ? 'border-left: 0.25vw solid #4a9eff; padding-left: 0.6vw;' : 'padding-left: 0.85vw;';
-      const color = isCurrent ? 'color: #fff; font-weight: 600;' : 'color: #aaa;';
+      let borderLeft: string;
+      let color: string;
+      if (isCurrent) {
+        borderLeft = 'border-left: 0.25vw solid #4a9eff; padding-left: 0.6vw;';
+        color = 'color: #fff; font-weight: 600;';
+      } else if (hasMissing) {
+        borderLeft = 'border-left: 0.25vw solid #ff4444; padding-left: 0.6vw;';
+        color = 'color: #ff6666;';
+      } else {
+        borderLeft = 'padding-left: 0.85vw;';
+        color = 'color: #aaa;';
+      }
       const cursor = clickable && !isCurrent ? 'cursor: pointer;' : '';
       const hover = clickable && !isCurrent ? 'onmouseover="this.style.background=\'rgba(255,255,255,0.1)\'" onmouseout="this.style.background=\'none\'"' : '';
 
@@ -172,6 +184,10 @@ export class TimelineOverlay {
       const durPad = durStr.padStart(7).replace(/ /g, '&nbsp;');
       html += `${startStr}–${endStr} ${idCol}${durPad}`;
       if (entry.isDefault) html += ' <span style="color: #888;">[def]</span>';
+      if (hasMissing) {
+        const missingList = entry.missingMedia!.join(', ');
+        html += ` <span style="color: #ff4444; font-size: 1.1vw;" title="Missing: ${missingList}">⚠ ${entry.missingMedia!.length}</span>`;
+      }
       if (entry.hidden && entry.hidden.length > 0) {
         const hiddenIds = entry.hidden.map(h => `#${h.file.replace('.xlf', '')} (p${h.priority})`).join(', ');
         html += ` <span style="color: #8899aa; font-size: 1.1vw;" title="Also scheduled: ${hiddenIds}">+${entry.hidden.length}</span>`;


### PR DESCRIPTION
## Summary

- Extend `TimelineEntry` interface with `missingMedia?: string[]`
- Render entries with missing media: red border, red text, `⚠ N` warning badge with tooltip
- Add `checkTimelineMediaStatus()` — proactive cache check for all scheduled layouts
- 2s debounced trigger in `notifyFileCached()` after downloads settle
- Cleanup timer in destroy

## Test plan

- [x] Full monorepo: 1271 passed, 7 skipped
- [ ] Deploy with layout that has uncached media → overlay shows red entry with ⚠ badge
- [ ] Wait for media to download → red disappears, entry turns normal

Depends on #175. Closes #174.