### PR TITLE
Consolidate config handling: dedup SHELL_ONLY_KEYS, add Config getters

### DIFF
--- a/packages/pwa/src/main.ts
+++ b/packages/pwa/src/main.ts
@@ -383,10 +383,7 @@ class PwaPlayer {
       //   transport: "auto"   → probe REST → SOAP fallback (default)
       //   /player/pwa-xmds/   → forced SOAP (URL-based override)
       //   ?transport=xmds     → forced SOAP (query param override)
-      const cfgTransport = (() => {
-        try { return JSON.parse(localStorage.getItem('xibo_config') || '{}').transport; }
-        catch { return undefined; }
-      })();
+      const cfgTransport = config.transport !== 'auto' ? config.transport : undefined;
       const urlTransport = new URLSearchParams(window.location.search).get('transport');
       const transport = urlTransport
         || (PLAYER_BASE.includes('pwa-xmds') ? 'xmds' : null)
@@ -419,7 +416,7 @@ class PwaPlayer {
       // Forward console logs to proxy stdout (for journald/log analysis).
       // Controlled by debug.consoleLogs in config.json.
       // Optional debug.consoleLogsInterval (seconds) sets the batch flush interval (default 10s).
-      const debugConfig = JSON.parse(localStorage.getItem('xibo_config') || '{}')?.debug;
+      const debugConfig = config.debug;
       if (debugConfig?.consoleLogs) {
         const flushIntervalMs = (debugConfig.consoleLogsInterval || 10) * 1000;
         let batch: Array<{ level: string; name: string; message: string; ts: string }> = [];
@@ -1019,12 +1016,9 @@ class PwaPlayer {
     log.info('Remote controls initialized (keyboard + MediaSession)');
   }
 
-  /** Read controls config from localStorage (injected by proxy from config.json). */
+  /** Read controls config (injected by proxy from config.json into localStorage). */
   private getControls(): Record<string, any> {
-    try {
-      const cfg = JSON.parse(localStorage.getItem('xibo_config') || '{}');
-      return cfg.controls || {};
-    } catch { return {}; }
+    return config.controls;
   }
 
   /**

--- a/packages/utils/src/config.js
+++ b/packages/utils/src/config.js
@@ -331,6 +331,10 @@ export class Config {
 
   get googleGeoApiKey() { return this.data.googleGeoApiKey || ''; }
   set googleGeoApiKey(val) { this.data.googleGeoApiKey = val; this.save(); }
+
+  get controls() { return this.data.controls || {}; }
+  get transport() { return this.data.transport || 'auto'; }
+  get debug() { return this.data.debug || {}; }
 }
 
 export const config = new Config();
@@ -343,7 +347,7 @@ export const config = new Config();
  * to extractPwaConfig().
  *
  * Electron extras:  autoLaunch
- * Chromium extras:  browser, extraBrowserFlags, relaxSslCerts
+ * Chromium extras:  browser, extraBrowserFlags
  */
 export const SHELL_ONLY_KEYS = new Set([
   'serverPort',
@@ -353,6 +357,7 @@ export const SHELL_ONLY_KEYS = new Set([
   'preventSleep',
   'width',
   'height',
+  'relaxSslCerts',
 ]);
 
 /**


### PR DESCRIPTION
## Summary

- Add `relaxSslCerts` to shared `SHELL_ONLY_KEYS` — was leaking to PWA localStorage from Electron
- Add `controls`, `transport`, `debug` read-only getters to `Config` class
- Replace 3 raw `JSON.parse(localStorage)` calls in PWA `main.ts` with Config accessors

## Test plan

- [x] All 1358 SDK tests pass
- [ ] `ansible-playbook playbooks/services/pwa-local-test.yml` — verify controls, transport selection, debug console logs still work
- [ ] Verify `relaxSslCerts` no longer appears in `localStorage['xibo_config']`

Closes #205