### PR TITLE
feat: shell command execution from CMS (#202)

### DIFF
--- a/packages/docs/CONFIGURATION.md
+++ b/packages/docs/CONFIGURATION.md
@@ -148,12 +148,17 @@ The `controls` object has two sub-sections:
 | `browser`           | string | `"chromium"` | Browser binary: `chromium`, `chrome`, or a custom path |
 | `extraBrowserFlags` | string | `""`         | Additional Chromium command-line flags (space-separated) |
 
+### Shell Commands
+
+| Key                  | Type    | Default | Description                          |
+|----------------------|---------|---------|--------------------------------------|
+| `allowShellCommands` | boolean | `false` | Allow CMS to execute shell commands on this display. **Security-sensitive** — only enable on trusted networks. Commands are sent via XMR or embedded in layout widgets. 30-second timeout per command. Electron uses IPC; Chromium uses an HTTP endpoint on the proxy server. |
+
 ### Electron-only
 
 | Key                  | Type    | Default | Description                          |
 |----------------------|---------|---------|--------------------------------------|
 | `autoLaunch`         | boolean | `false` | Auto-start on login (registers with OS autostart) |
-| `allowShellCommands` | boolean | `false` | Allow CMS to execute shell commands on this display. **Security-sensitive** — only enable on trusted networks. Commands are sent via XMR or embedded in layout widgets. 30-second timeout per command. |
 
 ## Platform Support Matrix
 
@@ -178,7 +183,7 @@ Not all keys apply to every platform. Shell-only keys are filtered out by `extra
 | `playerApiBase`     | yes | yes      | yes      |                          |
 | `googleGeoApiKey`   | yes | yes      | yes      |                          |
 | `autoLaunch`        | —   | yes      | —        | Electron-only            |
-| `allowShellCommands`| —   | yes      | —        | Electron-only, default OFF |
+| `allowShellCommands`| —   | yes      | yes      | Shell-only, default OFF    |
 | `browser`           | —   | —        | yes      | Chromium-only            |
 | `extraBrowserFlags` | —   | —        | yes      | Chromium-only            |
 

--- a/packages/proxy/src/proxy.js
+++ b/packages/proxy/src/proxy.js
@@ -9,9 +9,13 @@
 
 import fs from 'fs';
 import path from 'path';
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
 import { Readable, pipeline } from 'node:stream';
 import express from 'express';
 import cors from 'cors';
+
+const execPromise = promisify(exec);
 import { createLogger, registerLogSink, PLAYER_API, setPlayerApi, computeCmsId } from '@xiboplayer/utils';
 import { ContentStore } from './content-store.js';
 
@@ -147,7 +151,7 @@ function serveChunkedFile(req, res, store, key, meta, contentType) {
  * @param {function} [options.onLog] — log sink for cross-process forwarding; receives ({ level, name, args })
  * @returns {import('express').Express}
  */
-export function createProxyApp({ pwaPath, appVersion = '0.0.0', pwaConfig, configFilePath, dataDir, onLog, icHandler } = {}) {
+export function createProxyApp({ pwaPath, appVersion = '0.0.0', pwaConfig, configFilePath, dataDir, onLog, icHandler, allowShellCommands = false } = {}) {
   const app = express();
 
   // Override Player API base path if configured (before registering routes)
@@ -269,6 +273,33 @@ export function createProxyApp({ pwaPath, appVersion = '0.0.0', pwaConfig, confi
     logServer.info('Quit requested — shutting down');
     res.json({ ok: true });
     setTimeout(() => process.exit(0), 100);
+  });
+
+  // ─── Shell Command Execution (#202) ─────────────────────────────
+  // Execute native shell commands from CMS (widget/display commands).
+  // Gated by allowShellCommands option (default: false).
+  // Used by Chromium kiosk (no IPC); Electron prefers its own IPC path.
+  app.post('/shell-command', express.json(), async (req, res) => {
+    if (!allowShellCommands) {
+      logServer.warn('Shell command rejected (allowShellCommands: false)');
+      return res.json({ success: false, reason: 'Shell commands disabled' });
+    }
+    const { commandString } = req.body || {};
+    if (!commandString) return res.json({ success: false, reason: 'Empty command' });
+
+    // Strip CMS type prefix (e.g., "shell|reboot" → "reboot")
+    const cmd = commandString.includes('|') ? commandString.split('|').slice(1).join('|') : commandString;
+    if (!cmd) return res.json({ success: false, reason: 'Empty command after prefix strip' });
+
+    logServer.info('[Shell] Executing:', cmd);
+    try {
+      const { stdout, stderr } = await execPromise(cmd, { timeout: 30000 });
+      logServer.info('[Shell] OK:', stdout.trim());
+      res.json({ success: true, stdout: stdout.trim(), stderr: stderr.trim() });
+    } catch (error) {
+      logServer.error('[Shell] Failed:', error.message);
+      res.json({ success: false, reason: error.message });
+    }
   });
 
   // ─── Auth Token ──────────────────────────────────────────────────
@@ -955,8 +986,8 @@ export function createProxyApp({ pwaPath, appVersion = '0.0.0', pwaConfig, confi
  * @param {string} [options.appVersion='0.0.0']
  * @returns {Promise<{ server: import('http').Server, port: number }>}
  */
-export function startServer({ port = 8765, pwaPath, appVersion = '0.0.0', pwaConfig, configFilePath, dataDir, onLog, icHandler } = {}) {
-  const app = createProxyApp({ pwaPath, appVersion, pwaConfig, configFilePath, dataDir, onLog, icHandler });
+export function startServer({ port = 8765, pwaPath, appVersion = '0.0.0', pwaConfig, configFilePath, dataDir, onLog, icHandler, allowShellCommands = false } = {}) {
+  const app = createProxyApp({ pwaPath, appVersion, pwaConfig, configFilePath, dataDir, onLog, icHandler, allowShellCommands });
 
   return new Promise((resolve, reject) => {
     const server = app.listen(port, 'localhost', () => {

--- a/packages/pwa/src/main.ts
+++ b/packages/pwa/src/main.ts
@@ -763,16 +763,26 @@ class PwaPlayer {
     });
 
     // Native command execution (#202) — shell commands delegated by PlayerCore
+    // Electron: use IPC (in-process, faster). Chromium/other: HTTP to proxy server.
     this.core.on('execute-native-command', async (data: any) => {
+      let result;
       if ((window as any).electronAPI?.executeShellCommand) {
-        const result = await (window as any).electronAPI.executeShellCommand({
+        result = await (window as any).electronAPI.executeShellCommand({
           commandString: data.commandString,
         });
-        this.core.emit('command-result', { code: data.code, ...result });
       } else {
-        log.warn('Native command not supported on this platform:', data.code);
-        this.core.emit('command-result', { code: data.code, success: false, reason: 'Platform does not support native commands' });
+        try {
+          const resp = await fetch('/shell-command', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ commandString: data.commandString }),
+          });
+          result = await resp.json();
+        } catch (err: any) {
+          result = { success: false, reason: err.message };
+        }
       }
+      this.core.emit('command-result', { code: data.code, ...result });
     });
 
     // Display settings events

--- a/packages/utils/src/config.js
+++ b/packages/utils/src/config.js
@@ -589,7 +589,7 @@ export const config = new Config();
 const PLATFORM_KEYS = {
   kioskMode:          ['electron', 'chromium'],
   autoLaunch:         ['electron'],
-  allowShellCommands: ['electron'],
+  allowShellCommands: ['electron', 'chromium'],
   browser:            ['chromium'],
   extraBrowserFlags:  ['chromium'],
 };


### PR DESCRIPTION
## Summary
- Wire `execute-native-command` (PlayerCore) and `widgetCommand` (RendererLite) events in PWA main.ts
- Add `POST /shell-command` HTTP endpoint to `@xiboplayer/proxy`, gated by `allowShellCommands` option (default: false)
- PWA tries Electron IPC first, falls back to HTTP for Chromium/other platforms
- Add `allowShellCommands` to `SHELL_ONLY_KEYS` and `PLATFORM_KEYS` (electron + chromium)
- Document in CONFIGURATION.md

## Security
- **Default OFF** — requires explicit `allowShellCommands: true` in config.json
- **Shell-only** — never reaches PWA localStorage
- **30s timeout** — prevents hanging commands
- **Logged** — every execution logged to console/journal
- Strips CMS type prefix (`shell|reboot` → `reboot`) before execution

## Related PRs
- xibo-players/xiboplayer-electron — IPC handler + preload bridge
- xibo-players/xiboplayer-chromium — passes flag to proxy server

## Test plan
- [ ] `pnpm test` — all 1408 tests pass
- [ ] Electron: set `allowShellCommands: true`, send command via XMR → verify execution
- [ ] Chromium: set `allowShellCommands: true`, send command via XMR → verify execution
- [ ] Default OFF: command logs warning, does not execute
- [ ] Widget commands in XLF layout execute on widget start