### PR TITLE
fix: use exact video duration instead of Math.floor truncation

### DIFF
--- a/packages/pwa/src/main.ts
+++ b/packages/pwa/src/main.ts
@@ -1984,7 +1984,7 @@ class PwaPlayer {
       };
 
       video.addEventListener('loadedmetadata', () => {
-        const dur = Math.floor(video.duration);
+        const dur = video.duration;
         cleanup();
         resolve(dur);
       }, { once: true });

--- a/packages/renderer/src/renderer-lite.js
+++ b/packages/renderer/src/renderer-lite.js
@@ -2151,7 +2151,7 @@ export class RendererLite {
     // NOT update the current layout's duration with a different layout's video.
     const createdForLayoutId = this.currentLayoutId;
     const onLoadedMetadata = () => {
-      const videoDuration = Math.floor(video.duration);
+      const videoDuration = video.duration;
       this.log.info(`Video ${storedAs} duration detected: ${videoDuration}s`);
 
       if (widget.duration === 0 || widget.useDuration === 0) {


### PR DESCRIPTION
## Summary

Fixes #214 — `Math.floor(video.duration)` truncates fractional seconds, causing the layout timer to fire up to ~1s before the video actually ends.

Two call sites:
- `packages/pwa/src/main.ts` — background video probe
- `packages/renderer/src/renderer-lite.js` — live `loadedmetadata`

Both now use `video.duration` directly. `setTimeout` handles fractional milliseconds, and display formatting already rounds for UI purposes.

## Test plan
- [x] 1387 tests passing (1 pre-existing flaky test in download-manager unrelated)
- [ ] Visual: verify video plays to completion before layout transition