### PR TITLE
docs: config system documentation and platform-specific key validation

### DIFF
--- a/packages/docs/CONFIGURATION.md
+++ b/packages/docs/CONFIGURATION.md
@@ -24,6 +24,24 @@ On first run (RPM/DEB install), the system default from `/usr/share/xiboplayer-*
 
 These are set automatically by the PWA setup page on first run.
 
+### Per-CMS Storage
+
+The player supports connecting to multiple CMS servers. Configuration and media caches are stored per-CMS so switching between servers doesn't lose data or require re-registration.
+
+**Storage layout** (in `localStorage`):
+
+| Key                    | Contents                                            |
+|------------------------|-----------------------------------------------------|
+| `xibo_global`          | Device identity: `hardwareKey`, `xmrPubKey`, `xmrPrivKey` |
+| `xibo_cms:{cmsId}`     | CMS-scoped: `cmsUrl`, `cmsKey`, `displayName`, `xmrChannel` |
+| `xibo_active_cms`      | String `cmsId` of the currently active CMS          |
+
+The `cmsId` is a deterministic hash of the CMS URL origin (format: `{hostname}-{fnvHash12}`), e.g. `displays.superpantalles.com-a1b2c3d4e5f6`.
+
+Global keys (`hardwareKey`, RSA keys) identify the physical display and never change — the same device presents the same identity to every CMS. CMS-scoped keys are preserved per server, so switching back restores previous registration.
+
+See [PER_CMS_CACHE.md](PER_CMS_CACHE.md) for the full design rationale and cache directory layout.
+
 ### Server
 
 | Key          | Type   | Default          | Description                          |
@@ -40,6 +58,12 @@ These are set automatically by the PWA setup page on first run.
 | `preventSleep`    | boolean | `true`  | Disable screen blanking and DPMS             |
 | `width`           | number  | `1920`  | Window width (when not fullscreen/kiosk)      |
 | `height`          | number  | `1080`  | Window height (when not fullscreen/kiosk)     |
+
+### Security
+
+| Key              | Type    | Default | Description                                  |
+|------------------|---------|---------|----------------------------------------------|
+| `relaxSslCerts`  | boolean | `true`  | Disable SSL certificate verification for CMS connections. Useful for self-signed certificates. Shell-only — does not reach the PWA. |
 
 ### Logging
 
@@ -64,6 +88,15 @@ You can also set the log level at runtime in the browser DevTools console:
 localStorage.setItem('xibo_log_level', 'DEBUG');
 location.reload();
 ```
+
+#### Debug Object
+
+| Key                       | Type    | Default | Description                                  |
+|---------------------------|---------|---------|----------------------------------------------|
+| `debug.consoleLogs`       | boolean | `false` | Forward browser console output to the proxy server's stdout. Useful for headless debugging. |
+| `debug.consoleLogsInterval` | number | `10`  | Batch flush interval in seconds for forwarded console logs. |
+
+When `debug.consoleLogs` is enabled, the PWA batches `console.*` calls and POSTs them to the proxy at the configured interval. The proxy prints them to stdout, making browser logs visible in shell/journal output.
 
 ### Player Controls & Overlays
 
@@ -97,9 +130,10 @@ The `controls` object has two sub-sections:
 
 ### Transport
 
-| Key           | Type   | Default  | Description                          |
-|---------------|--------|----------|--------------------------------------|
-| `transport`   | string | `"auto"` | CMS transport: `auto`, `rest`, `soap` |
+| Key              | Type   | Default             | Description                          |
+|------------------|--------|---------------------|--------------------------------------|
+| `transport`      | string | `"auto"`            | CMS transport: `auto`, `rest`, `soap` |
+| `playerApiBase`  | string | `"/api/v2/player"`  | Base path for the REST Player API. Override if the CMS uses a custom route prefix. |
 
 ### Geolocation
 
@@ -120,6 +154,49 @@ The `controls` object has two sub-sections:
 |--------------|---------|---------|--------------------------------------|
 | `autoLaunch` | boolean | `false` | Auto-start on login (registers with OS autostart) |
 
+## Platform Support Matrix
+
+Not all keys apply to every platform. Shell-only keys are filtered out by `extractPwaConfig()` and never reach the PWA.
+
+| Key                 | PWA | Electron | Chromium | Notes                    |
+|---------------------|-----|----------|----------|--------------------------|
+| `cmsUrl`            | yes | yes      | yes      |                          |
+| `cmsKey`            | yes | yes      | yes      |                          |
+| `displayName`       | yes | yes      | yes      |                          |
+| `serverPort`        | —   | yes      | yes      | Shell-only               |
+| `kioskMode`         | —   | yes      | yes      | Shell-only               |
+| `fullscreen`        | —   | yes      | yes      | Shell-only               |
+| `hideMouseCursor`   | —   | yes      | yes      | Shell-only               |
+| `preventSleep`      | —   | yes      | yes      | Shell-only               |
+| `width` / `height`  | —   | yes      | yes      | Shell-only               |
+| `relaxSslCerts`     | —   | yes      | yes      | Shell-only               |
+| `logLevel`          | yes | yes      | yes      |                          |
+| `debug`             | yes | yes      | yes      | Passes through to PWA    |
+| `controls`          | yes | yes      | yes      |                          |
+| `transport`         | yes | yes      | yes      |                          |
+| `playerApiBase`     | yes | yes      | yes      |                          |
+| `googleGeoApiKey`   | yes | yes      | yes      |                          |
+| `autoLaunch`        | —   | yes      | —        | Electron-only            |
+| `browser`           | —   | —        | yes      | Chromium-only            |
+| `extraBrowserFlags` | —   | —        | yes      | Chromium-only            |
+
+A runtime warning is logged when a platform-specific key is set in the wrong shell's `config.json` (e.g. `browser` in Electron config). These warnings are informational only and do not prevent startup.
+
+## Environment Variables
+
+Environment variables are the highest-priority config source. They are used in Node.js contexts (tests, CI) and override all other sources.
+
+| Env Variable       | Maps to           | Description                          |
+|--------------------|-------------------|--------------------------------------|
+| `CMS_URL`          | `cmsUrl`          | CMS base URL                         |
+| `CMS_KEY`          | `cmsKey`          | CMS server key                       |
+| `DISPLAY_NAME`     | `displayName`     | Display name                         |
+| `HARDWARE_KEY`     | `hardwareKey`     | Hardware key (for test fixtures)     |
+| `XMR_CHANNEL`      | `xmrChannel`      | XMR channel UUID                     |
+| `GOOGLE_GEO_API_KEY` | `googleGeoApiKey` | Google Geolocation API key         |
+
+In the browser (PWA), `localStorage` is the primary source; env vars are not available.
+
 ## Example: Debugging Config
 
 ```json
@@ -132,6 +209,10 @@ The `controls` object has two sub-sections:
   "fullscreen": false,
   "hideMouseCursor": false,
   "logLevel": "DEBUG",
+
+  "debug": {
+    "consoleLogs": true
+  },
 
   "controls": {
     "keyboard": {

--- a/packages/docs/PER_CMS_CACHE.md
+++ b/packages/docs/PER_CMS_CACHE.md
@@ -31,11 +31,11 @@ RSA keys (`xmrPubKey`, `xmrPrivKey`) are tied to the `hardwareKey` and used for 
 | `googleGeoApiKey` | localStorage | **No** | API key is display-level, not CMS-specific |
 | Media cache | Filesystem | **Yes** | Media IDs are CMS-scoped, collide across servers |
 
-## Proposed Solution
+## Implementation
 
 ### 1. Per-CMS Media Cache
 
-Namespace the cache directory by a CMS origin identifier derived from the CMS URL.
+The cache directory is namespaced by a CMS origin identifier derived from the CMS URL.
 
 #### Directory Structure
 
@@ -51,45 +51,24 @@ Where `{cms-id}` is `{hostname}-{sha256-first-12}`, e.g.:
 
 The human-readable hostname prefix makes it easy to identify directories when debugging. The hash suffix ensures uniqueness even if two CMS instances share a hostname on different ports.
 
-#### Key Change Point
-
-In `proxy.js` (line ~257), the store is currently created as:
-
-```js
-new ContentStore(path.join(dataDir, 'media'))
-```
-
-This becomes:
-
-```js
-const cmsId = computeCmsId(cmsConfig.cmsUrl);
-new ContentStore(path.join(dataDir, 'cache', cmsId, 'media'))
-```
-
 ### 2. Per-CMS Config
 
-Change `localStorage` from a single `xibo_config` key to a namespaced structure:
+`localStorage` uses a namespaced structure:
 
 ```
-Current:   localStorage['xibo_config'] = { cmsUrl, cmsKey, displayName, hardwareKey, ... }
-
-Proposed:  localStorage['xibo_global']  = { hardwareKey, xmrPubKey, xmrPrivKey, googleGeoApiKey }
-           localStorage['xibo_cms:{cms-id}'] = { cmsUrl, cmsKey, displayName, xmrChannel }
-           localStorage['xibo_active_cms'] = '{cms-id}'
+localStorage['xibo_global']          = { hardwareKey, xmrPubKey, xmrPrivKey }
+localStorage['xibo_cms:{cms-id}']    = { cmsUrl, cmsKey, displayName, xmrChannel }
+localStorage['xibo_active_cms']      = '{cms-id}'
 ```
 
-#### Config class changes
+The `Config` class (`packages/utils/src/config.js`):
 
-The `Config` class (`packages/utils/src/config.js`) needs to:
+1. `load()` reads global keys from `xibo_global` and CMS-specific keys from `xibo_cms:{active-cms-id}`
+2. `save()` writes to the appropriate key based on the `GLOBAL_KEYS` set
+3. `switchCms(cmsUrl)` saves the current CMS profile, loads (or creates) the target CMS profile, and updates `xibo_active_cms`
+4. `listCmsProfiles()` returns all known CMS configs
 
-1. Split `load()` to read global keys from `xibo_global` and CMS-specific keys from `xibo_cms:{active-cms-id}`
-2. Split `save()` to write to the appropriate key based on which property changed
-3. Add `switchCms(cmsUrl)` method that:
-   - Saves current CMS-specific config
-   - Computes `cms-id` for the new CMS URL
-   - Loads existing config for that CMS (if previously registered) or starts fresh
-   - Updates `xibo_active_cms`
-4. Add `listCmsProfiles()` method that returns all known CMS configs
+See [CONFIGURATION.md](CONFIGURATION.md) for the full key reference and platform support matrix.
 
 ## Files Affected
 

--- a/packages/utils/src/config.js
+++ b/packages/utils/src/config.js
@@ -582,6 +582,37 @@ export const config = new Config();
  * Electron extras:  autoLaunch
  * Chromium extras:  browser, extraBrowserFlags
  */
+/**
+ * Keys that are specific to a particular shell platform.
+ * Used by warnPlatformMismatch() to detect config.json mistakes.
+ */
+const PLATFORM_KEYS = {
+  kioskMode:        ['electron', 'chromium'],
+  autoLaunch:       ['electron'],
+  browser:          ['chromium'],
+  extraBrowserFlags: ['chromium'],
+};
+
+/**
+ * Log warnings for config keys that don't belong to the current platform.
+ * Informational only — does not prevent startup.
+ *
+ * @param {Object} configObj - The full config.json object
+ * @param {string} platform - Current platform: 'electron' or 'chromium'
+ */
+export function warnPlatformMismatch(configObj, platform) {
+  if (!configObj || !platform) return;
+  const p = platform.toLowerCase();
+  for (const [key, platforms] of Object.entries(PLATFORM_KEYS)) {
+    if (key in configObj && !platforms.includes(p)) {
+      console.warn(
+        `[Config] Key "${key}" is only supported on ${platforms.join('/')}, ` +
+        `but current platform is ${p} — this key will be ignored`
+      );
+    }
+  }
+}
+
 export const SHELL_ONLY_KEYS = new Set([
   'serverPort',
   'kioskMode',

--- a/packages/utils/src/config.test.js
+++ b/packages/utils/src/config.test.js
@@ -25,7 +25,7 @@ vi.mock('@xiboplayer/crypto', () => {
   };
 });
 
-import { Config, computeCmsId, fnvHash } from './config.js';
+import { Config, computeCmsId, fnvHash, warnPlatformMismatch } from './config.js';
 
 /**
  * Seed split localStorage with a full config (global + CMS-scoped).
@@ -609,6 +609,53 @@ describe('Config', () => {
       await config.ensureXmrKeyPair();
 
       expect(config.xmrPrivKey).toMatch(/^-----BEGIN PRIVATE KEY-----/);
+    });
+  });
+
+  describe('warnPlatformMismatch()', () => {
+    let warnSpy;
+
+    beforeEach(() => {
+      warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it('should warn when Chromium-only key is used in Electron', () => {
+      warnPlatformMismatch({ browser: 'chrome', cmsUrl: 'https://test.com' }, 'electron');
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain('browser');
+      expect(warnSpy.mock.calls[0][0]).toContain('chromium');
+    });
+
+    it('should warn when Electron-only key is used in Chromium', () => {
+      warnPlatformMismatch({ autoLaunch: true }, 'chromium');
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain('autoLaunch');
+      expect(warnSpy.mock.calls[0][0]).toContain('electron');
+    });
+
+    it('should not warn for shared keys', () => {
+      warnPlatformMismatch({ kioskMode: true, cmsUrl: 'https://test.com' }, 'electron');
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('should not warn when config or platform is missing', () => {
+      warnPlatformMismatch(null, 'electron');
+      warnPlatformMismatch({ browser: 'chrome' }, '');
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('should warn for multiple mismatched keys', () => {
+      warnPlatformMismatch({ browser: 'chrome', extraBrowserFlags: '--flag' }, 'electron');
+
+      expect(warnSpy).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -4,7 +4,7 @@ export const VERSION = pkg.version;
 export { createLogger, setLogLevel, getLogLevel, isDebug, applyCmsLogLevel, mapCmsLogLevel, registerLogSink, unregisterLogSink, LOG_LEVELS } from './logger.js';
 export { EventEmitter } from './event-emitter.js';
 import { config as _config } from './config.js';
-export { config, SHELL_ONLY_KEYS, extractPwaConfig, computeCmsId, fnvHash } from './config.js';
+export { config, SHELL_ONLY_KEYS, extractPwaConfig, computeCmsId, fnvHash, warnPlatformMismatch } from './config.js';
 export { fetchWithRetry } from './fetch-retry.js';
 export { CmsApiClient, CmsApiError } from './cms-api.js';
 


### PR DESCRIPTION
## Summary

Closes #204.

- **CONFIGURATION.md**: Added missing keys (`relaxSslCerts`, `debug.consoleLogs`, `debug.consoleLogsInterval`, `playerApiBase`), per-CMS storage section, platform support matrix (key × PWA/Electron/Chromium), and environment variables reference
- **config.js**: Added `warnPlatformMismatch()` — runtime warnings when platform-specific keys are used in the wrong shell (e.g. `browser` in Electron config)
- **PER_CMS_CACHE.md**: Updated language from "Proposed Solution" to "Implementation" since the feature is already shipped
- **config.json.example** (Electron + Chromium): Added `debug: { consoleLogs: false }` block — these are in separate repos, will follow up there

## Test plan

- [x] `pnpm test` — all 1408 tests pass (5 new tests for `warnPlatformMismatch`)
- [ ] Review CONFIGURATION.md for completeness against config.js audit
- [ ] Verify platform matrix matches `SHELL_ONLY_KEYS` and `extractPwaConfig()` logic