### PR TITLE
refactor: formalize CmsClient interface with conformance checks

### DIFF
--- a/packages/xmds/src/cms-client.js
+++ b/packages/xmds/src/cms-client.js
@@ -1,0 +1,89 @@
+/**
+ * CmsClient interface definition — the unified contract for CMS communication.
+ *
+ * Both RestClient and XmdsClient implement this interface identically.
+ * PlayerCore calls these methods without knowing which transport is underneath.
+ * ProtocolDetector selects the implementation at startup.
+ *
+ * This file provides:
+ *   1. JSDoc type definitions for the interface
+ *   2. CMS_CLIENT_METHODS — canonical list of required methods
+ *   3. assertCmsClient() — runtime conformance check
+ *
+ * @example
+ *   import { ProtocolDetector, RestClient, XmdsClient } from '@xiboplayer/xmds';
+ *
+ *   const detector = new ProtocolDetector(cmsUrl, RestClient, XmdsClient);
+ *   const { client } = await detector.detect(config);
+ *   // client implements CmsClient — PlayerCore doesn't care which one
+ */
+
+/**
+ * @typedef {Object} RegisterDisplayResult
+ * @property {string} code - 'READY' or error code
+ * @property {string} message - Human-readable status message
+ * @property {Object|null} settings - Display settings (null if not READY)
+ * @property {string[]} tags - Display tags
+ * @property {Array<{commandCode: string, commandString: string}>} commands - Scheduled commands
+ * @property {Object} displayAttrs - Server-provided attributes (date, timezone, status)
+ * @property {string} checkRf - CRC checksum for RequiredFiles (skip if unchanged)
+ * @property {string} checkSchedule - CRC checksum for Schedule (skip if unchanged)
+ * @property {Object|null} syncConfig - Multi-display sync configuration
+ */
+
+/**
+ * @typedef {Object} RequiredFilesResult
+ * @property {Array<{type: string, id: string, size: number, md5: string, download: string, path: string, saveAs: string|null}>} files
+ * @property {Array<{id: string, storedAs: string}>} purge - Files to delete
+ */
+
+/**
+ * @typedef {Object} CmsClient
+ * @property {() => Promise<RegisterDisplayResult>} registerDisplay
+ * @property {() => Promise<RequiredFilesResult>} requiredFiles
+ * @property {() => Promise<Object>} schedule
+ * @property {(layoutId: string, regionId: string, mediaId: string) => Promise<string>} getResource
+ * @property {(status: Object) => Promise<any>} notifyStatus
+ * @property {(inventoryXml: string|Array) => Promise<any>} mediaInventory
+ * @property {(mediaId: string, type: string, reason: string) => Promise<boolean>} blackList
+ * @property {(logXml: string|Array, hardwareKeyOverride?: string) => Promise<boolean>} submitLog
+ * @property {(base64Image: string) => Promise<boolean>} submitScreenShot
+ * @property {(statsXml: string|Array, hardwareKeyOverride?: string) => Promise<boolean>} submitStats
+ * @property {(faultJson: string|Object) => Promise<boolean>} reportFaults
+ * @property {() => Promise<Object>} getWeather
+ */
+
+/**
+ * Canonical list of methods that every CmsClient implementation must provide.
+ * Used for runtime conformance checks and test assertions.
+ */
+export const CMS_CLIENT_METHODS = [
+  'registerDisplay',
+  'requiredFiles',
+  'schedule',
+  'getResource',
+  'notifyStatus',
+  'mediaInventory',
+  'blackList',
+  'submitLog',
+  'submitScreenShot',
+  'submitStats',
+  'reportFaults',
+  'getWeather',
+];
+
+/**
+ * Verify that an object implements the CmsClient interface.
+ * Throws if any required method is missing or not a function.
+ *
+ * @param {any} client - Object to check
+ * @param {string} [label] - Label for error messages (e.g. 'RestClient')
+ * @throws {Error} If the client doesn't conform
+ */
+export function assertCmsClient(client, label = 'client') {
+  for (const method of CMS_CLIENT_METHODS) {
+    if (typeof client[method] !== 'function') {
+      throw new Error(`${label} missing CmsClient method: ${method}()`);
+    }
+  }
+}

--- a/packages/xmds/src/cms-client.test.js
+++ b/packages/xmds/src/cms-client.test.js
@@ -1,0 +1,51 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { CMS_CLIENT_METHODS, assertCmsClient } from './cms-client.js';
+import { RestClient } from './rest-client.js';
+import { XmdsClient } from './xmds-client.js';
+
+const mockConfig = {
+  cmsUrl: 'https://example.com',
+  cmsKey: 'test',
+  hardwareKey: 'hw-001',
+  displayName: 'Test Display',
+  xmrChannel: '',
+};
+
+describe('CmsClient interface conformance', () => {
+  const restClient = new RestClient(mockConfig);
+  const xmdsClient = new XmdsClient(mockConfig);
+
+  it('CMS_CLIENT_METHODS lists 12 methods', () => {
+    expect(CMS_CLIENT_METHODS).toHaveLength(12);
+  });
+
+  for (const method of CMS_CLIENT_METHODS) {
+    it(`RestClient implements ${method}()`, () => {
+      expect(typeof restClient[method]).toBe('function');
+    });
+
+    it(`XmdsClient implements ${method}()`, () => {
+      expect(typeof xmdsClient[method]).toBe('function');
+    });
+  }
+
+  it('assertCmsClient passes for RestClient', () => {
+    expect(() => assertCmsClient(restClient, 'RestClient')).not.toThrow();
+  });
+
+  it('assertCmsClient passes for XmdsClient', () => {
+    expect(() => assertCmsClient(xmdsClient, 'XmdsClient')).not.toThrow();
+  });
+
+  it('assertCmsClient throws for incomplete client', () => {
+    const partial = { registerDisplay: () => {} };
+    expect(() => assertCmsClient(partial, 'partial')).toThrow('partial missing CmsClient method');
+  });
+
+  it('assertCmsClient throws for non-function property', () => {
+    const bad = Object.fromEntries(CMS_CLIENT_METHODS.map(m => [m, () => {}]));
+    bad.schedule = 'not a function';
+    expect(() => assertCmsClient(bad, 'bad')).toThrow('bad missing CmsClient method: schedule()');
+  });
+});

--- a/packages/xmds/src/index.js
+++ b/packages/xmds/src/index.js
@@ -4,4 +4,5 @@ export const VERSION = pkg.version;
 export { RestClient } from './rest-client.js';
 export { XmdsClient } from './xmds-client.js';
 export { ProtocolDetector } from './protocol-detector.js';
+export { CMS_CLIENT_METHODS, assertCmsClient } from './cms-client.js';
 export { parseScheduleResponse } from './schedule-parser.js';

--- a/packages/xmds/src/protocol-detector.js
+++ b/packages/xmds/src/protocol-detector.js
@@ -25,6 +25,7 @@
  */
 
 import { createLogger } from '@xiboplayer/utils';
+import { assertCmsClient } from './cms-client.js';
 
 const log = createLogger('Protocol');
 
@@ -78,13 +79,17 @@ export class ProtocolDetector {
     if (forceProtocol === 'rest') {
       this.protocol = 'rest';
       log.info('Using REST transport (forced)');
-      return { client: new this.RestClient(config), protocol: 'rest' };
+      const client = new this.RestClient(config);
+      assertCmsClient(client, 'RestClient');
+      return { client, protocol: 'rest' };
     }
 
     if (forceProtocol === 'xmds') {
       this.protocol = 'xmds';
       log.info('Using XMDS/SOAP transport (forced)');
-      return { client: new this.XmdsClient(config), protocol: 'xmds' };
+      const client = new this.XmdsClient(config);
+      assertCmsClient(client, 'XmdsClient');
+      return { client, protocol: 'xmds' };
     }
 
     // Auto-detect
@@ -99,12 +104,16 @@ export class ProtocolDetector {
     if (isRest) {
       this.protocol = 'rest';
       log.info('REST transport detected — using PlayerApiV2');
-      return { client: new this.RestClient(config), protocol: 'rest' };
+      const client = new this.RestClient(config);
+      assertCmsClient(client, 'RestClient');
+      return { client, protocol: 'rest' };
     }
 
     this.protocol = 'xmds';
     log.info('REST unavailable — using XMDS/SOAP transport');
-    return { client: new this.XmdsClient(config), protocol: 'xmds' };
+    const client = new this.XmdsClient(config);
+    assertCmsClient(client, 'XmdsClient');
+    return { client, protocol: 'xmds' };
   }
 
   /**
@@ -132,6 +141,7 @@ export class ProtocolDetector {
       log.info(`Protocol changed: ${previousProtocol} → ${newProtocol}`);
       this.protocol = newProtocol;
       const client = isRest ? new this.RestClient(config) : new this.XmdsClient(config);
+      assertCmsClient(client, isRest ? 'RestClient' : 'XmdsClient');
       return { client, protocol: newProtocol, changed: true };
     }
 

--- a/packages/xmds/src/protocol-detector.test.js
+++ b/packages/xmds/src/protocol-detector.test.js
@@ -10,6 +10,14 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ProtocolDetector } from './protocol-detector.js';
+import { CMS_CLIENT_METHODS } from './cms-client.js';
+
+// Stub all CmsClient methods on a mock constructor's prototype
+function addCmsClientStubs(MockClass) {
+  for (const method of CMS_CLIENT_METHODS) {
+    MockClass.prototype[method] = vi.fn();
+  }
+}
 
 describe('ProtocolDetector', () => {
   let MockRestClient;
@@ -28,11 +36,13 @@ describe('ProtocolDetector', () => {
       this.type = 'rest';
     });
     MockRestClient.isAvailable = vi.fn();
+    addCmsClientStubs(MockRestClient);
 
     MockXmdsClient = vi.fn(function (cfg) {
       this.config = cfg;
       this.type = 'xmds';
     });
+    addCmsClientStubs(MockXmdsClient);
   });
 
   // ── detect() ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add `cms-client.js` with JSDoc type definitions, `CMS_CLIENT_METHODS` canonical list, and `assertCmsClient()` runtime validator
- ProtocolDetector now validates client conformance on every `detect()` / `reprobe()` call — catches missing methods at startup, not at first CMS call
- Conformance test verifies both RestClient and XmdsClient implement all 12 required methods
- Export `CMS_CLIENT_METHODS` and `assertCmsClient` from `@xiboplayer/xmds`

## Test plan
- [x] 29 new + existing conformance tests (12 RestClient methods, 12 XmdsClient methods, assertion edge cases)
- [x] All 1387 tests pass (36 files)

Closes #200