### PR TITLE
feat: per-CMS cache and config storage

### DIFF
--- a/packages/core/src/player-core.js
+++ b/packages/core/src/player-core.js
@@ -50,7 +50,7 @@ import { DataConnectorManager } from './data-connectors.js';
 const log = createLogger('PlayerCore');
 
 // IndexedDB database/store for offline cache
-const OFFLINE_DB_NAME = 'xibo-offline-cache';
+const OFFLINE_DB_BASE = 'xibo-offline-cache';
 const OFFLINE_DB_VERSION = 1;
 const OFFLINE_STORE = 'cache';
 
@@ -60,9 +60,10 @@ function parseLayoutFile(f) {
 }
 
 /** Open the offline cache IndexedDB (creates store on first use) */
-function openOfflineDb() {
+function openOfflineDb(cmsId) {
+  const dbName = cmsId ? `${OFFLINE_DB_BASE}-${cmsId}` : OFFLINE_DB_BASE;
   return new Promise((resolve, reject) => {
-    const req = indexedDB.open(OFFLINE_DB_NAME, OFFLINE_DB_VERSION);
+    const req = indexedDB.open(dbName, OFFLINE_DB_VERSION);
     req.onupgradeneeded = () => {
       const db = req.result;
       if (!db.objectStoreNames.contains(OFFLINE_STORE)) {
@@ -87,6 +88,9 @@ export class PlayerCore extends EventEmitter {
     this.XmrWrapper = options.xmrWrapper;
     this.statsCollector = options.statsCollector; // Optional: proof of play tracking
     this.displaySettings = options.displaySettings; // Optional: CMS display settings manager
+
+    // CMS ID for namespaced IndexedDB databases
+    this._cmsId = options.cmsId || null;
 
     // Data connectors manager (real-time data for widgets)
     this.dataConnectorManager = new DataConnectorManager();
@@ -177,7 +181,7 @@ export class PlayerCore extends EventEmitter {
   /** Load offline cache from IndexedDB into memory on startup */
   async _initOfflineCache() {
     try {
-      const db = await openOfflineDb();
+      const db = await openOfflineDb(this._cmsId);
       const tx = db.transaction(OFFLINE_STORE, 'readonly');
       const store = tx.objectStore(OFFLINE_STORE);
 
@@ -206,7 +210,7 @@ export class PlayerCore extends EventEmitter {
   async _offlineSave(key, data) {
     this._offlineCache[key] = data;
     try {
-      const db = await openOfflineDb();
+      const db = await openOfflineDb(this._cmsId);
       const tx = db.transaction(OFFLINE_STORE, 'readwrite');
       tx.objectStore(OFFLINE_STORE).put(data, key);
       await new Promise((resolve, reject) => {

--- a/packages/proxy/src/proxy.js
+++ b/packages/proxy/src/proxy.js
@@ -12,7 +12,7 @@ import path from 'path';
 import { Readable } from 'node:stream';
 import express from 'express';
 import cors from 'cors';
-import { createLogger, registerLogSink, PLAYER_API, setPlayerApi } from '@xiboplayer/utils';
+import { createLogger, registerLogSink, PLAYER_API, setPlayerApi, computeCmsId } from '@xiboplayer/utils';
 import { ContentStore } from './content-store.js';
 
 const SKIP_HEADERS = ['transfer-encoding', 'connection', 'content-encoding', 'content-length'];
@@ -180,6 +180,15 @@ export function createProxyApp({ pwaPath, appVersion = '0.0.0', pwaConfig, confi
     // Update in-memory config — merge all POSTed fields (takes effect on next page load injection)
     currentPwaConfig = { ...(currentPwaConfig || {}), ...req.body };
 
+    // Reinitialize ContentStore if CMS URL changed (new CMS-namespaced directory)
+    if (dataDir && cmsUrl) {
+      const newCmsId = computeCmsId(cmsUrl);
+      if (newCmsId) {
+        currentPwaConfig.cmsId = newCmsId;
+        store = initContentStore(newCmsId);
+      }
+    }
+
     // Write config.json — merge with existing file to preserve non-POSTed keys (e.g. controls)
     if (configFilePath) {
       fs.mkdirSync(path.dirname(configFilePath), { recursive: true });
@@ -232,12 +241,22 @@ export function createProxyApp({ pwaPath, appVersion = '0.0.0', pwaConfig, confi
 
 
   // ─── ContentStore initialization ──────────────────────────────────
+  // Namespace by CMS ID when available: cache/{cmsId}/media/
+  // Falls back to flat media/ for backward compat when no cmsId.
   let store = null;
-  if (dataDir) {
-    store = new ContentStore(path.join(dataDir, 'media'));
-    store.init();
-    logProxy.info(`ContentStore enabled: ${path.join(dataDir, 'media')}`);
+  function initContentStore(cmsId) {
+    if (!dataDir) return null;
+    const storeDir = cmsId
+      ? path.join(dataDir, 'cache', cmsId, 'media')
+      : path.join(dataDir, 'media');
+    const s = new ContentStore(storeDir);
+    s.init();
+    logProxy.info(`ContentStore enabled: ${storeDir}`);
+    return s;
   }
+
+  const initialCmsId = pwaConfig?.cmsId || (pwaConfig?.cmsUrl ? computeCmsId(pwaConfig.cmsUrl) : null);
+  store = initContentStore(initialCmsId);
 
   // ─── Quit ────────────────────────────────────────────────────────
   // Allow the PWA to request a clean shutdown (Ctrl+Q in Chromium kiosk).
@@ -834,11 +853,23 @@ export function createProxyApp({ pwaPath, appVersion = '0.0.0', pwaConfig, confi
     return `<script>
 (function(){
   try {
-    var existing = {};
-    try { existing = JSON.parse(localStorage.getItem('xibo_config') || '{}'); } catch(e) {}
     var injected = ${configJson};
-    var merged = Object.assign({}, existing, injected);
-    localStorage.setItem('xibo_config', JSON.stringify(merged));
+    var GLOBAL_KEYS = { hardwareKey: 1, xmrPubKey: 1, xmrPrivKey: 1 };
+    var globalData = {};
+    try { globalData = JSON.parse(localStorage.getItem('xibo_global') || '{}'); } catch(e) {}
+    var cmsData = {};
+    for (var k in injected) {
+      if (GLOBAL_KEYS[k]) globalData[k] = injected[k];
+      else cmsData[k] = injected[k];
+    }
+    localStorage.setItem('xibo_global', JSON.stringify(globalData));
+    if (injected.cmsId) {
+      var cmsKey = 'xibo_cms:' + injected.cmsId;
+      var existingCms = {};
+      try { existingCms = JSON.parse(localStorage.getItem(cmsKey) || '{}'); } catch(e) {}
+      localStorage.setItem(cmsKey, JSON.stringify(Object.assign({}, existingCms, cmsData)));
+      localStorage.setItem('xibo_active_cms', injected.cmsId);
+    }
   } catch(e) { console.warn('ConfigInject failed:', e); }
 })();
 </script>`;

--- a/packages/pwa/src/main.ts
+++ b/packages/pwa/src/main.ts
@@ -155,7 +155,7 @@ class PwaPlayer {
       }
     );
 
-    // Create PlayerCore
+    // Create PlayerCore (with CMS-namespaced offline cache DB)
     this.core = new PlayerCore({
       config,
       xmds: this.xmds,
@@ -164,7 +164,8 @@ class PwaPlayer {
       renderer: this.renderer,
       xmrWrapper: XmrWrapper,
       statsCollector: this.statsCollector,
-      displaySettings: this.displaySettings
+      displaySettings: this.displaySettings,
+      cmsId: config.activeCmsId,
     });
 
     // Setup platform-specific event handlers
@@ -396,15 +397,16 @@ class PwaPlayer {
       const { client } = await this.protocolDetector.detect(config, forceProtocol);
       this.xmds = client;
 
-      // Initialize stats collector
-      this.statsCollector = new StatsCollector();
+      // Initialize stats collector (namespaced by CMS ID)
+      const cmsId = config.activeCmsId;
+      this.statsCollector = new StatsCollector(cmsId);
       await this.statsCollector.init();
-      log.info('Stats collector initialized');
+      log.info(`Stats collector initialized${cmsId ? ` (CMS: ${cmsId})` : ''}`);
 
-      // Initialize log reporter for CMS log submission
-      this.logReporter = new LogReporter();
+      // Initialize log reporter for CMS log submission (namespaced by CMS ID)
+      this.logReporter = new LogReporter(cmsId);
       await this.logReporter.init();
-      log.info('Log reporter initialized');
+      log.info(`Log reporter initialized${cmsId ? ` (CMS: ${cmsId})` : ''}`);
 
       // Bridge logger output to LogReporter for CMS submission
       registerLogSink(({ level, name, args }: { level: string; name: string; args: any[] }) => {

--- a/packages/stats/src/log-reporter.js
+++ b/packages/stats/src/log-reporter.js
@@ -12,7 +12,7 @@ import { createLogger } from '@xiboplayer/utils';
 const log = createLogger('@xiboplayer/stats');
 
 // IndexedDB configuration
-const DB_NAME = 'xibo-player-logs';
+const DB_BASE = 'xibo-player-logs';
 const DB_VERSION = 1;
 const LOGS_STORE = 'logs';
 
@@ -37,8 +37,12 @@ const LOGS_STORE = 'logs';
  * await reporter.clearSubmittedLogs(logs);
  */
 export class LogReporter {
-  constructor() {
+  /**
+   * @param {string} [cmsId] - Optional CMS ID for namespaced IndexedDB
+   */
+  constructor(cmsId) {
     this.db = null;
+    this._dbName = cmsId ? `${DB_BASE}-${cmsId}` : DB_BASE;
     this._reportedFaults = new Map(); // code -> timestamp (deduplication)
   }
 
@@ -66,7 +70,7 @@ export class LogReporter {
         return;
       }
 
-      const request = indexedDB.open(DB_NAME, DB_VERSION);
+      const request = indexedDB.open(this._dbName, DB_VERSION);
 
       request.onerror = () => {
         const error = new Error(`Failed to open IndexedDB: ${request.error}`);

--- a/packages/stats/src/stats-collector.js
+++ b/packages/stats/src/stats-collector.js
@@ -12,7 +12,7 @@ import { createLogger } from '@xiboplayer/utils';
 const log = createLogger('@xiboplayer/stats');
 
 // IndexedDB configuration
-const DB_NAME = 'xibo-player-stats';
+const DB_BASE = 'xibo-player-stats';
 const DB_VERSION = 1;
 const STATS_STORE = 'stats';
 
@@ -38,8 +38,12 @@ const STATS_STORE = 'stats';
  * await collector.clearSubmittedStats(stats);
  */
 export class StatsCollector {
-  constructor() {
+  /**
+   * @param {string} [cmsId] - Optional CMS ID for namespaced IndexedDB
+   */
+  constructor(cmsId) {
     this.db = null;
+    this._dbName = cmsId ? `${DB_BASE}-${cmsId}` : DB_BASE;
     this.inProgressStats = new Map(); // Track in-progress stats by key
   }
 
@@ -67,7 +71,7 @@ export class StatsCollector {
         return;
       }
 
-      const request = indexedDB.open(DB_NAME, DB_VERSION);
+      const request = indexedDB.open(this._dbName, DB_VERSION);
 
       request.onerror = () => {
         const error = new Error(`Failed to open IndexedDB: ${request.error}`);

--- a/packages/utils/src/config.js
+++ b/packages/utils/src/config.js
@@ -1,14 +1,69 @@
 /**
  * Configuration management with priority: env vars → localStorage → defaults
  *
+ * Storage layout (per-CMS namespacing):
+ *   xibo_global       — device identity: hardwareKey, xmrPubKey, xmrPrivKey
+ *   xibo_cms:{cmsId}  — CMS-scoped: cmsUrl, cmsKey, displayName, xmrChannel, ...
+ *   xibo_active_cms   — string cmsId of the currently active CMS
+ *   xibo_config       — legacy flat key (written for rollback compatibility)
+ *
  * In Node.js (tests, CLI): environment variables are the only source.
  * In browser (PWA player): localStorage is primary, env vars override if set.
  */
 import { generateRsaKeyPair, isValidPemKey } from '@xiboplayer/crypto';
 
-const STORAGE_KEY = 'xibo_config';
+const GLOBAL_KEY = 'xibo_global';         // Device identity (all CMSes)
+const CMS_PREFIX = 'xibo_cms:';           // Per-CMS config prefix
+const ACTIVE_CMS_KEY = 'xibo_active_cms'; // Active CMS ID
 const HW_DB_NAME = 'xibo-hw-backup';
 const HW_DB_VERSION = 1;
+
+// Keys that belong to device identity (global, not CMS-scoped)
+const GLOBAL_KEYS = new Set(['hardwareKey', 'xmrPubKey', 'xmrPrivKey']);
+
+/**
+ * FNV-1a hash producing a 12-character hex string.
+ * Deterministic: same input always produces same output.
+ * @param {string} str - Input string to hash
+ * @returns {string} 12-character lowercase hex string
+ */
+export function fnvHash(str) {
+  let hash = 2166136261; // FNV offset basis
+  for (let i = 0; i < str.length; i++) {
+    hash ^= str.charCodeAt(i);
+    hash += (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24);
+  }
+  hash = hash >>> 0;
+
+  // Extend to 12 chars with a second round using a different seed
+  let hash2 = hash + 1234567;
+  for (let i = 0; i < str.length; i++) {
+    hash2 ^= str.charCodeAt(i) + 1;
+    hash2 += (hash2 << 1) + (hash2 << 4) + (hash2 << 7) + (hash2 << 8) + (hash2 << 24);
+  }
+  hash2 = hash2 >>> 0;
+
+  return (hash.toString(16).padStart(8, '0') + hash2.toString(16).padStart(8, '0')).substring(0, 12);
+}
+
+/**
+ * Compute a deterministic CMS ID from a CMS URL.
+ * Format: {hostname}-{fnvHash12}
+ *
+ * @param {string} cmsUrl - Full CMS URL (e.g. "https://displays.superpantalles.com")
+ * @returns {string} CMS ID (e.g. "displays.superpantalles.com-a1b2c3d4e5f6")
+ */
+export function computeCmsId(cmsUrl) {
+  if (!cmsUrl) return null;
+  try {
+    const url = new URL(cmsUrl);
+    const origin = url.origin;
+    return `${url.hostname}-${fnvHash(origin)}`;
+  } catch (e) {
+    // Invalid URL — hash the raw string
+    return `unknown-${fnvHash(cmsUrl)}`;
+  }
+}
 
 /**
  * Check for environment variable config (highest priority).
@@ -35,6 +90,7 @@ function loadFromEnv() {
 
 export class Config {
   constructor() {
+    this._activeCmsId = null;
     this.data = this.load();
     // Async: try to restore hardware key from IndexedDB if localStorage lost it
     // (only when not running from env vars)
@@ -56,19 +112,63 @@ export class Config {
       return { cmsUrl: '', cmsKey: '', displayName: '', hardwareKey: '', xmrChannel: '' };
     }
 
-    // Try to load from localStorage
-    const json = localStorage.getItem(STORAGE_KEY);
-    let config = {};
+    // Load from split storage (or fresh install)
+    const globalJson = localStorage.getItem(GLOBAL_KEY);
 
-    if (json) {
+    if (globalJson) {
+      return this._loadSplit();
+    }
+
+    // Fresh install — no config at all
+    return this._loadFresh();
+  }
+
+  /**
+   * Load from split storage (new format).
+   * Merges xibo_global + xibo_cms:{activeCmsId} into a single data object.
+   */
+  _loadSplit() {
+    let global = {};
+    try {
+      global = JSON.parse(localStorage.getItem(GLOBAL_KEY) || '{}');
+    } catch (e) {
+      console.error('[Config] Failed to parse xibo_global:', e);
+    }
+
+    // Determine active CMS
+    const activeCmsId = localStorage.getItem(ACTIVE_CMS_KEY) || null;
+    this._activeCmsId = activeCmsId;
+
+    let cmsConfig = {};
+    if (activeCmsId) {
       try {
-        config = JSON.parse(json);
+        const cmsJson = localStorage.getItem(CMS_PREFIX + activeCmsId);
+        if (cmsJson) cmsConfig = JSON.parse(cmsJson);
       } catch (e) {
-        console.error('[Config] Failed to parse localStorage config:', e);
+        console.error('[Config] Failed to parse CMS config:', e);
       }
     }
 
-    // ── Single validation gate (same path for fresh + pre-seeded) ──
+    // Merge global + CMS-scoped
+    const config = { ...global, ...cmsConfig };
+
+    // Validate and generate missing keys
+    return this._validateConfig(config);
+  }
+
+  /**
+   * Fresh install — no existing config.
+   */
+  _loadFresh() {
+    const config = {};
+    return this._validateConfig(config);
+  }
+
+  /**
+   * Validate config, generate missing hardwareKey/xmrChannel.
+   * Shared by all load paths.
+   */
+  _validateConfig(config) {
     let changed = false;
 
     if (!config.hardwareKey || config.hardwareKey.length < 10) {
@@ -91,11 +191,154 @@ export class Config {
     config.cmsKey = config.cmsKey || '';
     config.displayName = config.displayName || '';
 
-    if (changed) {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(config));
+    if (changed && typeof localStorage !== 'undefined') {
+      // Save via split storage
+      this._saveSplit(config);
     }
 
     return config;
+  }
+
+  save() {
+    if (typeof localStorage === 'undefined') return;
+    this._saveSplit(this.data);
+  }
+
+  /**
+   * Write data to split storage: xibo_global + xibo_cms:{id} + legacy xibo_config.
+   */
+  _saveSplit(data) {
+    if (typeof localStorage === 'undefined') return;
+
+    // Split into global and CMS-scoped
+    const global = {};
+    const cmsScoped = {};
+    for (const [key, value] of Object.entries(data)) {
+      if (GLOBAL_KEYS.has(key)) {
+        global[key] = value;
+      } else {
+        cmsScoped[key] = value;
+      }
+    }
+
+    localStorage.setItem(GLOBAL_KEY, JSON.stringify(global));
+
+    // Compute CMS ID (may update if cmsUrl changed)
+    const cmsId = computeCmsId(data.cmsUrl);
+    if (cmsId) {
+      localStorage.setItem(CMS_PREFIX + cmsId, JSON.stringify(cmsScoped));
+      localStorage.setItem(ACTIVE_CMS_KEY, cmsId);
+      this._activeCmsId = cmsId;
+    }
+  }
+
+  /**
+   * Switch to a different CMS. Saves the current CMS profile,
+   * loads (or creates) the target CMS profile.
+   *
+   * @param {string} cmsUrl - New CMS URL to switch to
+   * @returns {{ cmsId: string, isNew: boolean }} The new CMS ID and whether it was newly created
+   */
+  switchCms(cmsUrl) {
+    if (typeof localStorage === 'undefined') {
+      throw new Error('switchCms requires localStorage (browser only)');
+    }
+
+    // Save current state
+    this.save();
+
+    const newCmsId = computeCmsId(cmsUrl);
+    if (!newCmsId) throw new Error('Invalid CMS URL');
+
+    // Try to load existing CMS profile
+    const existingJson = localStorage.getItem(CMS_PREFIX + newCmsId);
+    let cmsConfig = {};
+    let isNew = true;
+
+    if (existingJson) {
+      try {
+        cmsConfig = JSON.parse(existingJson);
+        isNew = false;
+        console.log(`[Config] Switching to existing CMS profile: ${newCmsId}`);
+      } catch (e) {
+        console.error('[Config] Failed to parse target CMS config:', e);
+      }
+    } else {
+      console.log(`[Config] Creating new CMS profile: ${newCmsId}`);
+      cmsConfig = {
+        cmsUrl,
+        cmsKey: '',
+        displayName: '',
+        xmrChannel: this.generateXmrChannel(),
+      };
+      localStorage.setItem(CMS_PREFIX + newCmsId, JSON.stringify(cmsConfig));
+    }
+
+    // Update active CMS
+    localStorage.setItem(ACTIVE_CMS_KEY, newCmsId);
+    this._activeCmsId = newCmsId;
+
+    // Merge global + new CMS config into data
+    let global = {};
+    try {
+      global = JSON.parse(localStorage.getItem(GLOBAL_KEY) || '{}');
+    } catch (_) {}
+
+    this.data = { ...global, ...cmsConfig };
+
+    // Ensure cmsUrl is set (in case the profile was pre-existing without it)
+    if (!this.data.cmsUrl) {
+      this.data.cmsUrl = cmsUrl;
+    }
+
+    return { cmsId: newCmsId, isNew };
+  }
+
+  /**
+   * List all CMS profiles stored in localStorage.
+   * @returns {Array<{ cmsId: string, cmsUrl: string, displayName: string, isActive: boolean }>}
+   */
+  listCmsProfiles() {
+    if (typeof localStorage === 'undefined') return [];
+
+    const profiles = [];
+    const activeCmsId = localStorage.getItem(ACTIVE_CMS_KEY) || null;
+
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (!key.startsWith(CMS_PREFIX)) continue;
+
+      const cmsId = key.slice(CMS_PREFIX.length);
+      try {
+        const data = JSON.parse(localStorage.getItem(key));
+        profiles.push({
+          cmsId,
+          cmsUrl: data.cmsUrl || '',
+          displayName: data.displayName || '',
+          isActive: cmsId === activeCmsId,
+        });
+      } catch (_) {}
+    }
+
+    return profiles;
+  }
+
+  /**
+   * Get the active CMS ID (deterministic hash of the CMS URL origin).
+   * Returns null if no CMS is configured.
+   * @returns {string|null}
+   */
+  get activeCmsId() {
+    // Return cached value if available
+    if (this._activeCmsId) return this._activeCmsId;
+    // Compute from current cmsUrl
+    const id = computeCmsId(this.data?.cmsUrl);
+    this._activeCmsId = id;
+    return id;
+  }
+
+  isConfigured() {
+    return !!(this.data.cmsUrl && this.data.cmsKey && this.data.displayName);
   }
 
   /**
@@ -177,16 +420,6 @@ export class Config {
     } catch (e) {
       // IndexedDB not available — that's fine
     }
-  }
-
-  save() {
-    if (typeof localStorage !== 'undefined') {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(this.data));
-    }
-  }
-
-  isConfigured() {
-    return !!(this.data.cmsUrl && this.data.cmsKey && this.data.displayName);
   }
 
   generateStableHardwareKey() {

--- a/packages/utils/src/config.test.js
+++ b/packages/utils/src/config.test.js
@@ -1,7 +1,8 @@
 /**
  * Config Tests
  *
- * Tests for configuration management with localStorage persistence
+ * Tests for configuration management with split localStorage persistence
+ * (xibo_global + xibo_cms:{cmsId} + xibo_active_cms)
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -24,7 +25,27 @@ vi.mock('@xiboplayer/crypto', () => {
   };
 });
 
-import { Config } from './config.js';
+import { Config, computeCmsId, fnvHash } from './config.js';
+
+/**
+ * Seed split localStorage with a full config (global + CMS-scoped).
+ * Helper to set up pre-existing config in the new format.
+ */
+function seedConfig(storage, data) {
+  const GLOBAL_KEYS = new Set(['hardwareKey', 'xmrPubKey', 'xmrPrivKey']);
+  const global = {};
+  const cms = {};
+  for (const [k, v] of Object.entries(data)) {
+    if (GLOBAL_KEYS.has(k)) global[k] = v;
+    else cms[k] = v;
+  }
+  storage.setItem('xibo_global', JSON.stringify(global));
+  const cmsId = computeCmsId(data.cmsUrl);
+  if (cmsId) {
+    storage.setItem(`xibo_cms:${cmsId}`, JSON.stringify(cms));
+    storage.setItem('xibo_active_cms', cmsId);
+  }
+}
 
 describe('Config', () => {
   let config;
@@ -32,7 +53,7 @@ describe('Config', () => {
   let mockRandomUUID;
 
   beforeEach(() => {
-    // Mock localStorage
+    // Mock localStorage (with key/length for iteration in listCmsProfiles)
     mockLocalStorage = {
       data: {},
       getItem(key) {
@@ -46,6 +67,12 @@ describe('Config', () => {
       },
       clear() {
         this.data = {};
+      },
+      key(index) {
+        return Object.keys(this.data)[index] || null;
+      },
+      get length() {
+        return Object.keys(this.data).length;
       }
     };
 
@@ -91,14 +118,14 @@ describe('Config', () => {
       expect(hwKey).toBe('pwa-1234567812344567890123456789');
     });
 
-    it('should save config to localStorage on creation', () => {
+    it('should save config to split localStorage on creation', () => {
       config = new Config();
 
-      const stored = JSON.parse(mockLocalStorage.getItem('xibo_config'));
-      expect(stored).toEqual(config.data);
+      const global = JSON.parse(mockLocalStorage.getItem('xibo_global'));
+      expect(global.hardwareKey).toBe(config.data.hardwareKey);
     });
 
-    it('should load existing config from localStorage', () => {
+    it('should load existing config from split localStorage', () => {
       const existingConfig = {
         cmsUrl: 'https://test.cms.com',
         cmsKey: 'test-key',
@@ -107,23 +134,25 @@ describe('Config', () => {
         xmrChannel: '12345678-1234-4567-8901-234567890abc'
       };
 
-      mockLocalStorage.setItem('xibo_config', JSON.stringify(existingConfig));
+      seedConfig(mockLocalStorage, existingConfig);
 
       config = new Config();
 
-      expect(config.data).toEqual(existingConfig);
+      expect(config.data.cmsUrl).toBe('https://test.cms.com');
+      expect(config.data.cmsKey).toBe('test-key');
+      expect(config.data.displayName).toBe('Test Display');
+      expect(config.data.hardwareKey).toBe('pwa-existinghardwarekey1234567');
+      expect(config.data.xmrChannel).toBe('12345678-1234-4567-8901-234567890abc');
     });
 
     it('should regenerate hardware key if invalid in stored config', () => {
-      const invalidConfig = {
+      seedConfig(mockLocalStorage, {
         cmsUrl: 'https://test.cms.com',
         cmsKey: 'test-key',
         displayName: 'Test Display',
         hardwareKey: 'short', // Invalid: too short
         xmrChannel: '12345678-1234-4567-8901-234567890abc'
-      };
-
-      mockLocalStorage.setItem('xibo_config', JSON.stringify(invalidConfig));
+      });
 
       config = new Config();
 
@@ -132,7 +161,7 @@ describe('Config', () => {
     });
 
     it('should handle corrupted JSON in localStorage', () => {
-      mockLocalStorage.setItem('xibo_config', 'invalid-json{');
+      mockLocalStorage.setItem('xibo_global', 'invalid-json{');
 
       config = new Config();
 
@@ -307,11 +336,12 @@ describe('Config', () => {
       expect(config.data.cmsUrl).toBe('https://new.cms.com');
     });
 
-    it('should save to localStorage when cmsUrl set', () => {
+    it('should save to split localStorage when cmsUrl set', () => {
       config.cmsUrl = 'https://test.com';
 
-      const stored = JSON.parse(mockLocalStorage.getItem('xibo_config'));
-      expect(stored.cmsUrl).toBe('https://test.com');
+      const cmsId = computeCmsId('https://test.com');
+      const cms = JSON.parse(mockLocalStorage.getItem(`xibo_cms:${cmsId}`));
+      expect(cms.cmsUrl).toBe('https://test.com');
     });
 
     it('should get/set cmsKey', () => {
@@ -383,22 +413,24 @@ describe('Config', () => {
       config = new Config();
     });
 
-    it('should save current config to localStorage', () => {
+    it('should save current config to split localStorage', () => {
       config.data.cmsUrl = 'https://manual.com';
       config.data.cmsKey = 'manual-key';
 
       config.save();
 
-      const stored = JSON.parse(mockLocalStorage.getItem('xibo_config'));
-      expect(stored.cmsUrl).toBe('https://manual.com');
-      expect(stored.cmsKey).toBe('manual-key');
+      const cmsId = computeCmsId('https://manual.com');
+      const cms = JSON.parse(mockLocalStorage.getItem(`xibo_cms:${cmsId}`));
+      expect(cms.cmsUrl).toBe('https://manual.com');
+      expect(cms.cmsKey).toBe('manual-key');
     });
 
     it('should auto-save when setters used', () => {
       config.cmsUrl = 'https://auto.com';
 
-      const stored = JSON.parse(mockLocalStorage.getItem('xibo_config'));
-      expect(stored.cmsUrl).toBe('https://auto.com');
+      const cmsId = computeCmsId('https://auto.com');
+      const cms = JSON.parse(mockLocalStorage.getItem(`xibo_cms:${cmsId}`));
+      expect(cms.cmsUrl).toBe('https://auto.com');
     });
   });
 
@@ -419,12 +451,12 @@ describe('Config', () => {
 
   describe('Edge Cases', () => {
     it('should handle missing hardwareKey in loaded config', () => {
-      mockLocalStorage.setItem('xibo_config', JSON.stringify({
+      seedConfig(mockLocalStorage, {
         cmsUrl: 'https://test.com',
         cmsKey: 'test-key',
         displayName: 'Test'
         // hardwareKey missing
-      }));
+      });
 
       config = new Config();
 
@@ -433,13 +465,13 @@ describe('Config', () => {
     });
 
     it('should handle null values in config', () => {
-      mockLocalStorage.setItem('xibo_config', JSON.stringify({
+      seedConfig(mockLocalStorage, {
         cmsUrl: null,
         cmsKey: null,
         displayName: null,
         hardwareKey: 'pwa-1234567812344567890123456789',
         xmrChannel: '12345678-1234-4567-8901-234567890abc'
-      }));
+      });
 
       config = new Config();
 
@@ -506,12 +538,12 @@ describe('Config', () => {
       expect(config.data.xmrPrivKey).toMatch(/^-----BEGIN PRIVATE KEY-----/);
     });
 
-    it('should persist keys to localStorage', async () => {
+    it('should persist keys to xibo_global', async () => {
       await config.ensureXmrKeyPair();
 
-      const stored = JSON.parse(mockLocalStorage.getItem('xibo_config'));
-      expect(stored.xmrPubKey).toMatch(/^-----BEGIN PUBLIC KEY-----/);
-      expect(stored.xmrPrivKey).toMatch(/^-----BEGIN PRIVATE KEY-----/);
+      const global = JSON.parse(mockLocalStorage.getItem('xibo_global'));
+      expect(global.xmrPubKey).toMatch(/^-----BEGIN PUBLIC KEY-----/);
+      expect(global.xmrPrivKey).toMatch(/^-----BEGIN PRIVATE KEY-----/);
     });
 
     it('should be idempotent — second call preserves existing keys', async () => {
@@ -577,6 +609,190 @@ describe('Config', () => {
       await config.ensureXmrKeyPair();
 
       expect(config.xmrPrivKey).toMatch(/^-----BEGIN PRIVATE KEY-----/);
+    });
+  });
+
+  describe('Per-CMS Namespacing', () => {
+    describe('fnvHash()', () => {
+      it('should produce 12-char hex string', () => {
+        expect(fnvHash('test')).toMatch(/^[0-9a-f]{12}$/);
+      });
+
+      it('should be deterministic', () => {
+        expect(fnvHash('hello')).toBe(fnvHash('hello'));
+      });
+
+      it('should differ for different inputs', () => {
+        expect(fnvHash('hello')).not.toBe(fnvHash('world'));
+      });
+    });
+
+    describe('computeCmsId()', () => {
+      it('should produce hostname-hash format', () => {
+        const id = computeCmsId('https://displays.superpantalles.com');
+        expect(id).toMatch(/^displays\.superpantalles\.com-[0-9a-f]{12}$/);
+      });
+
+      it('should handle localhost with port', () => {
+        const id = computeCmsId('http://localhost:8080');
+        expect(id).toMatch(/^localhost-[0-9a-f]{12}$/);
+      });
+
+      it('should return null for empty URL', () => {
+        expect(computeCmsId('')).toBeNull();
+        expect(computeCmsId(null)).toBeNull();
+        expect(computeCmsId(undefined)).toBeNull();
+      });
+
+      it('should be deterministic for same URL', () => {
+        const id1 = computeCmsId('https://cms.example.com');
+        const id2 = computeCmsId('https://cms.example.com');
+        expect(id1).toBe(id2);
+      });
+
+      it('should differ for different URLs', () => {
+        const id1 = computeCmsId('https://cms1.example.com');
+        const id2 = computeCmsId('https://cms2.example.com');
+        expect(id1).not.toBe(id2);
+      });
+
+      it('should handle invalid URL gracefully', () => {
+        const id = computeCmsId('not-a-url');
+        expect(id).toMatch(/^unknown-[0-9a-f]{12}$/);
+      });
+    });
+
+    describe('activeCmsId', () => {
+      it('should return null when no CMS configured', () => {
+        config = new Config();
+        expect(config.activeCmsId).toBeNull();
+      });
+
+      it('should return CMS ID when configured', () => {
+        seedConfig(mockLocalStorage, {
+          cmsUrl: 'https://test.cms.com',
+          cmsKey: 'key',
+          displayName: 'Test',
+          hardwareKey: 'pwa-existinghardwarekey1234567',
+          xmrChannel: '12345678-1234-4567-8901-234567890abc',
+        });
+
+        config = new Config();
+        expect(config.activeCmsId).toBe(computeCmsId('https://test.cms.com'));
+      });
+    });
+
+    describe('switchCms()', () => {
+      it('should switch to a new CMS and preserve hardwareKey', () => {
+        seedConfig(mockLocalStorage, {
+          cmsUrl: 'https://cms1.com',
+          cmsKey: 'key1',
+          displayName: 'Display on CMS1',
+          hardwareKey: 'pwa-existinghardwarekey1234567',
+          xmrChannel: '12345678-1234-4567-8901-234567890abc',
+        });
+
+        config = new Config();
+        const hwKey = config.hardwareKey;
+
+        const result = config.switchCms('https://cms2.com');
+
+        expect(result.isNew).toBe(true);
+        expect(result.cmsId).toBe(computeCmsId('https://cms2.com'));
+        expect(config.hardwareKey).toBe(hwKey); // Same device identity
+        expect(config.cmsUrl).toBe('https://cms2.com');
+        expect(config.cmsKey).toBe(''); // New CMS, no key yet
+      });
+
+      it('should switch back to a previously known CMS', () => {
+        seedConfig(mockLocalStorage, {
+          cmsUrl: 'https://cms1.com',
+          cmsKey: 'key1',
+          displayName: 'Display on CMS1',
+          hardwareKey: 'pwa-existinghardwarekey1234567',
+          xmrChannel: '12345678-1234-4567-8901-234567890abc',
+        });
+
+        config = new Config();
+
+        // Switch to CMS2
+        config.switchCms('https://cms2.com');
+        config.cmsKey = 'key2';
+        config.displayName = 'Display on CMS2';
+
+        // Switch back to CMS1
+        const result = config.switchCms('https://cms1.com');
+
+        expect(result.isNew).toBe(false);
+        expect(config.cmsKey).toBe('key1');
+        expect(config.displayName).toBe('Display on CMS1');
+      });
+    });
+
+    describe('listCmsProfiles()', () => {
+      it('should list all CMS profiles', () => {
+        seedConfig(mockLocalStorage, {
+          cmsUrl: 'https://cms1.com',
+          cmsKey: 'key1',
+          displayName: 'Display 1',
+          hardwareKey: 'pwa-existinghardwarekey1234567',
+          xmrChannel: '12345678-1234-4567-8901-234567890abc',
+        });
+
+        config = new Config();
+        config.switchCms('https://cms2.com');
+        config.displayName = 'Display 2';
+        config.save();
+
+        const profiles = config.listCmsProfiles();
+
+        expect(profiles.length).toBe(2);
+        expect(profiles.find(p => p.cmsUrl === 'https://cms1.com')).toBeTruthy();
+        expect(profiles.find(p => p.cmsUrl === 'https://cms2.com')).toBeTruthy();
+        // Only one should be active
+        expect(profiles.filter(p => p.isActive).length).toBe(1);
+      });
+    });
+
+    describe('Split storage save/load', () => {
+      it('should write split keys on save', () => {
+        config = new Config();
+        config.data.cmsUrl = 'https://test.com';
+        config.data.cmsKey = 'k';
+        config.save();
+
+        // Global key should exist
+        expect(mockLocalStorage.getItem('xibo_global')).toBeTruthy();
+        // CMS key should exist
+        const cmsId = computeCmsId('https://test.com');
+        expect(mockLocalStorage.getItem(`xibo_cms:${cmsId}`)).toBeTruthy();
+
+        // Global should have hardwareKey, not cmsUrl
+        const global = JSON.parse(mockLocalStorage.getItem('xibo_global'));
+        expect(global.hardwareKey).toBeTruthy();
+        expect(global.cmsUrl).toBeUndefined();
+
+        // CMS should have cmsUrl, not hardwareKey
+        const cms = JSON.parse(mockLocalStorage.getItem(`xibo_cms:${cmsId}`));
+        expect(cms.cmsUrl).toBe('https://test.com');
+        expect(cms.hardwareKey).toBeUndefined();
+      });
+
+      it('should reload from split storage correctly', () => {
+        // Write config
+        config = new Config();
+        config.data.cmsUrl = 'https://reload.com';
+        config.data.cmsKey = 'reload-key';
+        config.data.displayName = 'Reload Test';
+        config.save();
+
+        // Reload
+        const config2 = new Config();
+        expect(config2.cmsUrl).toBe('https://reload.com');
+        expect(config2.cmsKey).toBe('reload-key');
+        expect(config2.displayName).toBe('Reload Test');
+        expect(config2.hardwareKey).toBe(config.hardwareKey);
+      });
     });
   });
 });

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -4,7 +4,7 @@ export const VERSION = pkg.version;
 export { createLogger, setLogLevel, getLogLevel, isDebug, applyCmsLogLevel, mapCmsLogLevel, registerLogSink, unregisterLogSink, LOG_LEVELS } from './logger.js';
 export { EventEmitter } from './event-emitter.js';
 import { config as _config } from './config.js';
-export { config, SHELL_ONLY_KEYS, extractPwaConfig } from './config.js';
+export { config, SHELL_ONLY_KEYS, extractPwaConfig, computeCmsId, fnvHash } from './config.js';
 export { fetchWithRetry } from './fetch-retry.js';
 export { CmsApiClient, CmsApiError } from './cms-api.js';
 


### PR DESCRIPTION
## Summary

- Namespace config and cache by CMS server so switching CMS doesn't cause media ID collisions, cache invalidation, or identity confusion
- Split localStorage into `xibo_global` (device identity) + `xibo_cms:{cmsId}` (CMS-scoped) + `xibo_active_cms`
- Add `computeCmsId(cmsUrl)` — deterministic `{hostname}-{fnvHash12}` from URL origin
- Add `Config.switchCms()` and `listCmsProfiles()` for multi-CMS management
- Namespace IndexedDB databases per CMS (offline cache, stats, logs)
- Namespace proxy ContentStore path: `cache/{cmsId}/media/`
- Wire `cmsId` through PWA main → PlayerCore, StatsCollector, LogReporter

## Shell changes (separate repos)

Electron (`xiboplayer-electron/src/main.js`) and Chromium (`xiboplayer-chromium/xiboplayer/server/server.js`) both compute and inject `pwaConfig.cmsId` — to be committed in their respective repos.

## Test plan

- [x] All 1403 SDK tests pass
- [ ] Electron: start with config.json, verify `pwaConfig.cmsId` is injected
- [ ] Chromium: same verification
- [ ] Switch CMS URL, verify hardwareKey unchanged and new CMS profile created
- [ ] Verify ContentStore creates CMS-namespaced directory (`cache/{cmsId}/media/`)

Closes #142