### PR TITLE
fix: correct executeCommand type signature

### DIFF
--- a/packages/core/src/index.d.ts
+++ b/packages/core/src/index.d.ts
@@ -63,7 +63,7 @@ export class PlayerCore {
   isOffline(): boolean;
   isInOfflineMode(): boolean;
 
-  executeCommand(commandCode: string, commands?: Record<string, string>): Promise<void>;
+  executeCommand(commandCode: string, commands?: Record<string, { commandString: string }>): Promise<void>;
   handleTrigger(triggerCode: string): void;
   purgeAll(): Promise<void>;
   captureScreenshot(): Promise<void>;


### PR DESCRIPTION
## Summary

Type mismatch: `executeCommand` accepts `Record<string, { commandString: string }>` but was typed as `Record<string, string>`, causing TS build failure.

## Test plan
- [x] `pnpm build` succeeds
- [x] 1408 tests passing