### PR TITLE
fix: player must be a dumb queue consumer

### DIFF
--- a/packages/core/src/player-core.js
+++ b/packages/core/src/player-core.js
@@ -295,20 +295,25 @@ export class PlayerCore extends EventEmitter {
   async _evaluateAndSwitchLayout(layoutFiles, context) {
     const prefix = context ? `${context}: ` : '';
 
-    if (layoutFiles.length > 0) {
-      if (this.currentLayoutId) {
-        // Check if the playing layout is still in the schedule
-        const stillScheduled = layoutFiles.some(f => parseLayoutFile(f) === this.currentLayoutId);
+    // Use the queue (not raw layoutFiles) for play/expire decisions.
+    // The queue has all constraints baked in (maxPlaysPerHour, priorities, dayparting).
+    // The player is a dumb consumer — it only expires when the queue rebuilds
+    // with a different layout set (new CMS schedule, daypart boundary crossed).
+    const { queue } = this.schedule.getScheduleQueue(this._layoutDurations, this._queueOptions);
 
-        if (!stillScheduled) {
-          // Schedule changed and current layout is no longer in it — expire immediately.
+    if (queue.length > 0) {
+      if (this.currentLayoutId) {
+        const stillInQueue = queue.some(e => parseLayoutFile(e.layoutId) === this.currentLayoutId);
+
+        if (!stillInQueue) {
+          // Schedule changed and current layout is no longer in the queue — expire immediately.
           // Clear currentLayoutId and emit expire event so the renderer can teardown.
           // The renderer's layoutEnd → advanceToNextLayout flow handles the switch.
-          log.info(`Layout ${this.currentLayoutId} no longer scheduled — expiring`);
+          log.info(`Layout ${this.currentLayoutId} no longer in queue — expiring`);
           this.currentLayoutId = null;
           this.emit('layout-expire-current');
         } else {
-          // Layout is still scheduled — don't interrupt, just rebuild queue in background.
+          // Layout is still in queue — don't interrupt, just rebuild queue in background.
           // The playing layout ends when its timer fires (layoutEnd event),
           // at which point advanceToNextLayout() pops from the already-updated queue.
           log.info(`Layout ${this.currentLayoutId} playing — queue updated in background, playback continues`);
@@ -546,15 +551,6 @@ export class PlayerCore extends EventEmitter {
 
       // Process scheduled commands (auto-execute commands whose time has arrived)
       this._processScheduledCommands();
-
-      // If no layouts scheduled and we're playing one that was filtered (e.g., maxPlaysPerHour),
-      // force switch to default layout if available
-      if (layoutFiles.length === 0 && this.currentLayoutId && this.schedule.schedule?.default) {
-        const defaultLayoutId = parseLayoutFile(this.schedule.schedule.default);
-        log.info(`Current layout filtered by schedule, switching to default layout ${defaultLayoutId}`);
-        this.currentLayoutId = null; // Clear to force switch
-        this.emit('layout-prepare-request', defaultLayoutId);
-      }
 
       // Submit stats if enabled and collector is available
       if (regResult.settings?.statsEnabled === 'On' || regResult.settings?.statsEnabled === '1') {

--- a/packages/core/src/player-core.test.js
+++ b/packages/core/src/player-core.test.js
@@ -367,6 +367,7 @@ describe('PlayerCore', () => {
       core.on('no-layouts-scheduled', spy);
 
       mockSchedule.getCurrentLayouts.mockReturnValue([]);
+      mockSchedule._defaultQueue = [];
 
       await core.collect();
 
@@ -1819,6 +1820,7 @@ describe('PlayerCore', () => {
 
       core._offlineCache = { schedule: { default: '0', layouts: [] }, settings: null, requiredFiles: null };
       mockSchedule.getCurrentLayouts.mockReturnValue([]);
+      mockSchedule._defaultQueue = [];
 
       core.collectOffline();
 


### PR DESCRIPTION
## Summary
- Player now checks the schedule queue (not `getCurrentLayouts()`) for expire decisions
- `getCurrentLayouts()` applies `maxPlaysPerHour` filtering, so rate-limited layouts were treated as "no longer scheduled" — causing rapid layout skipping and GPU exhaustion
- Removes the force-switch-to-default block in `collect()` which was a workaround for the same issue

## Test plan
- [x] All 1280 tests passing
- [ ] Deploy and verify no more "no longer scheduled — expiring" for rate-limited layouts
- [ ] Verify layouts leaving their time window still expire correctly

Fixes #182