### PR TITLE
fix: update config gate for per-CMS storage keys

### DIFF
--- a/packages/core/src/index.d.ts
+++ b/packages/core/src/index.d.ts
@@ -9,6 +9,7 @@ export interface PlayerCoreOptions {
   xmrWrapper: any;
   statsCollector?: any;
   displaySettings?: any;
+  cmsId?: string;
 }
 
 export class PlayerCore {

--- a/packages/pwa/index.html
+++ b/packages/pwa/index.html
@@ -107,8 +107,21 @@
 
   <!-- Remove status bar overlay unless explicitly enabled in config -->
   <script>
+    // Read config from per-CMS storage (xibo_global + xibo_cms:{id}), fall back to legacy xibo_config
+    function readStoredConfig() {
+      try {
+        var activeCmsId = localStorage.getItem('xibo_active_cms');
+        if (activeCmsId) {
+          var global = JSON.parse(localStorage.getItem('xibo_global') || '{}');
+          var cms = JSON.parse(localStorage.getItem('xibo_cms:' + activeCmsId) || '{}');
+          return Object.assign({}, global, cms);
+        }
+        // Legacy fallback
+        return JSON.parse(localStorage.getItem('xibo_config') || '{}');
+      } catch (e) { return {}; }
+    }
     try {
-      var cfg = JSON.parse(localStorage.getItem('xibo_config') || '{}');
+      var cfg = readStoredConfig();
       var hover = cfg.controls && cfg.controls.mouse && cfg.controls.mouse.statusBarOnHover;
       if (hover !== true) {
         document.getElementById('overlay').remove();
@@ -124,11 +137,8 @@
 
     let hasStoredConfig = false;
     try {
-      const raw = localStorage.getItem('xibo_config');
-      if (raw) {
-        const cfg = JSON.parse(raw);
-        hasStoredConfig = !!(cfg.cmsUrl && cfg.cmsKey);
-      }
+      const storedCfg = readStoredConfig();
+      hasStoredConfig = !!(storedCfg.cmsUrl && storedCfg.cmsKey);
     } catch (e) { /* corrupt config — treat as missing */ }
 
     console.log('[Player] Has URL config:', hasUrlConfig);

--- a/packages/utils/src/config.js
+++ b/packages/utils/src/config.js
@@ -230,6 +230,9 @@ export class Config {
       localStorage.setItem(ACTIVE_CMS_KEY, cmsId);
       this._activeCmsId = cmsId;
     }
+
+    // Legacy flat key for rollback compatibility (index.html gate, tests, etc.)
+    localStorage.setItem('xibo_config', JSON.stringify(data));
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #216 — after the per-CMS config migration (#210), the config gate in `index.html` still read from the legacy `xibo_config` key, causing a redirect loop on fresh installs.

### Changes
- `index.html`: read config from `xibo_global` + `xibo_cms:{active-id}`, fall back to legacy `xibo_config`
- `config.js`: write legacy `xibo_config` flat key in `_saveSplit()` for rollback compat (documented but missing)
- `index.d.ts`: add missing `cmsId` to `PlayerCoreOptions` type (build fix from #210)

## Test plan
- [x] 1408 tests passing
- [ ] Full wipe → setup → authorize → player loads without redirect loop