### PR TITLE
feat: unify media naming on storedAs filenames

### DIFF
--- a/packages/cache/src/download-manager.js
+++ b/packages/cache/src/download-manager.js
@@ -708,13 +708,15 @@ export class DownloadQueue {
 
     let boosted = 0;
     for (const t of this.queue) {
-      if (idSet.has(String(t._parentFile?.fileInfo.id)) && t._priority < priority) {
+      const matchValue = t._parentFile?.fileInfo.saveAs || String(t._parentFile?.fileInfo.id);
+      if (idSet.has(matchValue) && t._priority < priority) {
         t._priority = priority;
         boosted++;
       }
     }
     for (const t of this._activeTasks) {
-      if (idSet.has(String(t._parentFile?.fileInfo.id)) && t._priority < priority) {
+      const matchValue = t._parentFile?.fileInfo.saveAs || String(t._parentFile?.fileInfo.id);
+      if (idSet.has(matchValue) && t._priority < priority) {
         t._priority = priority;
       }
     }

--- a/packages/cache/src/widget-html.js
+++ b/packages/cache/src/widget-html.js
@@ -38,7 +38,7 @@ export async function cacheWidgetHtml(layoutId, regionId, mediaId, html) {
   const cacheKey = `${PLAYER_API}/widgets/${layoutId}/${regionId}/${mediaId}`;
 
   // Inject <base> tag — resolves relative media refs (e.g. "42") to mirror route
-  const baseTag = `<base href="${PLAYER_API}/media/">`;
+  const baseTag = `<base href="${PLAYER_API}/media/file/">`;
   let modifiedHtml = html;
 
   // Insert base tag after <head> opening tag (skip if already present)

--- a/packages/cache/src/widget-html.test.js
+++ b/packages/cache/src/widget-html.test.js
@@ -101,7 +101,7 @@ describe('cacheWidgetHtml', () => {
       await cacheWidgetHtml('472', '223', '193', html);
 
       const stored = getStoredWidget();
-      expect(stored).toContain('<base href="/api/v2/player/media/">');
+      expect(stored).toContain('<base href="/api/v2/player/media/file/">');
     });
 
     it('injects <base> tag when no <head> tag exists', async () => {
@@ -109,7 +109,7 @@ describe('cacheWidgetHtml', () => {
       await cacheWidgetHtml('472', '223', '193', html);
 
       const stored = getStoredWidget();
-      expect(stored).toContain('<base href="/api/v2/player/media/">');
+      expect(stored).toContain('<base href="/api/v2/player/media/file/">');
     });
   });
 

--- a/packages/core/src/player-core.js
+++ b/packages/core/src/player-core.js
@@ -941,7 +941,7 @@ export class PlayerCore extends EventEmitter {
       // For layout files: match layout ID with file ID (layout 78 needs layout/78)
       // For media files: check if fileId is in requiredFiles array
       const isLayoutFile = fileType === 'layout' && layoutId === parseInt(fileId);
-      const isRequiredMedia = fileType === 'media' && requiredFiles.includes(parseInt(fileId));
+      const isRequiredMedia = fileType === 'media' && requiredFiles.includes(fileId);
 
       if (isLayoutFile || isRequiredMedia) {
         log.debug(`${fileType} ${fileId} was needed by pending layout ${layoutId}, checking if ready...`);

--- a/packages/proxy/src/proxy.js
+++ b/packages/proxy/src/proxy.js
@@ -513,7 +513,19 @@ export function createProxyApp({ pwaPath, appVersion = '0.0.0', pwaConfig, confi
     }
   }
 
-  // Media: {PLAYER_API}/media/:id
+  // Media by storedAs filename: {PLAYER_API}/media/file/{storedAs}
+  // Primary route — widget HTML references media by storedAs (e.g. 42_abc123.jpg)
+  app.get(`${PLAYER_API}/media/file/{*storedAs}`, (req, res) => {
+    const storedAs = [req.params.storedAs].flat().pop();
+    const key = `${STORE_PREFIX}/media/file/${storedAs}`;
+    cacheThrough(req, res, key, `${PLAYER_API}/media/file/${storedAs}`);
+  });
+  app.head(`${PLAYER_API}/media/file/{*storedAs}`, (req, res) => {
+    const storedAs = [req.params.storedAs].flat().pop();
+    headFromStore(req, res, `${STORE_PREFIX}/media/file/${storedAs}`, 'application/octet-stream');
+  });
+
+  // Media by numeric ID (legacy): {PLAYER_API}/media/:id
   app.get(`${PLAYER_API}/media/:id`, (req, res) => {
     const key = `${STORE_PREFIX}/media/${req.params.id}`;
     cacheThrough(req, res, key, `${PLAYER_API}/media/${req.params.id}`);

--- a/packages/pwa/src/main.ts
+++ b/packages/pwa/src/main.ts
@@ -68,6 +68,7 @@ class PwaPlayer {
   private _iframeObserver: MutationObserver | null = null; // Iframe key-forwarding observer
   private _swIcHandler: any = null; // SW Interactive Control message handler
   private _chunkConfig: any = null; // Device-adaptive chunk configuration
+  private _fileIdToSaveAs: Map<string, string> = new Map(); // Numeric file ID → storedAs filename
 
   async init() {
     log.info('Initializing player with RendererLite + PlayerCore...');
@@ -124,23 +125,8 @@ class PwaPlayer {
       },
       container,
       {
-        // Provide media URL resolver - uses streaming via Service Worker
-        getMediaUrl: async (fileId: number) => {
-          log.debug(`getMediaUrl called for media ${fileId}`);
-
-          // Check if file exists in cache via mirror route HEAD
-          const exists = await store.has('api/v2/player', `media/${fileId}`);
-
-          if (!exists) {
-            log.warn(`Media ${fileId} not in cache`);
-            return '';
-          }
-
-          // Return direct URL — proxy mirror route serves from ContentStore
-          const streamingUrl = `${window.location.origin}${PLAYER_API}/media/${fileId}`;
-          log.debug(`Using streaming URL for media ${fileId}: ${streamingUrl}`);
-          return streamingUrl;
-        },
+        // Provide fileId→saveAs map for layout background resolution
+        fileIdToSaveAs: this._fileIdToSaveAs,
 
         // Provide widget HTML resolver — check ContentStore via proxy
         getWidgetHtml: async (widget: any) => {
@@ -1135,8 +1121,12 @@ class PwaPlayer {
   private notifyFileCached(fileId: string, fileType: string) {
     log.debug(`Download complete: ${fileType}/${fileId}`);
 
-    if (fileType === 'media' || fileType === 'layout') {
+    if (fileType === 'layout') {
       this.core.notifyMediaReady(parseInt(fileId), fileType);
+    } else if (fileType === 'media') {
+      // Pass saveAs string for media files (matches pendingLayouts entries)
+      const saveAs = this._fileIdToSaveAs.get(fileId) || fileId;
+      this.core.notifyMediaReady(saveAs, fileType);
     }
 
     // Debounced duration probe — run after downloads settle
@@ -1165,6 +1155,13 @@ class PwaPlayer {
 
     /** Store key = URL path without leading / and query params */
     const storeKeyFrom = (f: any) => (f.path || '').split('?')[0].replace(/^\/+/, '') || `${f.type || 'media'}/${f.id}`;
+
+    // Build fileId→saveAs map from CMS RequiredFiles data
+    for (const f of files) {
+      if (f.saveAs) {
+        this._fileIdToSaveAs.set(String(f.id), f.saveAs);
+      }
+    }
 
     // Build lookup maps from flat CMS file list
     const xlfFiles = new Map();
@@ -1592,16 +1589,17 @@ class PwaPlayer {
     });
 
     // Handle video playback errors — re-download only missing chunks
-    this.renderer.on('videoError', async ({ fileId }: any) => {
-      const storeKey = `${PLAYER_API.slice(1)}/media/${fileId}`;
+    this.renderer.on('videoError', async ({ storedAs }: any) => {
+      if (!storedAs) return;
+      const storeKey = `${PLAYER_API.slice(1)}/media/file/${storedAs}`;
       try {
         const resp = await fetch(`/store/missing-chunks/${storeKey}`);
         const { missing } = await resp.json();
         if (missing.length === 0) {
-          log.warn(`Video error for media ${fileId} but no missing chunks — possible decode error`);
+          log.warn(`Video error for ${storedAs} but no missing chunks — possible decode error`);
           return;
         }
-        log.warn(`Video ${fileId}: ${missing.length} missing chunks (${missing.join(', ')}), re-downloading`);
+        log.warn(`Video ${storedAs}: ${missing.length} missing chunks (${missing.join(', ')}), re-downloading`);
 
         // Unmark completion (keeps existing chunks on disk) so HEAD returns 404
         await fetch('/store/unmark-complete', {
@@ -1612,10 +1610,10 @@ class PwaPlayer {
 
         // Trigger collection — enqueueFile will populate skipChunks for existing chunks
         this.core.collectNow().catch((err: any) => {
-          log.error(`Failed to trigger re-download for media ${fileId}:`, err.message);
+          log.error(`Failed to trigger re-download for ${storedAs}:`, err.message);
         });
       } catch (err: any) {
-        log.error(`Failed to check/re-download media ${fileId}:`, err.message);
+        log.error(`Failed to check/re-download ${storedAs}:`, err.message);
       }
     });
   }
@@ -1711,19 +1709,23 @@ class PwaPlayer {
    * Get all required media file IDs and video-specific IDs from layout XLF.
    * Single parse to avoid double DOMParser overhead on the same XML.
    */
-  private getMediaIds(xlfXml: string): { allMedia: number[]; videoMedia: number[] } {
+  /**
+   * Get all required media saveAs filenames and video-specific ones from layout XLF.
+   * Returns saveAs strings (via _fileIdToSaveAs map) for store key matching.
+   */
+  private getMediaIds(xlfXml: string): { allMedia: string[]; videoMedia: string[] } {
     const parser = new DOMParser();
     const doc = parser.parseFromString(xlfXml, 'text/xml');
-    const allMedia: number[] = [];
-    const videoMedia: number[] = [];
+    const allMedia: string[] = [];
+    const videoMedia: string[] = [];
 
     doc.querySelectorAll('media[fileId]').forEach(el => {
       const fileId = el.getAttribute('fileId');
       if (fileId) {
-        const id = parseInt(fileId, 10);
-        allMedia.push(id);
+        const saveAs = this._fileIdToSaveAs.get(fileId) || fileId;
+        allMedia.push(saveAs);
         if (el.getAttribute('type') === 'video') {
-          videoMedia.push(id);
+          videoMedia.push(saveAs);
         }
       }
     });
@@ -1731,9 +1733,9 @@ class PwaPlayer {
     // Include background image file ID from layout element
     const bgFileId = doc.querySelector('layout')?.getAttribute('background');
     if (bgFileId) {
-      const parsed = parseInt(bgFileId, 10);
-      if (!isNaN(parsed) && !allMedia.includes(parsed)) {
-        allMedia.push(parsed);
+      const saveAs = this._fileIdToSaveAs.get(bgFileId) || bgFileId;
+      if (!allMedia.includes(saveAs)) {
+        allMedia.push(saveAs);
       }
     }
 
@@ -1744,17 +1746,21 @@ class PwaPlayer {
    * Check if all required media files are cached and ready.
    * Uses StoreClient.has() → HEAD /store${PLAYER_API}/media/:id to check ContentStore.
    */
-  private async checkAllMediaCached(mediaIds: number[]): Promise<boolean> {
-    for (const mediaId of mediaIds) {
+  /**
+   * Check if all required media files are cached and ready.
+   * Uses storedAs filenames for store key matching: /media/file/{saveAs}
+   */
+  private async checkAllMediaCached(mediaSaveAs: string[]): Promise<boolean> {
+    for (const saveAs of mediaSaveAs) {
       try {
-        const cached = await store.has('api/v2/player', `media/${mediaId}`);
+        const cached = await store.has('api/v2/player', `media/file/${saveAs}`);
         if (!cached) {
-          log.debug(`Media ${mediaId} not yet cached`);
+          log.debug(`Media ${saveAs} not yet cached`);
           return false;
         }
-        log.debug(`Media ${mediaId} cached`);
+        log.debug(`Media ${saveAs} cached`);
       } catch (error) {
-        log.warn(`Unable to verify media ${mediaId}, assuming cached (offline mode)`);
+        log.warn(`Unable to verify media ${saveAs}, assuming cached (offline mode)`);
       }
     }
     return true;
@@ -1852,10 +1858,10 @@ class PwaPlayer {
         }
 
         const missing: string[] = [];
-        for (const mediaId of allMedia) {
+        for (const saveAs of allMedia) {
           try {
-            const cached = await store.has('api/v2/player', `media/${mediaId}`);
-            if (!cached) missing.push(String(mediaId));
+            const cached = await store.has('api/v2/player', `media/file/${saveAs}`);
+            if (!cached) missing.push(saveAs);
           } catch {
             // Assume cached on error (offline mode)
           }
@@ -1902,11 +1908,12 @@ class PwaPlayer {
           const fileId = mediaEl.getAttribute('fileId');
           if (!fileId) continue;
 
-          const exists = await store.has('api/v2/player', `media/${fileId}`);
+          const saveAs = this._fileIdToSaveAs.get(fileId) || fileId;
+          const exists = await store.has('api/v2/player', `media/file/${saveAs}`);
           if (!exists) continue;
 
           // Probe metadata only — does NOT download the full video
-          const duration = await this.probeVideoDuration(`${window.location.origin}${PLAYER_API}/media/${fileId}`);
+          const duration = await this.probeVideoDuration(`${window.location.origin}${PLAYER_API}/media/file/${saveAs}`);
           if (duration > 0) {
             videoDurations.set(fileId, duration);
           }

--- a/packages/renderer/src/layout-pool.test.js
+++ b/packages/renderer/src/layout-pool.test.js
@@ -33,8 +33,7 @@ describe('LayoutPool', () => {
       container,
       layout: { width: 1920, height: 1080, duration: 60, bgcolor: '#000', regions: [] },
       regions: new Map(),
-      blobUrls: new Set(),
-      mediaUrlCache: new Map()
+      blobUrls: new Set()
     };
   }
 
@@ -168,18 +167,6 @@ describe('LayoutPool', () => {
 
       expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:test-1');
       expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:test-2');
-    });
-
-    it('should revoke media blob URLs on eviction', () => {
-      const entry = createMockEntry(1);
-      entry.mediaUrlCache.set(10, 'blob:media-10');
-      entry.mediaUrlCache.set(20, 'blob:media-20');
-
-      pool.add(1, entry);
-      pool.evict(1);
-
-      expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:media-10');
-      expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:media-20');
     });
 
     it('should remove container from DOM', () => {

--- a/packages/renderer/src/renderer-lite.js
+++ b/packages/renderer/src/renderer-lite.js
@@ -186,7 +186,7 @@ export class RendererLite {
    * @param {string} config.hardwareKey - Display hardware key
    * @param {HTMLElement} container - DOM container for rendering
    * @param {Object} options - Renderer options
-   * @param {Function} options.getMediaUrl - Function to get media file URL (mediaId) => url
+   * @param {Map<string,string>} [options.fileIdToSaveAs] - Map from numeric file ID to storedAs filename (for layout backgrounds)
    * @param {Function} options.getWidgetHtml - Function to get widget HTML (layoutId, regionId, widgetId) => html
    */
   constructor(config, container, options = {}) {
@@ -210,7 +210,6 @@ export class RendererLite {
     this._layoutTimerStartedAt = null;  // Date.now() when layout timer started
     this._layoutTimerDurationMs = null; // Total layout duration in ms
     this.widgetTimers = new Map(); // widgetId => timer
-    this.mediaUrlCache = new Map(); // fileId => blob URL (for parallel pre-fetching)
     this.layoutBlobUrls = new Map(); // layoutId => Set<blobUrl> (for lifecycle tracking)
     this.audioOverlays = new Map(); // widgetId => [HTMLAudioElement] (audio overlays for widgets)
 
@@ -964,34 +963,12 @@ export class RendererLite {
   // ── Layout Helpers ───────────────────────────────────────────────
 
   /**
-   * Pre-fetch all media URLs for a layout's widgets in parallel.
-   * @param {Object} layout - Parsed layout
-   * @param {Map} [cache=this.mediaUrlCache] - Target cache map
+   * Get media file URL for storedAs filename.
+   * @param {string} storedAs - The storedAs filename (e.g. "42_abc123.jpg")
+   * @returns {string} Full URL for the media file
    */
-  async _prefetchMediaUrls(layout, cache) {
-    if (!this.options.getMediaUrl) return;
-    const targetCache = cache || this.mediaUrlCache;
-    const mediaPromises = [];
-
-    for (const region of layout.regions) {
-      for (const widget of region.widgets) {
-        if (widget.fileId) {
-          const fileId = parseInt(widget.fileId || widget.id);
-          if (!targetCache.has(fileId)) {
-            mediaPromises.push(
-              this.options.getMediaUrl(fileId)
-                .then(url => { targetCache.set(fileId, url); })
-                .catch(err => { this.log.warn(`Failed to fetch media ${fileId}:`, err); })
-            );
-          }
-        }
-      }
-    }
-
-    if (mediaPromises.length > 0) {
-      this.log.info(`Pre-fetching ${mediaPromises.length} media URLs in parallel...`);
-      await Promise.all(mediaPromises);
-    }
+  _mediaFileUrl(storedAs) {
+    return `${window.location.origin}${PLAYER_API}/media/file/${storedAs}`;
   }
 
   /**
@@ -1037,18 +1014,6 @@ export class RendererLite {
     }
   }
 
-  /**
-   * Revoke blob: URLs from a media URL cache.
-   * @param {Map} cache - Media URL cache (fileId → url)
-   */
-  _revokeMediaBlobUrls(cache) {
-    for (const [, blobUrl] of cache) {
-      if (blobUrl?.startsWith?.('blob:')) {
-        URL.revokeObjectURL(blobUrl);
-      }
-    }
-  }
-
   // ── Layout Rendering ──────────────────────────────────────────────
 
   /**
@@ -1082,7 +1047,6 @@ export class RendererLite {
         this.layoutEndEmitted = false;
 
         // DON'T call stopCurrentLayout() - keep elements alive!
-        // DON'T clear mediaUrlCache - keep blob URLs alive!
         // DON'T recreate regions/elements - already exist!
 
         // Emit layout start event
@@ -1128,22 +1092,16 @@ export class RendererLite {
       this.container.style.backgroundColor = layout.bgcolor;
       this.container.style.backgroundImage = ''; // Reset previous
 
-      // Apply background image if specified in XLF
-      if (layout.background && this.options.getMediaUrl) {
-        try {
-          const bgUrl = await this.options.getMediaUrl(parseInt(layout.background));
-          if (bgUrl) {
-            this._applyBackgroundImage(this.container, bgUrl);
-            this.log.info(`Background image set: ${layout.background}`);
-          }
-        } catch (err) {
-          this.log.warn('Failed to load background image:', err);
+      // Apply background image if specified in XLF (uses fileIdToSaveAs map)
+      if (layout.background) {
+        const saveAs = this.options.fileIdToSaveAs?.get(String(layout.background));
+        if (saveAs) {
+          this._applyBackgroundImage(this.container, this._mediaFileUrl(saveAs));
+          this.log.info(`Background image set: ${layout.background} (${saveAs})`);
+        } else {
+          this.log.warn(`Background image ${layout.background}: no saveAs mapping found`);
         }
       }
-
-      // PRE-FETCH: Get all media URLs in parallel (huge speedup!)
-      this.mediaUrlCache.clear();
-      await this._prefetchMediaUrls(layout);
 
       // Create regions
       for (const regionConfig of layout.regions) {
@@ -1560,22 +1518,8 @@ export class RendererLite {
       audio.loop = audioNode.loop;
       audio.volume = Math.max(0, Math.min(1, audioNode.volume / 100));
 
-      // Resolve audio URI via cache/proxy
-      const mediaId = parseInt(audioNode.mediaId);
-      let audioSrc = mediaId ? this.mediaUrlCache.get(mediaId) : null;
-
-      if (!audioSrc && mediaId && this.options.getMediaUrl) {
-        // Async — fire and forget, set src when ready
-        this.options.getMediaUrl(mediaId).then(url => {
-          audio.src = url;
-        }).catch(() => {
-          audio.src = `${window.location.origin}${PLAYER_API}/media/${audioNode.uri}`;
-        });
-      } else if (!audioSrc) {
-        audio.src = `${window.location.origin}${PLAYER_API}/media/${audioNode.uri}`;
-      } else {
-        audio.src = audioSrc;
-      }
+      // Direct URL from storedAs filename
+      audio.src = audioNode.uri ? this._mediaFileUrl(audioNode.uri) : '';
 
       // Append to DOM to prevent garbage collection in some browsers
       audio.style.display = 'none';
@@ -1934,17 +1878,12 @@ export class RendererLite {
 
     img.style.opacity = '0';
 
-    // Get media URL from cache (already pre-fetched!) or fetch on-demand
-    const fileId = parseInt(widget.fileId || widget.id);
-    let imageSrc = this.mediaUrlCache.get(fileId);
+    // Direct URL from storedAs filename — store key = widget reference = serve URL
+    const src = widget.options.uri
+      ? this._mediaFileUrl(widget.options.uri)
+      : '';
 
-    if (!imageSrc && this.options.getMediaUrl) {
-      imageSrc = await this.options.getMediaUrl(fileId);
-    } else if (!imageSrc) {
-      imageSrc = `${window.location.origin}${PLAYER_API}/media/${widget.options.uri}`;
-    }
-
-    img.src = imageSrc;
+    img.src = src;
     return img;
   }
 
@@ -1967,27 +1906,22 @@ export class RendererLite {
     video.controls = false; // Hidden by default — toggle with V key in PWA
     video.playsInline = true; // Prevent fullscreen on mobile
 
-    // Get media URL from cache (already pre-fetched!) or fetch on-demand
-    const fileId = parseInt(widget.fileId || widget.id);
+    // Direct URL from storedAs filename
+    const storedAs = widget.options.uri || '';
+    const fileId = widget.fileId || widget.id;
 
     // Handle video end - pause on last frame instead of showing black
     // Widget cycling will restart the video via updateMediaElement()
     const onEnded = () => {
       if (widget.options.loop === '1') {
         video.currentTime = 0;
-        this.log.info(`Video ${fileId} ended - reset to start, waiting for widget cycle to replay`);
+        this.log.info(`Video ${storedAs} ended - reset to start, waiting for widget cycle to replay`);
       } else {
-        this.log.info(`Video ${fileId} ended - paused on last frame`);
+        this.log.info(`Video ${storedAs} ended - paused on last frame`);
       }
     };
     video.addEventListener('ended', onEnded);
-    let videoSrc = this.mediaUrlCache.get(fileId);
-
-    if (!videoSrc && this.options.getMediaUrl) {
-      videoSrc = await this.options.getMediaUrl(fileId);
-    } else if (!videoSrc) {
-      videoSrc = `${window.location.origin}${PLAYER_API}/media/${fileId}`;
-    }
+    let videoSrc = storedAs ? this._mediaFileUrl(storedAs) : '';
 
     // HLS/DASH streaming support
     const isHlsStream = videoSrc.includes('.m3u8');
@@ -2033,7 +1967,7 @@ export class RendererLite {
     const createdForLayoutId = this.currentLayoutId;
     const onLoadedMetadata = () => {
       const videoDuration = Math.floor(video.duration);
-      this.log.info(`Video ${fileId} duration detected: ${videoDuration}s`);
+      this.log.info(`Video ${storedAs} duration detected: ${videoDuration}s`);
 
       if (widget.duration === 0 || widget.useDuration === 0) {
         widget.duration = videoDuration;
@@ -2042,14 +1976,14 @@ export class RendererLite {
         if (this.currentLayoutId === createdForLayoutId) {
           this.updateLayoutDuration();
         } else {
-          this.log.info(`Video ${fileId} duration set but layout timer not updated (preloaded for layout ${createdForLayoutId}, current is ${this.currentLayoutId})`);
+          this.log.info(`Video ${storedAs} duration set but layout timer not updated (preloaded for layout ${createdForLayoutId}, current is ${this.currentLayoutId})`);
         }
       }
     };
     video.addEventListener('loadedmetadata', onLoadedMetadata);
 
     const onLoadedData = () => {
-      this.log.info('Video loaded and ready:', fileId);
+      this.log.info('Video loaded and ready:', storedAs);
     };
     video.addEventListener('loadeddata', onLoadedData);
 
@@ -2057,13 +1991,13 @@ export class RendererLite {
       const error = video.error;
       const errorCode = error?.code;
       const errorMessage = error?.message || 'Unknown error';
-      this.log.warn(`Video error: ${fileId}, code: ${errorCode}, time: ${video.currentTime.toFixed(1)}s, message: ${errorMessage}`);
-      this.emit('videoError', { fileId, errorCode, errorMessage, currentTime: video.currentTime });
+      this.log.warn(`Video error: ${storedAs}, code: ${errorCode}, time: ${video.currentTime.toFixed(1)}s, message: ${errorMessage}`);
+      this.emit('videoError', { storedAs, fileId, errorCode, errorMessage, currentTime: video.currentTime });
     };
     video.addEventListener('error', onError);
 
     const onPlaying = () => {
-      this.log.info('Video playing:', fileId);
+      this.log.info('Video playing:', storedAs);
     };
     video.addEventListener('playing', onPlaying);
 
@@ -2076,7 +2010,7 @@ export class RendererLite {
       ['playing', onPlaying],
     ];
 
-    this.log.info('Video element created:', fileId, video.src);
+    this.log.info('Video element created:', storedAs, video.src);
 
     return video;
   }
@@ -2161,25 +2095,18 @@ export class RendererLite {
     audio.loop = widget.options.loop === '1';
     audio.volume = parseFloat(widget.options.volume || '100') / 100;
 
-    // Get media URL from cache (already pre-fetched!) or fetch on-demand
-    const fileId = parseInt(widget.fileId || widget.id);
-    let audioSrc = this.mediaUrlCache.get(fileId);
-
-    if (!audioSrc && this.options.getMediaUrl) {
-      audioSrc = await this.options.getMediaUrl(fileId);
-    } else if (!audioSrc) {
-      audioSrc = `${window.location.origin}${PLAYER_API}/media/${fileId}`;
-    }
-
-    audio.src = audioSrc;
+    // Direct URL from storedAs filename
+    const storedAs = widget.options.uri || '';
+    const fileId = widget.fileId || widget.id;
+    audio.src = storedAs ? this._mediaFileUrl(storedAs) : '';
 
     // Handle audio end - similar to video ended handling
     const onAudioEnded = () => {
       if (widget.options.loop === '1') {
         audio.currentTime = 0;
-        this.log.info(`Audio ${fileId} ended - reset to start, waiting for widget cycle to replay`);
+        this.log.info(`Audio ${storedAs} ended - reset to start, waiting for widget cycle to replay`);
       } else {
-        this.log.info(`Audio ${fileId} ended - playback complete`);
+        this.log.info(`Audio ${storedAs} ended - playback complete`);
       }
     };
     audio.addEventListener('ended', onAudioEnded);
@@ -2188,7 +2115,7 @@ export class RendererLite {
     const audioCreatedForLayoutId = this.currentLayoutId;
     const onAudioLoadedMetadata = () => {
       const audioDuration = Math.floor(audio.duration);
-      this.log.info(`Audio ${fileId} duration detected: ${audioDuration}s`);
+      this.log.info(`Audio ${storedAs} duration detected: ${audioDuration}s`);
 
       if (widget.duration === 0 || widget.useDuration === 0) {
         widget.duration = audioDuration;
@@ -2197,7 +2124,7 @@ export class RendererLite {
         if (this.currentLayoutId === audioCreatedForLayoutId) {
           this.updateLayoutDuration();
         } else {
-          this.log.info(`Audio ${fileId} duration set but layout timer not updated (preloaded for layout ${audioCreatedForLayoutId}, current is ${this.currentLayoutId})`);
+          this.log.info(`Audio ${storedAs} duration set but layout timer not updated (preloaded for layout ${audioCreatedForLayoutId}, current is ${this.currentLayoutId})`);
         }
       }
     };
@@ -2206,7 +2133,7 @@ export class RendererLite {
     // Handle audio errors
     const onAudioError = () => {
       const error = audio.error;
-      this.log.warn(`Audio error (non-fatal): ${fileId}, code: ${error?.code}, message: ${error?.message || 'Unknown'}`);
+      this.log.warn(`Audio error (non-fatal): ${storedAs}, code: ${error?.code}, message: ${error?.message || 'Unknown'}`);
     };
     audio.addEventListener('error', onAudioError);
 
@@ -2341,15 +2268,10 @@ export class RendererLite {
       }
     }
 
-    // Get PDF URL from cache (already pre-fetched!) or fetch on-demand
-    const fileId = parseInt(widget.fileId || widget.id);
-    let pdfUrl = this.mediaUrlCache.get(fileId);
-
-    if (!pdfUrl && this.options.getMediaUrl) {
-      pdfUrl = await this.options.getMediaUrl(fileId);
-    } else if (!pdfUrl) {
-      pdfUrl = `${window.location.origin}${PLAYER_API}/media/${widget.options.uri}`;
-    }
+    // Direct URL from storedAs filename
+    let pdfUrl = widget.options.uri
+      ? this._mediaFileUrl(widget.options.uri)
+      : '';
 
     // Render PDF with multi-page cycling
     try {
@@ -2640,26 +2562,15 @@ export class RendererLite {
       // Set background
       wrapper.style.backgroundColor = layout.bgcolor;
 
-      // Apply background image if specified
-      if (layout.background && this.options.getMediaUrl) {
-        try {
-          const bgUrl = await this.options.getMediaUrl(parseInt(layout.background));
-          if (bgUrl) {
-            this._applyBackgroundImage(wrapper, bgUrl);
-          }
-        } catch (err) {
-          this.log.warn('Preload: Failed to load background image:', err);
+      // Apply background image if specified (uses fileIdToSaveAs map)
+      if (layout.background) {
+        const saveAs = this.options.fileIdToSaveAs?.get(String(layout.background));
+        if (saveAs) {
+          this._applyBackgroundImage(wrapper, this._mediaFileUrl(saveAs));
         }
       }
 
-      // Pre-fetch all media URLs in parallel
-      const preloadMediaUrlCache = new Map();
-      await this._prefetchMediaUrls(layout, preloadMediaUrlCache);
-
-      // Temporarily swap mediaUrlCache so createWidgetElement uses preload cache
-      const savedMediaUrlCache = this.mediaUrlCache;
       const savedCurrentLayoutId = this.currentLayoutId;
-      this.mediaUrlCache = preloadMediaUrlCache;
 
       // Create regions in the hidden wrapper
       const preloadRegions = new Map();
@@ -2721,7 +2632,6 @@ export class RendererLite {
       }
 
       // Restore state
-      this.mediaUrlCache = savedMediaUrlCache;
       this.currentLayoutId = savedCurrentLayoutId;
 
       // Pause all videos in preloaded layout (autoplay starts them even when hidden)
@@ -2743,10 +2653,9 @@ export class RendererLite {
         layout,
         regions: preloadRegions,
         blobUrls: preloadBlobUrls,
-        mediaUrlCache: preloadMediaUrlCache
       });
 
-      this.log.info(`Layout ${layoutId} preloaded into pool (${preloadRegions.size} regions, ${preloadMediaUrlCache.size} media)`);
+      this.log.info(`Layout ${layoutId} preloaded into pool (${preloadRegions.size} regions)`);
       return true;
 
     } catch (error) {
@@ -2819,7 +2728,6 @@ export class RendererLite {
       if (oldLayoutId) {
         this.revokeBlobUrlsForLayout(oldLayoutId);
       }
-      this._revokeMediaBlobUrls(this.mediaUrlCache);
     }
 
     // Emit layoutEnd for old layout if timer hasn't already
@@ -2828,7 +2736,6 @@ export class RendererLite {
     }
 
     this.regions.clear();
-    this.mediaUrlCache.clear();
 
     // ── Activate preloaded layout ──
     preloaded.container.style.visibility = 'visible';
@@ -2839,7 +2746,6 @@ export class RendererLite {
     this.currentLayout = preloaded.layout;
     this.currentLayoutId = layoutId;
     this.regions = preloaded.regions;
-    this.mediaUrlCache = preloaded.mediaUrlCache || new Map();
     this.layoutEndEmitted = false;
 
     // Update container background to match preloaded layout
@@ -2975,13 +2881,10 @@ export class RendererLite {
         }
       }
 
-      // Revoke media blob URLs from cache
-      this._revokeMediaBlobUrls(this.mediaUrlCache);
     }
 
     // Clear state
     this.regions.clear();
-    this.mediaUrlCache.clear();
 
     // Emit layout end event only if timer hasn't already emitted it.
     // Timer-based layoutEnd (natural expiry) is authoritative — stopCurrentLayout
@@ -3029,9 +2932,6 @@ export class RendererLite {
       overlayDiv.style.zIndex = String(1000 + priority); // Higher priority = higher z-index
       overlayDiv.style.pointerEvents = 'auto'; // Enable clicks on overlay
       overlayDiv.style.backgroundColor = layout.bgcolor;
-
-      // Pre-fetch all media URLs for overlay
-      await this._prefetchMediaUrls(layout);
 
       // Calculate scale for overlay layout
       this.calculateScale(layout);

--- a/packages/renderer/src/renderer-lite.overlays.test.js
+++ b/packages/renderer/src/renderer-lite.overlays.test.js
@@ -65,7 +65,7 @@ describe('RendererLite - Overlay Rendering', () => {
       },
       container,
       {
-        getMediaUrl: async (fileId) => `http://test.local/media/${fileId}`,
+        fileIdToSaveAs: new Map(),
         getWidgetHtml: async (widget) => widget.raw || '<p>Widget HTML</p>'
       }
     );
@@ -163,32 +163,6 @@ describe('RendererLite - Overlay Rendering', () => {
       // Should still be the same element
       const secondOverlayDiv = container.querySelector('#overlay_200');
       expect(secondOverlayDiv).toBe(firstOverlayDiv);
-    });
-
-    it('should pre-fetch media URLs for overlay widgets', async () => {
-      const getMediaUrl = vi.fn(async (fileId) => `http://test.local/media/${fileId}`);
-
-      const customRenderer = new RendererLite(
-        { cmsUrl: 'http://test.local', hardwareKey: 'test-key' },
-        container,
-        {
-          getMediaUrl,
-          getWidgetHtml: async (widget) => widget.raw
-        }
-      );
-
-      const xlfWithMedia = `<?xml version="1.0"?>
-<layout width="1920" height="1080" bgcolor="#000000">
-  <region id="1" width="400" height="200" top="0" left="0" zindex="0">
-    <media id="10" fileId="555" type="image" duration="10">
-      <options><uri>test.jpg</uri></options>
-    </media>
-  </region>
-</layout>`;
-
-      await customRenderer.renderOverlay(xlfWithMedia, 300, 10);
-
-      expect(getMediaUrl).toHaveBeenCalledWith(555);
     });
 
     it('should set overlay timer based on duration', async () => {

--- a/packages/renderer/src/renderer-lite.test.js
+++ b/packages/renderer/src/renderer-lite.test.js
@@ -11,7 +11,6 @@ import { RendererLite } from './renderer-lite.js';
 describe('RendererLite', () => {
   let container;
   let renderer;
-  let mockGetMediaUrl;
   let mockGetWidgetHtml;
 
   beforeEach(() => {
@@ -29,7 +28,6 @@ describe('RendererLite', () => {
     }
 
     // Mock callbacks
-    mockGetMediaUrl = vi.fn((fileId) => Promise.resolve(`blob://test-${fileId}`));
     mockGetWidgetHtml = vi.fn((widget) => Promise.resolve(`<html>Widget ${widget.id}</html>`));
 
     // Create renderer instance
@@ -37,7 +35,7 @@ describe('RendererLite', () => {
       { cmsUrl: 'https://test.com', hardwareKey: 'test-key' },
       container,
       {
-        getMediaUrl: mockGetMediaUrl,
+        fileIdToSaveAs: new Map(),
         getWidgetHtml: mockGetWidgetHtml
       }
     );
@@ -415,7 +413,6 @@ describe('RendererLite', () => {
       expect(element.className).toBe('renderer-lite-widget');
       expect(element.style.width).toBe('100%');
       expect(element.style.height).toBe('100%');
-      expect(mockGetMediaUrl).toHaveBeenCalledWith(1);
     });
 
     it('should default to objectFit contain and objectPosition center center', async () => {
@@ -566,7 +563,6 @@ describe('RendererLite', () => {
       expect(element.muted).toBe(true);
       // loop is intentionally false - handled manually via 'ended' event to avoid black frames
       expect(element.loop).toBe(false);
-      expect(mockGetMediaUrl).toHaveBeenCalledWith(5);
     });
 
     it('should create text widget with iframe (blob fallback)', async () => {
@@ -1014,20 +1010,6 @@ describe('RendererLite', () => {
   });
 
   describe('Memory Management', () => {
-    it('should clear mediaUrlCache on layout switch', async () => {
-      const xlf1 = `<layout><region id="r1"></region></layout>`;
-      const xlf2 = `<layout><region id="r2"></region></layout>`;
-
-      await renderer.renderLayout(xlf1, 1);
-      renderer.mediaUrlCache.set(1, 'blob://test-1');
-
-      // Switch to different layout
-      await renderer.renderLayout(xlf2, 2);
-
-      // Cache should be cleared
-      expect(renderer.mediaUrlCache.size).toBe(0);
-    });
-
     it('should clear regions on stopCurrentLayout', async () => {
       const xlf = `
         <layout>
@@ -1111,8 +1093,22 @@ describe('RendererLite', () => {
     });
   });
 
-  describe('Parallel Media Pre-fetch', () => {
-    it('should pre-fetch all media URLs in parallel', async () => {
+  describe('Media URL construction via fileIdToSaveAs', () => {
+    it('should construct media URLs using fileIdToSaveAs map', async () => {
+      const fileIdToSaveAs = new Map([
+        ['1', '1.png'],
+        ['5', '5.mp4'],
+        ['7', '7.png']
+      ]);
+      const r = new RendererLite(
+        { cmsUrl: 'https://test.com', hardwareKey: 'test-key' },
+        container,
+        {
+          fileIdToSaveAs,
+          getWidgetHtml: mockGetWidgetHtml
+        }
+      );
+
       const xlf = `
         <layout>
           <region id="r1">
@@ -1129,16 +1125,11 @@ describe('RendererLite', () => {
         </layout>
       `;
 
-      await renderer.renderLayout(xlf, 1);
+      await r.renderLayout(xlf, 1);
 
-      // All media URLs should have been fetched
-      expect(mockGetMediaUrl).toHaveBeenCalledTimes(3);
-      expect(mockGetMediaUrl).toHaveBeenCalledWith(1);
-      expect(mockGetMediaUrl).toHaveBeenCalledWith(5);
-      expect(mockGetMediaUrl).toHaveBeenCalledWith(7);
-
-      // All should be in cache
-      expect(renderer.mediaUrlCache.size).toBe(3);
+      // fileIdToSaveAs should have all 3 entries
+      expect(fileIdToSaveAs.size).toBe(3);
+      r.cleanup();
     });
   });
 


### PR DESCRIPTION
## Summary

- Switch media URLs from `/media/{id}` to `/media/file/{storedAs}` so download key = widget reference = serve URL
- Remove `getMediaUrl` async callback, `mediaUrlCache`, and `_prefetchMediaUrls` from the renderer — media URLs are now constructed directly from `widget.options.uri`
- Add `fileIdToSaveAs` map (built from RequiredFiles) for layout background resolution

## What gets eliminated

| Removed | Location |
|---------|----------|
| `getMediaUrl()` async callback | main.ts, renderer constructor |
| `mediaUrlCache` Map | renderer-lite.js |
| `_prefetchMediaUrls()` | renderer-lite.js |
| Async URL resolution for every media widget | renderer image/video/PDF/audio methods |
| The naming mismatch (ID vs filename) | Entire pipeline |

## Changed files (10)

- `packages/cache/src/widget-html.js` — base tag → `/media/file/`
- `packages/proxy/src/proxy.js` — add `/media/file/{storedAs}` routes
- `packages/renderer/src/renderer-lite.js` — remove mediaUrlCache, direct URL construction
- `packages/pwa/src/main.ts` — build fileIdToSaveAs map, remove getMediaUrl
- `packages/core/src/player-core.js` — string comparison in notifyMediaReady
- `packages/cache/src/download-manager.js` — prioritizeLayoutFiles matches by saveAs
- 4 test files updated

## Test plan

- [x] `pnpm test` — 1246 tests pass (1 pre-existing proxy test failure)
- [ ] CMS: verify RequiredFiles returns `/media/file/{saveAs}` URLs
- [ ] Electron: media renders, widget iframes find cached files, backgrounds display
- [ ] Offline: disconnect after collection → all media serves from cache

## Depends on

- xibo-cms PR: `feature/media-storedas-urls` (CMS must return `/media/file/{saveAs}` URLs)