### PR TITLE
fix: timeline overlay uses queue instead of independent simulation

### DIFF
--- a/packages/core/src/player-core.js
+++ b/packages/core/src/player-core.js
@@ -1688,15 +1688,18 @@ export class PlayerCore extends EventEmitter {
       .map(([k, v]) => `${k}:${v.ready}:${v.missingKey}`)
       .join('|');
     const pendingEntries = [...this.pendingLayouts.keys()].sort().join(',');
-    const fingerprint = `${this._lastCheckSchedule}|${durationEntries}|${this.currentLayoutId}|${mediaStatusEntries}|${pendingEntries}`;
+    const queuePos = this.schedule._queuePosition || 0;
+    const fingerprint = `${this._lastCheckSchedule}|${durationEntries}|${this.currentLayoutId}|${queuePos}|${mediaStatusEntries}|${pendingEntries}`;
 
     if (fingerprint === this._lastTimelineFingerprint && this._lastTimeline) {
       this.emit('timeline-updated', this._lastTimeline);
       return;
     }
 
-    const timeline = calculateTimeline(this.schedule, this._layoutDurations, {
+    const { queue } = this.schedule.getScheduleQueue(this._layoutDurations, this._queueOptions);
+    const timeline = calculateTimeline(queue, this.schedule._queuePosition, {
       currentLayoutStartedAt: this._lastLayoutChangeTime ? new Date(this._lastLayoutChangeTime) : null,
+      defaultLayout: this.schedule.schedule?.default || null,
     });
     if (timeline.length === 0) return;
 

--- a/packages/core/src/player-core.test.js
+++ b/packages/core/src/player-core.test.js
@@ -66,7 +66,7 @@ describe('PlayerCore', () => {
       findActionByTrigger: vi.fn(() => null),
       // Queue-based scheduling
       _queuePosition: 0,
-      _defaultQueue: [{ layoutId: '100', duration: 60 }],
+      _defaultQueue: [{ layoutId: '100.xlf', duration: 60 }],
       getScheduleQueue: vi.fn(function() {
         return { queue: this._defaultQueue, periodSeconds: 60 };
       }),
@@ -1501,15 +1501,15 @@ describe('PlayerCore', () => {
     describe('getNextLayout', () => {
       it('should return the next layout from the queue', () => {
         mockSchedule._defaultQueue = [
-          { layoutId: '100', duration: 60 },
-          { layoutId: '200', duration: 60 },
-          { layoutId: '300', duration: 60 },
+          { layoutId: '100.xlf', duration: 60 },
+          { layoutId: '200.xlf', duration: 60 },
+          { layoutId: '300.xlf', duration: 60 },
         ];
         mockSchedule._queuePosition = 0;
 
         const result = core.getNextLayout();
 
-        expect(result).toEqual({ layoutId: 100, layoutFile: '100' });
+        expect(result).toEqual({ layoutId: 100, layoutFile: '100.xlf' });
       });
 
       it('should return null when queue is empty and no default', () => {
@@ -1539,8 +1539,8 @@ describe('PlayerCore', () => {
         core.on('layout-prepare-request', spy);
 
         mockSchedule._defaultQueue = [
-          { layoutId: '100', duration: 60 },
-          { layoutId: '200', duration: 60 },
+          { layoutId: '100.xlf', duration: 60 },
+          { layoutId: '200.xlf', duration: 60 },
         ];
         mockSchedule._queuePosition = 0;
 
@@ -1553,7 +1553,7 @@ describe('PlayerCore', () => {
         const spy = createSpy();
         core.on('layout-prepare-request', spy);
 
-        mockSchedule._defaultQueue = [{ layoutId: '100', duration: 60 }];
+        mockSchedule._defaultQueue = [{ layoutId: '100.xlf', duration: 60 }];
         mockSchedule._queuePosition = 0;
         core.currentLayoutId = 100;
 
@@ -1607,9 +1607,9 @@ describe('PlayerCore', () => {
         core.on('layout-prepare-request', (id) => emitted.push(id));
 
         mockSchedule._defaultQueue = [
-          { layoutId: '100', duration: 60 },
-          { layoutId: '200', duration: 60 },
-          { layoutId: '300', duration: 60 },
+          { layoutId: '100.xlf', duration: 60 },
+          { layoutId: '200.xlf', duration: 60 },
+          { layoutId: '300.xlf', duration: 60 },
         ];
         mockSchedule._queuePosition = 0;
 
@@ -1806,7 +1806,7 @@ describe('PlayerCore', () => {
 
       core._offlineCache = { schedule: { default: '0', layouts: [] }, settings: null, requiredFiles: null };
       mockSchedule.getCurrentLayouts.mockReturnValue(['500.xlf']);
-      mockSchedule._defaultQueue = [{ layoutId: '500', duration: 60 }];
+      mockSchedule._defaultQueue = [{ layoutId: '500.xlf', duration: 60 }];
       mockSchedule._queuePosition = 0;
 
       core.collectOffline();
@@ -2114,9 +2114,9 @@ describe('PlayerCore', () => {
 
     it('should skip blacklisted layouts in getNextLayout', () => {
       mockSchedule._defaultQueue = [
-        { layoutId: '100', duration: 60 },
-        { layoutId: '200', duration: 60 },
-        { layoutId: '300', duration: 60 },
+        { layoutId: '100.xlf', duration: 60 },
+        { layoutId: '200.xlf', duration: 60 },
+        { layoutId: '300.xlf', duration: 60 },
       ];
       mockSchedule._queuePosition = 0;
 
@@ -2131,9 +2131,9 @@ describe('PlayerCore', () => {
 
     it('should skip blacklisted layouts in advanceToNextLayout', () => {
       mockSchedule._defaultQueue = [
-        { layoutId: '100', duration: 60 },
-        { layoutId: '200', duration: 60 },
-        { layoutId: '300', duration: 60 },
+        { layoutId: '100.xlf', duration: 60 },
+        { layoutId: '200.xlf', duration: 60 },
+        { layoutId: '300.xlf', duration: 60 },
       ];
       mockSchedule._queuePosition = 0;
       core.currentLayoutId = 100;
@@ -2156,8 +2156,8 @@ describe('PlayerCore', () => {
 
     it('should fall back to first entry if all are blacklisted', () => {
       mockSchedule._defaultQueue = [
-        { layoutId: '100', duration: 60 },
-        { layoutId: '200', duration: 60 },
+        { layoutId: '100.xlf', duration: 60 },
+        { layoutId: '200.xlf', duration: 60 },
       ];
       mockSchedule._queuePosition = 0;
 
@@ -2175,9 +2175,9 @@ describe('PlayerCore', () => {
 
     it('should skip blacklisted in peekNextLayout', () => {
       mockSchedule._defaultQueue = [
-        { layoutId: '100', duration: 60 },
-        { layoutId: '200', duration: 60 },
-        { layoutId: '300', duration: 60 },
+        { layoutId: '100.xlf', duration: 60 },
+        { layoutId: '200.xlf', duration: 60 },
+        { layoutId: '300.xlf', duration: 60 },
       ];
       mockSchedule._queuePosition = 0;
       core.currentLayoutId = 100;
@@ -2192,8 +2192,8 @@ describe('PlayerCore', () => {
       // So peek returns null
       // Let's set position so peek returns 200 first, then falls through to 300
       mockSchedule._queuePosition = 1; // peek sees '200'
-      mockSchedule.peekNextInQueue.mockReturnValue({ layoutId: '200', duration: 60 });
-      mockSchedule.peekAfterNext.mockReturnValue({ layoutId: '300', duration: 60 });
+      mockSchedule.peekNextInQueue.mockReturnValue({ layoutId: '200.xlf', duration: 60 });
+      mockSchedule.peekAfterNext.mockReturnValue({ layoutId: '300.xlf', duration: 60 });
 
       // peekNextLayout sees 200 is blacklisted → returns null
       const peek = core.peekNextLayout();

--- a/packages/schedule/src/index.d.ts
+++ b/packages/schedule/src/index.d.ts
@@ -14,6 +14,6 @@ export class ScheduleManager {
 
 export const scheduleManager: ScheduleManager;
 
-export function calculateTimeline(layouts: any[], durations: Map<string, number>, options?: any): any[];
+export function calculateTimeline(queue: Array<{layoutId: string, duration: number}>, queuePosition: number, options?: any): any[];
 export function parseLayoutDuration(xlf: string, videoDurations?: Map<string, number> | null): { duration: number; isDynamic: boolean };
 export function buildScheduleQueue(schedule: any, durations: Map<string, number>): any[];

--- a/packages/schedule/src/timeline.js
+++ b/packages/schedule/src/timeline.js
@@ -111,23 +111,6 @@ function canSimulatedPlay(history, maxPlaysPerHour, timeMs) {
 }
 
 /**
- * Seed simulated play history from real play history.
- * Maps layoutId-based history to layoutFile-based history.
- * @param {Map<string, number[]>} realHistory - schedule.playHistory (layoutId → [timestamps])
- * @returns {Map<string, number[]>} layoutFile → [timestamps]
- */
-function seedPlayHistory(realHistory) {
-  const simulated = new Map();
-  if (!realHistory) return simulated;
-
-  for (const [layoutId, timestamps] of realHistory) {
-    const file = `${layoutId}.xlf`;
-    simulated.set(file, [...timestamps]);
-  }
-  return simulated;
-}
-
-/**
  * From a list of layout metadata, apply simulated rate limiting and priority
  * filtering to determine which layouts can actually play at the given time.
  * Mirrors the real player logic: filter rate-limited layouts first, then
@@ -156,129 +139,59 @@ function getPlayableLayouts(allLayouts, simPlays, timeMs) {
 }
 
 /**
- * Calculate a deterministic playback timeline by simulating round-robin scheduling
- * with rate limiting (maxPlaysPerHour) and priority fallback. Produces a real
- * schedule prediction that matches actual player behavior.
+ * Calculate a deterministic playback timeline by walking the pre-built schedule queue.
  *
- * When high-priority layouts hit their maxPlaysPerHour limit, the simulation
- * falls back to lower-priority scheduled layouts before using the CMS default.
+ * The queue already has all constraints baked in (maxPlaysPerHour, priorities,
+ * dayparting, default layout fills). This function simply cycles through it from
+ * the current position, generating time-stamped entries for the overlay.
  *
- * @param {Object} schedule - ScheduleManager instance (needs getAllLayoutsAtTime(), schedule.default, playHistory)
- * @param {Map<string, number>} durations - Map of layoutFile → duration in seconds
+ * @param {Array<{layoutId: string, duration: number}>} queue - Pre-built schedule queue from buildScheduleQueue()
+ * @param {number} queuePosition - Current position in the queue (from schedule._queuePosition)
  * @param {Object} [options]
  * @param {Date}   [options.from]    - Start time (default: now)
- * @param {number} [options.hours]   - Hours to simulate (default: 2)
- * @param {number} [options.defaultDuration] - Fallback duration in seconds (default: 60)
+ * @param {number} [options.hours]   - Hours to project (default: 2)
+ * @param {string} [options.defaultLayout] - Default layout file (to tag isDefault entries)
  * @param {Date}   [options.currentLayoutStartedAt] - When current layout started (adjusts first entry to remaining time)
  * @returns {Array<{layoutFile: string, startTime: Date, endTime: Date, duration: number, isDefault: boolean}>}
  */
-export function calculateTimeline(schedule, durations, options = {}) {
+export function calculateTimeline(queue, queuePosition, options = {}) {
   const from = options.from || new Date();
   const hours = options.hours || 2;
   const to = new Date(from.getTime() + hours * 3600000);
-  const defaultDuration = options.defaultDuration || 60;
   const currentLayoutStartedAt = options.currentLayoutStartedAt || null;
+  const defaultLayout = options.defaultLayout || null;
+
+  if (!queue || queue.length === 0) return [];
+
   const timeline = [];
   let currentTime = new Date(from);
+  let pos = queuePosition % queue.length;
   let isFirstEntry = true;
-
-  // Use getAllLayoutsAtTime if available (new API), fall back to getLayoutsAtTime (old API)
-  const hasFullApi = typeof schedule.getAllLayoutsAtTime === 'function';
-
-  // Seed simulated play history from real plays
-  const simPlays = seedPlayHistory(schedule.playHistory);
-
   const maxEntries = 500;
 
   while (currentTime < to && timeline.length < maxEntries) {
-    const timeMs = currentTime.getTime();
-    let playable;
+    const entry = queue[pos];
+    let dur = entry.duration;
 
-    let hiddenLayouts = null;
-
-    if (hasFullApi) {
-      // Full simulation: get ALL active layouts, apply rate limiting + priority
-      const allLayouts = schedule.getAllLayoutsAtTime(currentTime);
-      playable = allLayouts.length > 0
-        ? getPlayableLayouts(allLayouts, simPlays, timeMs)
-        : [];
-      // Detect hidden layouts (lower priority, not playing)
-      if (allLayouts.length > playable.length) {
-        hiddenLayouts = allLayouts
-          .filter(l => !playable.includes(l.file))
-          .map(l => ({ file: l.file, priority: l.priority }));
-      }
-    } else {
-      // Legacy fallback: no rate limiting simulation
-      playable = schedule.getLayoutsAtTime(currentTime);
+    // First entry: use remaining duration if we know when the current layout started
+    if (isFirstEntry && currentLayoutStartedAt) {
+      const elapsedSec = (from.getTime() - currentLayoutStartedAt.getTime()) / 1000;
+      dur = Math.max(1, Math.round(dur - elapsedSec));
+      isFirstEntry = false;
     }
 
-    if (playable.length === 0) {
-      // No playable layouts — use CMS default or skip ahead
-      const defaultFile = schedule.schedule?.default;
-      if (defaultFile) {
-        const dur = durations.get(defaultFile) || defaultDuration;
-        timeline.push({
-          layoutFile: defaultFile,
-          startTime: new Date(currentTime),
-          endTime: new Date(timeMs + dur * 1000),
-          duration: dur,
-          isDefault: true,
-        });
-        currentTime = new Date(timeMs + dur * 1000);
-      } else {
-        currentTime = new Date(timeMs + 60000);
-      }
-      continue;
-    }
+    const endMs = currentTime.getTime() + dur * 1000;
 
-    // Round-robin through playable layouts
-    for (let i = 0; i < playable.length && currentTime < to && timeline.length < maxEntries; i++) {
-      const file = playable[i];
-      let dur = durations.get(file) || defaultDuration;
+    timeline.push({
+      layoutFile: entry.layoutId,
+      startTime: new Date(currentTime),
+      endTime: new Date(endMs),
+      duration: dur,
+      isDefault: defaultLayout ? entry.layoutId === defaultLayout : false,
+    });
 
-      // First entry: use remaining duration if we know when the current layout started
-      if (isFirstEntry && currentLayoutStartedAt) {
-        const elapsedSec = (from.getTime() - currentLayoutStartedAt.getTime()) / 1000;
-        const remaining = Math.max(1, Math.round(dur - elapsedSec));
-        dur = remaining;
-        isFirstEntry = false;
-      }
-
-      const endMs = currentTime.getTime() + dur * 1000;
-
-      const entry = {
-        layoutFile: file,
-        startTime: new Date(currentTime),
-        endTime: new Date(endMs),
-        duration: dur,
-        isDefault: false,
-      };
-      if (hiddenLayouts && hiddenLayouts.length > 0) {
-        entry.hidden = hiddenLayouts;
-      }
-      timeline.push(entry);
-
-      // Record simulated play
-      if (hasFullApi) {
-        if (!simPlays.has(file)) simPlays.set(file, []);
-        simPlays.get(file).push(currentTime.getTime());
-      }
-
-      currentTime = new Date(endMs);
-
-      // Re-evaluate: if playable set changed, re-enter outer loop
-      if (hasFullApi) {
-        const nextAll = schedule.getAllLayoutsAtTime(currentTime);
-        const nextPlayable = nextAll.length > 0
-          ? getPlayableLayouts(nextAll, simPlays, currentTime.getTime())
-          : [];
-        if (!arraysEqual(playable, nextPlayable)) break;
-      } else {
-        const next = schedule.getLayoutsAtTime(currentTime);
-        if (!arraysEqual(playable, next)) break;
-      }
-    }
+    currentTime = new Date(endMs);
+    pos = (pos + 1) % queue.length;
   }
 
   return timeline;

--- a/packages/schedule/src/timeline.test.js
+++ b/packages/schedule/src/timeline.test.js
@@ -1,60 +1,25 @@
 /**
  * Timeline Calculator Tests
  *
- * Tests for calculateTimeline() — the pure simulation function that produces
- * deterministic playback predictions from schedule + durations.
+ * Tests for calculateTimeline() — walks a pre-built queue to produce
+ * time-stamped playback predictions for the overlay.
  */
 
 import { describe, it, expect } from 'vitest';
 import { calculateTimeline, parseLayoutDuration } from './timeline.js';
 
-// ── Helpers ──────────────────────────────────────────────────────
-
-/** Create a mock schedule with getAllLayoutsAtTime() support */
-function createMockSchedule({ layouts = [], defaultLayout = null, playHistory = null } = {}) {
-  return {
-    schedule: { default: defaultLayout },
-    playHistory: playHistory || new Map(),
-    getAllLayoutsAtTime(time) {
-      const t = time.getTime();
-      return layouts.filter(l => {
-        const from = new Date(l.fromdt).getTime();
-        const to = new Date(l.todt).getTime();
-        return t >= from && t < to;
-      });
-    },
-    getLayoutsAtTime(time) {
-      return this.getAllLayoutsAtTime(time).map(l => l.file);
-    },
-  };
-}
-
-function hoursFromNow(h) {
-  return new Date(Date.now() + h * 3600000).toISOString();
-}
-
 // Fixed "now" for deterministic tests
 const NOW = new Date('2026-03-03T10:00:00Z');
-
-function fixedDate(isoTime) {
-  return new Date(isoTime);
-}
 
 // ── Tests ────────────────────────────────────────────────────────
 
 describe('calculateTimeline', () => {
-  describe('Basic scheduling', () => {
-    it('should produce entries for a single scheduled layout', () => {
-      const schedule = createMockSchedule({
-        layouts: [{
-          file: '100.xlf', priority: 10, maxPlaysPerHour: 0,
-          fromdt: '2026-03-03T09:00:00Z', todt: '2026-03-03T12:00:00Z',
-        }],
-      });
-      const durations = new Map([['100.xlf', 30]]);
+  describe('Basic queue walking', () => {
+    it('should produce entries from a single-entry queue', () => {
+      const queue = [{ layoutId: '100.xlf', duration: 30 }];
 
-      const timeline = calculateTimeline(schedule, durations, {
-        from: NOW, hours: 1,
+      const timeline = calculateTimeline(queue, 0, {
+        from: NOW, hours: 0.1,
       });
 
       expect(timeline.length).toBeGreaterThan(0);
@@ -63,213 +28,78 @@ describe('calculateTimeline', () => {
       expect(timeline[0].isDefault).toBe(false);
     });
 
-    it('should use default layout when no scheduled layouts exist', () => {
-      const schedule = createMockSchedule({
-        layouts: [],
+    it('should tag default layout entries', () => {
+      const queue = [{ layoutId: 'default.xlf', duration: 45 }];
+
+      const timeline = calculateTimeline(queue, 0, {
+        from: NOW, hours: 0.1,
         defaultLayout: 'default.xlf',
       });
-      const durations = new Map([['default.xlf', 45]]);
 
-      const timeline = calculateTimeline(schedule, durations, {
-        from: NOW, hours: 0.1,
-      });
-
-      expect(timeline.length).toBeGreaterThan(0);
       expect(timeline[0].layoutFile).toBe('default.xlf');
       expect(timeline[0].isDefault).toBe(true);
       expect(timeline[0].duration).toBe(45);
     });
 
-    it('should use fallback duration when layout not in durations map', () => {
-      const schedule = createMockSchedule({
-        layouts: [{
-          file: '100.xlf', priority: 10, maxPlaysPerHour: 0,
-          fromdt: '2026-03-03T09:00:00Z', todt: '2026-03-03T12:00:00Z',
-        }],
-      });
-      const durations = new Map(); // No durations known
+    it('should cycle through multiple queue entries', () => {
+      const queue = [
+        { layoutId: '100.xlf', duration: 30 },
+        { layoutId: '200.xlf', duration: 45 },
+      ];
 
-      const timeline = calculateTimeline(schedule, durations, {
-        from: NOW, hours: 0.1, defaultDuration: 42,
-      });
-
-      expect(timeline[0].duration).toBe(42);
-    });
-
-    it('should round-robin multiple layouts at same priority', () => {
-      const schedule = createMockSchedule({
-        layouts: [
-          { file: '100.xlf', priority: 10, maxPlaysPerHour: 0,
-            fromdt: '2026-03-03T09:00:00Z', todt: '2026-03-03T12:00:00Z' },
-          { file: '200.xlf', priority: 10, maxPlaysPerHour: 0,
-            fromdt: '2026-03-03T09:00:00Z', todt: '2026-03-03T12:00:00Z' },
-        ],
-      });
-      const durations = new Map([['100.xlf', 30], ['200.xlf', 30]]);
-
-      const timeline = calculateTimeline(schedule, durations, {
+      const timeline = calculateTimeline(queue, 0, {
         from: NOW, hours: 0.1,
       });
 
-      // Both layouts should appear in the timeline
       const files = timeline.map(e => e.layoutFile);
       expect(files).toContain('100.xlf');
       expect(files).toContain('200.xlf');
-    });
-  });
-
-  describe('Priority handling', () => {
-    it('should play higher priority layout over lower priority', () => {
-      const schedule = createMockSchedule({
-        layouts: [
-          { file: 'low.xlf', priority: 5, maxPlaysPerHour: 0,
-            fromdt: '2026-03-03T09:00:00Z', todt: '2026-03-03T12:00:00Z' },
-          { file: 'high.xlf', priority: 10, maxPlaysPerHour: 0,
-            fromdt: '2026-03-03T09:00:00Z', todt: '2026-03-03T12:00:00Z' },
-        ],
-      });
-      const durations = new Map([['low.xlf', 30], ['high.xlf', 30]]);
-
-      const timeline = calculateTimeline(schedule, durations, {
-        from: NOW, hours: 0.5,
-      });
-
-      // All entries should be high priority
-      const uniqueFiles = [...new Set(timeline.map(e => e.layoutFile))];
-      expect(uniqueFiles).toEqual(['high.xlf']);
+      // Should alternate
+      expect(files[0]).toBe('100.xlf');
+      expect(files[1]).toBe('200.xlf');
+      expect(files[2]).toBe('100.xlf');
     });
 
-    it('should annotate hidden (overshadowed) layouts', () => {
-      const schedule = createMockSchedule({
-        layouts: [
-          { file: 'low.xlf', priority: 5, maxPlaysPerHour: 0,
-            fromdt: '2026-03-03T09:00:00Z', todt: '2026-03-03T12:00:00Z' },
-          { file: 'high.xlf', priority: 10, maxPlaysPerHour: 0,
-            fromdt: '2026-03-03T09:00:00Z', todt: '2026-03-03T12:00:00Z' },
-        ],
-      });
-      const durations = new Map([['low.xlf', 30], ['high.xlf', 30]]);
+    it('should start from the given queue position', () => {
+      const queue = [
+        { layoutId: '100.xlf', duration: 30 },
+        { layoutId: '200.xlf', duration: 30 },
+        { layoutId: '300.xlf', duration: 30 },
+      ];
 
-      const timeline = calculateTimeline(schedule, durations, {
+      const timeline = calculateTimeline(queue, 2, {
         from: NOW, hours: 0.1,
       });
 
-      // First entry should have hidden layouts
-      expect(timeline[0].hidden).toBeDefined();
-      expect(timeline[0].hidden).toEqual(
-        expect.arrayContaining([expect.objectContaining({ file: 'low.xlf' })])
-      );
-    });
-  });
-
-  describe('Rate limiting (maxPlaysPerHour)', () => {
-    it('should respect maxPlaysPerHour by falling back to lower priority', () => {
-      const schedule = createMockSchedule({
-        layouts: [
-          { file: 'limited.xlf', priority: 10, maxPlaysPerHour: 2,
-            fromdt: '2026-03-03T09:00:00Z', todt: '2026-03-03T12:00:00Z' },
-          { file: 'filler.xlf', priority: 5, maxPlaysPerHour: 0,
-            fromdt: '2026-03-03T09:00:00Z', todt: '2026-03-03T12:00:00Z' },
-        ],
-      });
-      const durations = new Map([['limited.xlf', 30], ['filler.xlf', 30]]);
-
-      const timeline = calculateTimeline(schedule, durations, {
-        from: NOW, hours: 1,
-      });
-
-      // limited.xlf should appear at most 2 times in the hour
-      const limitedPlays = timeline.filter(e => e.layoutFile === 'limited.xlf');
-      expect(limitedPlays.length).toBeLessThanOrEqual(2);
-
-      // filler.xlf should fill the gaps
-      const fillerPlays = timeline.filter(e => e.layoutFile === 'filler.xlf');
-      expect(fillerPlays.length).toBeGreaterThan(0);
+      expect(timeline[0].layoutFile).toBe('300.xlf');
+      expect(timeline[1].layoutFile).toBe('100.xlf');
+      expect(timeline[2].layoutFile).toBe('200.xlf');
     });
 
-    it('should fall back to default when all layouts are rate-limited', () => {
-      const schedule = createMockSchedule({
-        layouts: [
-          { file: 'limited.xlf', priority: 10, maxPlaysPerHour: 1,
-            fromdt: '2026-03-03T09:00:00Z', todt: '2026-03-03T12:00:00Z' },
-        ],
-        defaultLayout: 'default.xlf',
-      });
-      const durations = new Map([['limited.xlf', 30], ['default.xlf', 30]]);
+    it('should wrap queue position when past end', () => {
+      const queue = [
+        { layoutId: '100.xlf', duration: 30 },
+        { layoutId: '200.xlf', duration: 30 },
+      ];
 
-      const timeline = calculateTimeline(schedule, durations, {
-        from: NOW, hours: 1,
+      const timeline = calculateTimeline(queue, 5, {
+        from: NOW, hours: 0.1,
       });
 
-      // Should have both limited and default layouts
-      const files = [...new Set(timeline.map(e => e.layoutFile))];
-      expect(files).toContain('limited.xlf');
-      expect(files).toContain('default.xlf');
-
-      // limited.xlf at most once per hour
-      const limitedPlays = timeline.filter(e => e.layoutFile === 'limited.xlf');
-      expect(limitedPlays.length).toBeLessThanOrEqual(1);
-    });
-  });
-
-  describe('Time boundaries', () => {
-    it('should stop at schedule end time', () => {
-      const schedule = createMockSchedule({
-        layouts: [{
-          file: '100.xlf', priority: 10, maxPlaysPerHour: 0,
-          fromdt: '2026-03-03T10:00:00Z', todt: '2026-03-03T10:30:00Z',
-        }],
-        defaultLayout: 'default.xlf',
-      });
-      const durations = new Map([['100.xlf', 60], ['default.xlf', 60]]);
-
-      const timeline = calculateTimeline(schedule, durations, {
-        from: NOW, hours: 1,
-      });
-
-      // After 10:30, should switch to default
-      const afterEnd = timeline.filter(e =>
-        e.startTime >= new Date('2026-03-03T10:30:00Z')
-      );
-      for (const entry of afterEnd) {
-        expect(entry.layoutFile).toBe('default.xlf');
-      }
-    });
-
-    it('should not produce entries beyond the simulation window', () => {
-      const schedule = createMockSchedule({
-        layouts: [{
-          file: '100.xlf', priority: 10, maxPlaysPerHour: 0,
-          fromdt: '2026-03-03T09:00:00Z', todt: '2026-03-03T14:00:00Z',
-        }],
-      });
-      const durations = new Map([['100.xlf', 30]]);
-
-      const timeline = calculateTimeline(schedule, durations, {
-        from: NOW, hours: 1,
-      });
-
-      const endOfWindow = new Date(NOW.getTime() + 3600000);
-      for (const entry of timeline) {
-        expect(entry.startTime.getTime()).toBeLessThan(endOfWindow.getTime());
-      }
+      // 5 % 2 = 1, so starts at 200.xlf
+      expect(timeline[0].layoutFile).toBe('200.xlf');
+      expect(timeline[1].layoutFile).toBe('100.xlf');
     });
   });
 
   describe('currentLayoutStartedAt (remaining time adjustment)', () => {
     it('should adjust first entry duration to remaining time', () => {
-      const schedule = createMockSchedule({
-        layouts: [{
-          file: '100.xlf', priority: 10, maxPlaysPerHour: 0,
-          fromdt: '2026-03-03T09:00:00Z', todt: '2026-03-03T12:00:00Z',
-        }],
-      });
-      const durations = new Map([['100.xlf', 60]]);
+      const queue = [{ layoutId: '100.xlf', duration: 60 }];
 
       // Layout started 20 seconds ago → 40 seconds remaining
       const startedAt = new Date(NOW.getTime() - 20000);
 
-      const timeline = calculateTimeline(schedule, durations, {
+      const timeline = calculateTimeline(queue, 0, {
         from: NOW, hours: 0.5,
         currentLayoutStartedAt: startedAt,
       });
@@ -278,40 +108,82 @@ describe('calculateTimeline', () => {
     });
 
     it('should clamp remaining time to at least 1 second', () => {
-      const schedule = createMockSchedule({
-        layouts: [{
-          file: '100.xlf', priority: 10, maxPlaysPerHour: 0,
-          fromdt: '2026-03-03T09:00:00Z', todt: '2026-03-03T12:00:00Z',
-        }],
-      });
-      const durations = new Map([['100.xlf', 30]]);
+      const queue = [{ layoutId: '100.xlf', duration: 30 }];
 
       // Layout started 60 seconds ago but duration is only 30 → already overdue
       const startedAt = new Date(NOW.getTime() - 60000);
 
-      const timeline = calculateTimeline(schedule, durations, {
+      const timeline = calculateTimeline(queue, 0, {
         from: NOW, hours: 0.1,
         currentLayoutStartedAt: startedAt,
       });
 
       expect(timeline[0].duration).toBeGreaterThanOrEqual(1);
     });
+
+    it('should only adjust first entry, not subsequent', () => {
+      const queue = [{ layoutId: '100.xlf', duration: 60 }];
+      const startedAt = new Date(NOW.getTime() - 20000);
+
+      const timeline = calculateTimeline(queue, 0, {
+        from: NOW, hours: 0.1,
+        currentLayoutStartedAt: startedAt,
+      });
+
+      expect(timeline[0].duration).toBe(40);
+      expect(timeline[1].duration).toBe(60); // Full duration
+    });
+  });
+
+  describe('Time boundaries', () => {
+    it('should not produce entries beyond the simulation window', () => {
+      const queue = [{ layoutId: '100.xlf', duration: 30 }];
+
+      const timeline = calculateTimeline(queue, 0, {
+        from: NOW, hours: 1,
+      });
+
+      const endOfWindow = new Date(NOW.getTime() + 3600000);
+      for (const entry of timeline) {
+        expect(entry.startTime.getTime()).toBeLessThan(endOfWindow.getTime());
+      }
+    });
+
+    it('should produce continuous timeline (no gaps between entries)', () => {
+      const queue = [
+        { layoutId: '100.xlf', duration: 30 },
+        { layoutId: '200.xlf', duration: 45 },
+      ];
+
+      const timeline = calculateTimeline(queue, 0, {
+        from: NOW, hours: 0.5,
+      });
+
+      for (let i = 1; i < timeline.length; i++) {
+        expect(timeline[i].startTime.getTime()).toBe(timeline[i - 1].endTime.getTime());
+      }
+    });
+
+    it('should handle a large number of entries without exceeding 500 cap', () => {
+      const queue = [{ layoutId: '100.xlf', duration: 5 }]; // 5s = many entries
+
+      const timeline = calculateTimeline(queue, 0, {
+        from: NOW, hours: 2,
+      });
+
+      expect(timeline.length).toBeLessThanOrEqual(500);
+    });
   });
 
   describe('Determinism', () => {
     it('should produce identical output for identical inputs', () => {
-      const schedule = createMockSchedule({
-        layouts: [
-          { file: '100.xlf', priority: 10, maxPlaysPerHour: 0,
-            fromdt: '2026-03-03T09:00:00Z', todt: '2026-03-03T12:00:00Z' },
-          { file: '200.xlf', priority: 10, maxPlaysPerHour: 0,
-            fromdt: '2026-03-03T09:00:00Z', todt: '2026-03-03T12:00:00Z' },
-        ],
-      });
-      const durations = new Map([['100.xlf', 30], ['200.xlf', 45]]);
+      const queue = [
+        { layoutId: '100.xlf', duration: 30 },
+        { layoutId: '200.xlf', duration: 45 },
+      ];
 
-      const t1 = calculateTimeline(schedule, durations, { from: NOW, hours: 1 });
-      const t2 = calculateTimeline(schedule, durations, { from: NOW, hours: 1 });
+      const t1 = calculateTimeline(queue, 0, { from: NOW, hours: 1 });
+      const t2 = calculateTimeline(queue, 0, { from: NOW, hours: 1 });
 
       expect(t1.length).toBe(t2.length);
       for (let i = 0; i < t1.length; i++) {
@@ -323,67 +195,54 @@ describe('calculateTimeline', () => {
     });
 
     it('should produce DIFFERENT output when "from" time changes', () => {
-      const schedule = createMockSchedule({
-        layouts: [{
-          file: '100.xlf', priority: 10, maxPlaysPerHour: 0,
-          fromdt: '2026-03-03T09:00:00Z', todt: '2026-03-03T12:00:00Z',
-        }],
-      });
-      const durations = new Map([['100.xlf', 30]]);
+      const queue = [{ layoutId: '100.xlf', duration: 30 }];
 
-      const t1 = calculateTimeline(schedule, durations, { from: NOW, hours: 1 });
+      const t1 = calculateTimeline(queue, 0, { from: NOW, hours: 1 });
       const laterNow = new Date(NOW.getTime() + 300000); // 5 min later
-      const t2 = calculateTimeline(schedule, durations, { from: laterNow, hours: 1 });
+      const t2 = calculateTimeline(queue, 0, { from: laterNow, hours: 1 });
 
       // Start times must differ because the anchor moved
       expect(t1[0].startTime.getTime()).not.toBe(t2[0].startTime.getTime());
     });
+
+    it('should produce DIFFERENT output when position changes', () => {
+      const queue = [
+        { layoutId: '100.xlf', duration: 30 },
+        { layoutId: '200.xlf', duration: 30 },
+      ];
+
+      const t1 = calculateTimeline(queue, 0, { from: NOW, hours: 0.1 });
+      const t2 = calculateTimeline(queue, 1, { from: NOW, hours: 0.1 });
+
+      expect(t1[0].layoutFile).toBe('100.xlf');
+      expect(t2[0].layoutFile).toBe('200.xlf');
+    });
   });
 
   describe('Edge cases', () => {
-    it('should return empty array when no layouts and no default', () => {
-      const schedule = createMockSchedule({ layouts: [], defaultLayout: null });
-      const durations = new Map();
-
-      const timeline = calculateTimeline(schedule, durations, {
-        from: NOW, hours: 1,
-      });
-
+    it('should return empty array for empty queue', () => {
+      const timeline = calculateTimeline([], 0, { from: NOW, hours: 1 });
       expect(timeline).toEqual([]);
     });
 
-    it('should handle a large number of entries without exceeding 500 cap', () => {
-      const schedule = createMockSchedule({
-        layouts: [{
-          file: '100.xlf', priority: 10, maxPlaysPerHour: 0,
-          fromdt: '2026-03-03T09:00:00Z', todt: '2026-03-03T20:00:00Z',
-        }],
-      });
-      const durations = new Map([['100.xlf', 5]]); // 5s = many entries
-
-      const timeline = calculateTimeline(schedule, durations, {
-        from: NOW, hours: 2,
-      });
-
-      expect(timeline.length).toBeLessThanOrEqual(500);
+    it('should return empty array for null queue', () => {
+      const timeline = calculateTimeline(null, 0, { from: NOW, hours: 1 });
+      expect(timeline).toEqual([]);
     });
 
-    it('should produce continuous timeline (no gaps between entries)', () => {
-      const schedule = createMockSchedule({
-        layouts: [{
-          file: '100.xlf', priority: 10, maxPlaysPerHour: 0,
-          fromdt: '2026-03-03T09:00:00Z', todt: '2026-03-03T12:00:00Z',
-        }],
-      });
-      const durations = new Map([['100.xlf', 30]]);
+    it('should handle mixed default and scheduled entries in queue', () => {
+      const queue = [
+        { layoutId: '100.xlf', duration: 30 },
+        { layoutId: 'default.xlf', duration: 60 },
+      ];
 
-      const timeline = calculateTimeline(schedule, durations, {
-        from: NOW, hours: 0.5,
+      const timeline = calculateTimeline(queue, 0, {
+        from: NOW, hours: 0.1,
+        defaultLayout: 'default.xlf',
       });
 
-      for (let i = 1; i < timeline.length; i++) {
-        expect(timeline[i].startTime.getTime()).toBe(timeline[i - 1].endTime.getTime());
-      }
+      expect(timeline[0].isDefault).toBe(false);
+      expect(timeline[1].isDefault).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary
- `calculateTimeline()` now walks the pre-built schedule queue from `_queuePosition` instead of running its own independent round-robin simulation
- Eliminates overlay drift where the timeline kept showing layout 490 while the player had moved to 364, 366, 1, etc.
- Removes 225 lines of simulation code (priority fallback, rate-limit tracking, play history seeding) that duplicated `buildScheduleQueue()` logic
- Queue position included in fingerprint so timeline updates on layout transitions

## Test plan
- [x] All 1280 tests passing
- [ ] Deploy and verify no more "Mismatch: entering X but overlay expects Y" warnings
- [ ] Verify timeline overlay matches actual layout playback order

Fixes #191