### PR TITLE
feat: cross-device multi-display sync via WebSocket relay

### DIFF
--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -18,7 +18,8 @@
   "dependencies": {
     "@xiboplayer/utils": "workspace:*",
     "express": "^5.2.1",
-    "cors": "^2.8.6"
+    "cors": "^2.8.6",
+    "ws": "^8.0.0"
   },
   "devDependencies": {
     "vitest": "^2.0.0"

--- a/packages/proxy/src/index.js
+++ b/packages/proxy/src/index.js
@@ -1,2 +1,3 @@
 export { createProxyApp, startServer } from './proxy.js';
 export { ContentStore } from './content-store.js';
+export { attachSyncRelay } from './sync-relay.js';

--- a/packages/proxy/src/proxy.js
+++ b/packages/proxy/src/proxy.js
@@ -18,6 +18,7 @@ import cors from 'cors';
 const execPromise = promisify(exec);
 import { createLogger, registerLogSink, PLAYER_API, setPlayerApi, computeCmsId } from '@xiboplayer/utils';
 import { ContentStore } from './content-store.js';
+import { attachSyncRelay } from './sync-relay.js';
 
 const SKIP_HEADERS = ['transfer-encoding', 'connection', 'content-encoding', 'content-length'];
 
@@ -986,13 +987,17 @@ export function createProxyApp({ pwaPath, appVersion = '0.0.0', pwaConfig, confi
  * @param {string} [options.appVersion='0.0.0']
  * @returns {Promise<{ server: import('http').Server, port: number }>}
  */
-export function startServer({ port = 8765, pwaPath, appVersion = '0.0.0', pwaConfig, configFilePath, dataDir, onLog, icHandler, allowShellCommands = false } = {}) {
+export function startServer({ port = 8765, listenAddress = 'localhost', pwaPath, appVersion = '0.0.0', pwaConfig, configFilePath, dataDir, onLog, icHandler, allowShellCommands = false } = {}) {
   const app = createProxyApp({ pwaPath, appVersion, pwaConfig, configFilePath, dataDir, onLog, icHandler, allowShellCommands });
 
   return new Promise((resolve, reject) => {
-    const server = app.listen(port, 'localhost', () => {
-      logServer.info(`Running on http://localhost:${port}`);
+    const server = app.listen(port, listenAddress, () => {
+      logServer.info(`Running on http://${listenAddress}:${port}`);
       logServer.info('READY');
+
+      // Attach WebSocket sync relay (lightweight — no cost when unused)
+      attachSyncRelay(server);
+
       resolve({ server, port });
     });
 

--- a/packages/proxy/src/sync-relay.js
+++ b/packages/proxy/src/sync-relay.js
@@ -1,0 +1,89 @@
+/**
+ * Sync Relay — WebSocket message relay for cross-device multi-display sync
+ *
+ * Attaches to an existing HTTP server (noServer mode) and handles WebSocket
+ * connections on the /sync path. Every message received from one client is
+ * broadcast to all OTHER connected clients (relay/hub pattern).
+ *
+ * The sync protocol itself (heartbeats, layout-change, layout-ready, etc.)
+ * is handled entirely by SyncManager on each client — the relay is just
+ * a dumb pipe.
+ *
+ * Heartbeat: server pings every 30s, expects pong within 10s.
+ * Stale clients are terminated to prevent zombie connections.
+ */
+
+import { WebSocketServer } from 'ws';
+import { createLogger } from '@xiboplayer/utils';
+
+const PING_INTERVAL = 30000;
+const PONG_TIMEOUT = 10000;
+
+const log = createLogger('SyncRelay', 'INFO');
+
+/**
+ * Attach a WebSocket sync relay to an existing HTTP server.
+ *
+ * @param {import('http').Server} server — the HTTP server from Express
+ * @returns {WebSocketServer} the wss instance (for testing / inspection)
+ */
+export function attachSyncRelay(server) {
+  const wss = new WebSocketServer({ noServer: true });
+
+  // Handle HTTP→WebSocket upgrade on /sync path only
+  server.on('upgrade', (req, socket, head) => {
+    const pathname = new URL(req.url, 'http://localhost').pathname;
+    if (pathname === '/sync') {
+      wss.handleUpgrade(req, socket, head, (ws) => {
+        wss.emit('connection', ws, req);
+      });
+    } else {
+      socket.destroy();
+    }
+  });
+
+  // Connection handler
+  wss.on('connection', (ws, req) => {
+    const addr = req.socket.remoteAddress;
+    log.info(`Client connected: ${addr} (${wss.clients.size} total)`);
+    ws.isAlive = true;
+
+    ws.on('pong', () => {
+      ws.isAlive = true;
+    });
+
+    ws.on('message', (data) => {
+      // Broadcast to all OTHER connected clients
+      for (const client of wss.clients) {
+        if (client !== ws && client.readyState === 1 /* OPEN */) {
+          client.send(data);
+        }
+      }
+    });
+
+    ws.on('close', () => {
+      log.info(`Client disconnected: ${addr} (${wss.clients.size} remaining)`);
+    });
+  });
+
+  // Heartbeat: detect stale connections
+  const pingTimer = setInterval(() => {
+    for (const ws of wss.clients) {
+      if (!ws.isAlive) {
+        log.info('Terminating stale client');
+        ws.terminate();
+        continue;
+      }
+      ws.isAlive = false;
+      ws.ping();
+    }
+  }, PING_INTERVAL);
+
+  // Clean up when server closes
+  wss.on('close', () => {
+    clearInterval(pingTimer);
+  });
+
+  log.info('Sync relay attached on /sync');
+  return wss;
+}

--- a/packages/pwa/src/main.ts
+++ b/packages/pwa/src/main.ts
@@ -495,6 +495,15 @@ class PwaPlayer {
       if (this.syncManager) {
         this.syncManager.stop();
       }
+
+      // Cross-device sync: build WebSocket relay URL when syncGroup is an IP.
+      // Lead connects to its own relay (localhost), followers connect to lead's IP.
+      // When syncGroup is 'lead', this is same-machine only (BroadcastChannel).
+      if (syncConfig.syncPublisherPort && syncConfig.syncGroup !== 'lead') {
+        const host = syncConfig.isLead ? 'localhost' : syncConfig.syncGroup;
+        syncConfig.relayUrl = `ws://${host}:${syncConfig.syncPublisherPort}/sync`;
+      }
+
       this.syncManager = new SyncManager({
         displayId: config.hardwareKey,
         syncConfig,

--- a/packages/sync/src/bc-transport.js
+++ b/packages/sync/src/bc-transport.js
@@ -1,0 +1,51 @@
+/**
+ * BroadcastChannelTransport — same-machine sync transport
+ *
+ * Wraps the browser BroadcastChannel API behind the sync transport interface.
+ * Used for multi-tab / multi-window sync on a single device.
+ *
+ * Transport interface: { send(msg), onMessage(callback), close(), get connected() }
+ */
+
+const DEFAULT_CHANNEL = 'xibo-sync';
+
+export class BroadcastChannelTransport {
+  /**
+   * @param {string} [channelName='xibo-sync']
+   */
+  constructor(channelName = DEFAULT_CHANNEL) {
+    this.channel = new BroadcastChannel(channelName);
+    this._connected = true;
+  }
+
+  /**
+   * Send a message to all other tabs/windows on this channel.
+   * @param {Object} msg — plain object (structured-cloned by BroadcastChannel)
+   */
+  send(msg) {
+    if (!this.channel) return;
+    this.channel.postMessage(msg);
+  }
+
+  /**
+   * Register a callback for incoming messages.
+   * @param {Function} callback — receives the message data (already deserialized)
+   */
+  onMessage(callback) {
+    this.channel.onmessage = (e) => callback(e.data);
+  }
+
+  /** Close the channel. */
+  close() {
+    if (this.channel) {
+      this.channel.close();
+      this.channel = null;
+    }
+    this._connected = false;
+  }
+
+  /** @returns {boolean} Whether the channel is open */
+  get connected() {
+    return this._connected && !!this.channel;
+  }
+}

--- a/packages/sync/src/index.d.ts
+++ b/packages/sync/src/index.d.ts
@@ -1,22 +1,79 @@
 export const VERSION: string;
 
+export interface SyncTransport {
+  send(msg: any): void;
+  onMessage(callback: (msg: any) => void): void;
+  close(): void;
+  readonly connected: boolean;
+}
+
 export interface SyncConfig {
   syncGroup: string;
   syncPublisherPort: number;
   syncSwitchDelay: number;
   syncVideoPauseDelay: number;
   isLead: boolean;
+  relayUrl?: string;
+}
+
+export class BroadcastChannelTransport implements SyncTransport {
+  constructor(channelName?: string);
+  send(msg: any): void;
+  onMessage(callback: (msg: any) => void): void;
+  close(): void;
+  readonly connected: boolean;
+}
+
+export class WebSocketTransport implements SyncTransport {
+  constructor(url: string);
+  send(msg: any): void;
+  onMessage(callback: (msg: any) => void): void;
+  close(): void;
+  readonly connected: boolean;
 }
 
 export class SyncManager {
-  constructor(config: SyncConfig, displayId: string);
-  config: SyncConfig;
+  constructor(options: {
+    displayId: string;
+    syncConfig: SyncConfig;
+    transport?: SyncTransport;
+    onLayoutChange?: (layoutId: string, showAt: number) => void;
+    onLayoutShow?: (layoutId: string) => void;
+    onVideoStart?: (layoutId: string, regionId: string) => void;
+    onStatsReport?: (followerId: string, statsXml: string, ack: () => void) => void;
+    onLogsReport?: (followerId: string, logsXml: string, ack: () => void) => void;
+    onStatsAck?: (targetDisplayId: string) => void;
+    onLogsAck?: (targetDisplayId: string) => void;
+  });
+
+  displayId: string;
+  syncConfig: SyncConfig;
   isLead: boolean;
+  transport: SyncTransport | null;
+  /** Backward-compatible alias for transport */
+  channel: SyncTransport | null;
+  followers: Map<string, any>;
 
   start(): void;
   stop(): void;
-  requestLayoutChange(layoutId: number, showDelay?: number): void;
-  notifyLayoutReady(layoutId: number): void;
-  onLayoutShow(callback: (layoutId: number) => void): void;
-  onLayoutChange(callback: (layoutId: number) => void): void;
+  requestLayoutChange(layoutId: string | number): Promise<void>;
+  requestVideoStart(layoutId: string | number, regionId: string): Promise<void>;
+  reportReady(layoutId: string | number): void;
+  reportStats(statsXml: string): void;
+  reportLogs(logsXml: string): void;
+  getStatus(): {
+    started: boolean;
+    isLead: boolean;
+    displayId: string;
+    followers: number;
+    pendingLayoutId: string | null;
+    transport: 'websocket' | 'broadcast-channel';
+    followerDetails: Array<{
+      displayId: string;
+      lastSeen: number;
+      ready: boolean;
+      readyLayoutId: string | null;
+      stale: boolean;
+    }>;
+  };
 }

--- a/packages/sync/src/sync-manager.js
+++ b/packages/sync/src/sync-manager.js
@@ -1,8 +1,9 @@
 /**
- * SyncManager - Multi-display synchronization via BroadcastChannel
+ * SyncManager - Multi-display synchronization
  *
  * Coordinates layout transitions across multiple browser tabs/windows
- * on the same machine (video wall, multi-monitor setups).
+ * (same machine via BroadcastChannel) or across devices on a LAN
+ * (via WebSocket relay on the lead's proxy server).
  *
  * Protocol:
  *   Lead                              Follower(s)
@@ -17,21 +18,28 @@
  *   Lead tracks active followers. If a follower goes silent for 15s,
  *   it's considered offline and excluded from ready-wait.
  *
+ * Transport:
+ *   Pluggable — BroadcastChannelTransport (same-machine) or
+ *   WebSocketTransport (cross-device via relay). Selected automatically
+ *   based on syncConfig.relayUrl.
+ *
  * @module @xiboplayer/sync
  */
 
 /**
  * @typedef {Object} SyncConfig
  * @property {string} syncGroup - "lead" or leader's LAN IP
- * @property {number} syncPublisherPort - TCP port (unused in browser, kept for compat)
+ * @property {number} syncPublisherPort - TCP port (used for WebSocket relay URL)
  * @property {number} syncSwitchDelay - Delay in ms before showing new content
  * @property {number} syncVideoPauseDelay - Delay in ms before unpausing video
  * @property {boolean} isLead - Whether this display is the leader
+ * @property {string} [relayUrl] - WebSocket relay URL for cross-device sync
  */
 
 import { createLogger } from '@xiboplayer/utils';
+import { BroadcastChannelTransport } from './bc-transport.js';
+import { WebSocketTransport } from './ws-transport.js';
 
-const CHANNEL_NAME = 'xibo-sync';
 const HEARTBEAT_INTERVAL = 5000;   // Send heartbeat every 5s
 const FOLLOWER_TIMEOUT = 15000;    // Consider follower offline after 15s silence
 const READY_TIMEOUT = 10000;       // Max wait for followers to be ready
@@ -41,6 +49,7 @@ export class SyncManager {
    * @param {Object} options
    * @param {string} options.displayId - This display's unique hardware key
    * @param {SyncConfig} options.syncConfig - Sync configuration from RegisterDisplay
+   * @param {Object} [options.transport] - Optional pre-built transport (for testing)
    * @param {Function} [options.onLayoutChange] - Called when lead requests layout change
    * @param {Function} [options.onLayoutShow] - Called when lead gives show signal
    * @param {Function} [options.onVideoStart] - Called when lead gives video start signal
@@ -66,7 +75,7 @@ export class SyncManager {
     this.onLogsAck = options.onLogsAck || null;
 
     // State
-    this.channel = null;
+    this.transport = options.transport || null;
     this.followers = new Map();      // displayId → { lastSeen, ready }
     this._heartbeatTimer = null;
     this._cleanupTimer = null;
@@ -79,20 +88,30 @@ export class SyncManager {
     this._log = createLogger(this.isLead ? 'Sync:LEAD' : 'Sync:FOLLOW');
   }
 
+  /** Backward-compatible alias for transport */
+  get channel() { return this.transport; }
+  set channel(v) { this.transport = v; }
+
   /**
-   * Start the sync manager (opens BroadcastChannel, begins heartbeats)
+   * Start the sync manager — selects transport, begins heartbeats.
    */
   start() {
     if (this._started) return;
     this._started = true;
 
-    if (typeof BroadcastChannel === 'undefined') {
-      this._log.warn( 'BroadcastChannel not available — sync disabled');
-      return;
+    // Select transport if none injected
+    if (!this.transport) {
+      if (this.syncConfig.relayUrl) {
+        this.transport = new WebSocketTransport(this.syncConfig.relayUrl);
+      } else if (typeof BroadcastChannel !== 'undefined') {
+        this.transport = new BroadcastChannelTransport();
+      } else {
+        this._log.warn('No transport available — sync disabled');
+        return;
+      }
     }
 
-    this.channel = new BroadcastChannel(CHANNEL_NAME);
-    this.channel.onmessage = (event) => this._handleMessage(event.data);
+    this.transport.onMessage((msg) => this._handleMessage(msg));
 
     // Start heartbeat
     this._heartbeatTimer = setInterval(() => this._sendHeartbeat(), HEARTBEAT_INTERVAL);
@@ -103,7 +122,8 @@ export class SyncManager {
       this._cleanupTimer = setInterval(() => this._cleanupStaleFollowers(), HEARTBEAT_INTERVAL);
     }
 
-    this._log.info( 'Started. DisplayId:', this.displayId);
+    this._log.info('Started. DisplayId:', this.displayId,
+      this.syncConfig.relayUrl ? `(relay: ${this.syncConfig.relayUrl})` : '(BroadcastChannel)');
   }
 
   /**
@@ -121,13 +141,13 @@ export class SyncManager {
       clearInterval(this._cleanupTimer);
       this._cleanupTimer = null;
     }
-    if (this.channel) {
-      this.channel.close();
-      this.channel = null;
+    if (this.transport) {
+      this.transport.close();
+      this.transport = null;
     }
 
     this.followers.clear();
-    this._log.info( 'Stopped');
+    this._log.info('Stopped');
   }
 
   // ── Lead API ──────────────────────────────────────────────────────
@@ -141,7 +161,7 @@ export class SyncManager {
    */
   async requestLayoutChange(layoutId) {
     if (!this.isLead) {
-      this._log.warn( 'requestLayoutChange called on follower — ignoring');
+      this._log.warn('requestLayoutChange called on follower — ignoring');
       return;
     }
 
@@ -156,7 +176,7 @@ export class SyncManager {
 
     const showAt = Date.now() + this.switchDelay;
 
-    this._log.info( `Requesting layout change: ${layoutId} (show at ${new Date(showAt).toISOString()}, ${this.followers.size} followers)`);
+    this._log.info(`Requesting layout change: ${layoutId} (show at ${new Date(showAt).toISOString()}, ${this.followers.size} followers)`);
 
     // Broadcast layout-change to all followers
     this._send({
@@ -178,7 +198,7 @@ export class SyncManager {
     }
 
     // Send show signal
-    this._log.info( `Sending layout-show: ${layoutId}`);
+    this._log.info(`Sending layout-show: ${layoutId}`);
     this._send({
       type: 'layout-show',
       layoutId,
@@ -225,7 +245,7 @@ export class SyncManager {
   reportReady(layoutId) {
     layoutId = String(layoutId);
 
-    this._log.info( `Reporting ready for layout ${layoutId}`);
+    this._log.info(`Reporting ready for layout ${layoutId}`);
 
     this._send({
       type: 'layout-ready',
@@ -283,7 +303,7 @@ export class SyncManager {
       case 'layout-change':
         // Follower: lead is requesting a layout change
         if (!this.isLead) {
-          this._log.info( `Layout change requested: ${msg.layoutId}`);
+          this._log.info(`Layout change requested: ${msg.layoutId}`);
           this.onLayoutChange(msg.layoutId, msg.showAt);
         }
         break;
@@ -298,7 +318,7 @@ export class SyncManager {
       case 'layout-show':
         // Follower: lead says show now
         if (!this.isLead) {
-          this._log.info( `Layout show signal: ${msg.layoutId}`);
+          this._log.info(`Layout show signal: ${msg.layoutId}`);
           this.onLayoutShow(msg.layoutId);
         }
         break;
@@ -306,7 +326,7 @@ export class SyncManager {
       case 'video-start':
         // Follower: lead says start video
         if (!this.isLead) {
-          this._log.info( `Video start signal: ${msg.layoutId} region ${msg.regionId}`);
+          this._log.info(`Video start signal: ${msg.layoutId} region ${msg.regionId}`);
           this.onVideoStart(msg.layoutId, msg.regionId);
         }
         break;
@@ -344,7 +364,7 @@ export class SyncManager {
         break;
 
       default:
-        this._log.warn( 'Unknown message type:', msg.type);
+        this._log.warn('Unknown message type:', msg.type);
     }
   }
 
@@ -361,7 +381,7 @@ export class SyncManager {
         readyLayoutId: null,
         role: msg.role || 'unknown',
       });
-      this._log.info( `Follower joined: ${msg.displayId} (${this.followers.size} total)`);
+      this._log.info(`Follower joined: ${msg.displayId} (${this.followers.size} total)`);
     }
   }
 
@@ -381,12 +401,12 @@ export class SyncManager {
       follower.lastSeen = Date.now();
     }
 
-    this._log.info( `Follower ${msg.displayId} ready for layout ${msg.layoutId}`);
+    this._log.info(`Follower ${msg.displayId} ready for layout ${msg.layoutId}`);
 
     // Check if all followers are now ready
     if (this._pendingLayoutId === msg.layoutId && this._readyResolve) {
       if (this._allFollowersReady(msg.layoutId)) {
-        this._log.info( 'All followers ready');
+        this._log.info('All followers ready');
         this._readyResolve();
         this._readyResolve = null;
       }
@@ -425,7 +445,7 @@ export class SyncManager {
               notReady.push(id);
             }
           }
-          this._log.warn( `Ready timeout — proceeding without: ${notReady.join(', ')}`);
+          this._log.warn(`Ready timeout — proceeding without: ${notReady.join(', ')}`);
           this._readyResolve = null;
           resolve();
         }
@@ -450,7 +470,7 @@ export class SyncManager {
     const now = Date.now();
     for (const [id, follower] of this.followers) {
       if (now - follower.lastSeen > FOLLOWER_TIMEOUT) {
-        this._log.info( `Removing stale follower: ${id} (last seen ${Math.round((now - follower.lastSeen) / 1000)}s ago)`);
+        this._log.info(`Removing stale follower: ${id} (last seen ${Math.round((now - follower.lastSeen) / 1000)}s ago)`);
         this.followers.delete(id);
       }
     }
@@ -458,11 +478,11 @@ export class SyncManager {
 
   /** @private */
   _send(msg) {
-    if (!this.channel) return;
+    if (!this.transport) return;
     try {
-      this.channel.postMessage(msg);
+      this.transport.send(msg);
     } catch (e) {
-      this._log.error( 'Failed to send:', e);
+      this._log.error('Failed to send:', e);
     }
   }
 
@@ -479,6 +499,7 @@ export class SyncManager {
       displayId: this.displayId,
       followers: this.followers.size,
       pendingLayoutId: this._pendingLayoutId,
+      transport: this.syncConfig.relayUrl ? 'websocket' : 'broadcast-channel',
       followerDetails: Array.from(this.followers.entries()).map(([id, f]) => ({
         displayId: id,
         lastSeen: f.lastSeen,
@@ -489,3 +510,6 @@ export class SyncManager {
     };
   }
 }
+
+export { BroadcastChannelTransport } from './bc-transport.js';
+export { WebSocketTransport } from './ws-transport.js';

--- a/packages/sync/src/sync-manager.test.js
+++ b/packages/sync/src/sync-manager.test.js
@@ -1,11 +1,12 @@
 /**
  * SyncManager unit tests
  *
- * Tests multi-display sync coordination via BroadcastChannel.
- * Uses a simple BroadcastChannel mock for Node.js environment.
+ * Tests multi-display sync coordination via pluggable transports.
+ * Uses a simple BroadcastChannel mock for the default transport path
+ * and a mock transport for the transport-injection path.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { SyncManager } from './sync-manager.js';
+import { SyncManager, BroadcastChannelTransport, WebSocketTransport } from './sync-manager.js';
 
 // ── BroadcastChannel mock ──────────────────────────────────────────
 // Simulates same-origin message passing between instances
@@ -50,6 +51,24 @@ class MockBroadcastChannel {
 
 // Install mock globally
 globalThis.BroadcastChannel = MockBroadcastChannel;
+
+// ── Mock Transport (for transport-injection tests) ──────────────────
+class MockTransport {
+  constructor() {
+    this._callback = null;
+    this._sent = [];
+    this._connected = true;
+  }
+  send(msg) { this._sent.push(msg); }
+  onMessage(callback) { this._callback = callback; }
+  close() { this._connected = false; }
+  get connected() { return this._connected; }
+
+  /** Simulate receiving a message from remote */
+  _receive(msg) {
+    if (this._callback) this._callback(msg);
+  }
+}
 
 // ── Helper to flush microtasks ──────────────────────────────────────
 const tick = (ms = 10) => new Promise(r => setTimeout(r, ms));
@@ -100,7 +119,7 @@ describe('SyncManager', () => {
       expect(follower1.isLead).toBe(false);
     });
 
-    it('should start and open BroadcastChannel', () => {
+    it('should start and open BroadcastChannel transport', () => {
       lead = new SyncManager({
         displayId: 'pwa-lead',
         syncConfig: makeSyncConfig(true),
@@ -108,10 +127,11 @@ describe('SyncManager', () => {
       lead.start();
 
       expect(lead.channel).not.toBeNull();
+      expect(lead.transport).not.toBeNull();
       expect(lead.getStatus().started).toBe(true);
     });
 
-    it('should stop and close BroadcastChannel', () => {
+    it('should stop and close transport', () => {
       lead = new SyncManager({
         displayId: 'pwa-lead',
         syncConfig: makeSyncConfig(true),
@@ -120,7 +140,70 @@ describe('SyncManager', () => {
       lead.stop();
 
       expect(lead.channel).toBeNull();
+      expect(lead.transport).toBeNull();
       expect(lead.getStatus().started).toBe(false);
+    });
+  });
+
+  describe('Transport injection', () => {
+    it('should use injected transport instead of BroadcastChannel', () => {
+      const transport = new MockTransport();
+      lead = new SyncManager({
+        displayId: 'pwa-lead',
+        syncConfig: makeSyncConfig(true),
+        transport,
+      });
+      lead.start();
+
+      expect(lead.transport).toBe(transport);
+      // Should have sent initial heartbeat
+      expect(transport._sent.length).toBe(1);
+      expect(transport._sent[0].type).toBe('heartbeat');
+    });
+
+    it('should handle messages from injected transport', () => {
+      const onLayoutChange = vi.fn();
+      const transport = new MockTransport();
+
+      follower1 = new SyncManager({
+        displayId: 'pwa-f1',
+        syncConfig: makeSyncConfig(false),
+        transport,
+        onLayoutChange,
+      });
+      follower1.start();
+
+      // Simulate a layout-change message from lead
+      transport._receive({
+        type: 'layout-change',
+        layoutId: '42',
+        showAt: Date.now() + 1000,
+        displayId: 'pwa-lead',
+      });
+
+      expect(onLayoutChange).toHaveBeenCalledWith('42', expect.any(Number));
+    });
+
+    it('should report websocket transport type in status when relayUrl set', () => {
+      const transport = new MockTransport();
+      lead = new SyncManager({
+        displayId: 'pwa-lead',
+        syncConfig: { ...makeSyncConfig(true), relayUrl: 'ws://localhost:8765/sync' },
+        transport,
+      });
+      lead.start();
+
+      expect(lead.getStatus().transport).toBe('websocket');
+    });
+
+    it('should report broadcast-channel transport type by default', () => {
+      lead = new SyncManager({
+        displayId: 'pwa-lead',
+        syncConfig: makeSyncConfig(true),
+      });
+      lead.start();
+
+      expect(lead.getStatus().transport).toBe('broadcast-channel');
     });
   });
 

--- a/packages/sync/src/ws-transport.js
+++ b/packages/sync/src/ws-transport.js
@@ -1,0 +1,125 @@
+/**
+ * WebSocketTransport — cross-device sync transport
+ *
+ * Connects to the lead player's proxy WebSocket relay at /sync.
+ * Used for LAN video walls where each screen is a separate device.
+ *
+ * Features:
+ * - Auto-reconnect with exponential backoff (1s → 2s → 4s → max 30s)
+ * - JSON serialization (WebSocket sends strings, not structured clones)
+ * - Same transport interface as BroadcastChannelTransport
+ *
+ * Transport interface: { send(msg), onMessage(callback), close(), get connected() }
+ */
+
+import { createLogger } from '@xiboplayer/utils';
+
+const INITIAL_RETRY_MS = 1000;
+const MAX_RETRY_MS = 30000;
+const BACKOFF_FACTOR = 2;
+
+export class WebSocketTransport {
+  /**
+   * @param {string} url — WebSocket URL, e.g. ws://192.168.1.100:8765/sync
+   */
+  constructor(url) {
+    this._url = url;
+    this._callback = null;
+    this._closed = false;
+    this._retryMs = INITIAL_RETRY_MS;
+    this._retryTimer = null;
+    this._log = createLogger('WS-Sync');
+    this.ws = null;
+
+    this._connect();
+  }
+
+  /**
+   * Send a message to the relay (which broadcasts to other clients).
+   * @param {Object} msg — plain object (JSON-serialized for WebSocket)
+   */
+  send(msg) {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify(msg));
+    }
+  }
+
+  /**
+   * Register a callback for incoming messages.
+   * @param {Function} callback — receives the parsed message object
+   */
+  onMessage(callback) {
+    this._callback = callback;
+  }
+
+  /** Close the connection and stop reconnecting. */
+  close() {
+    this._closed = true;
+    if (this._retryTimer) {
+      clearTimeout(this._retryTimer);
+      this._retryTimer = null;
+    }
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+  }
+
+  /** @returns {boolean} Whether the WebSocket is open */
+  get connected() {
+    return this.ws?.readyState === WebSocket.OPEN;
+  }
+
+  /** @private */
+  _connect() {
+    if (this._closed) return;
+
+    try {
+      this.ws = new WebSocket(this._url);
+    } catch (e) {
+      this._log.error('WebSocket creation failed:', e.message);
+      this._scheduleReconnect();
+      return;
+    }
+
+    this.ws.onopen = () => {
+      this._log.info(`Connected to ${this._url}`);
+      this._retryMs = INITIAL_RETRY_MS; // Reset backoff on success
+    };
+
+    this.ws.onmessage = (event) => {
+      if (!this._callback) return;
+      try {
+        const msg = JSON.parse(event.data);
+        this._callback(msg);
+      } catch (e) {
+        this._log.warn('Failed to parse message:', e.message);
+      }
+    };
+
+    this.ws.onclose = () => {
+      if (!this._closed) {
+        this._log.info('Connection closed — will reconnect');
+        this._scheduleReconnect();
+      }
+    };
+
+    this.ws.onerror = (e) => {
+      // onclose will fire after onerror, triggering reconnect
+      this._log.warn('WebSocket error');
+    };
+  }
+
+  /** @private */
+  _scheduleReconnect() {
+    if (this._closed || this._retryTimer) return;
+
+    this._log.info(`Reconnecting in ${this._retryMs}ms...`);
+    this._retryTimer = setTimeout(() => {
+      this._retryTimer = null;
+      this._connect();
+    }, this._retryMs);
+
+    this._retryMs = Math.min(this._retryMs * BACKOFF_FACTOR, MAX_RETRY_MS);
+  }
+}

--- a/packages/sync/vitest.config.js
+++ b/packages/sync/vitest.config.js
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
       express:
         specifier: ^5.2.1
         version: 5.2.1
+      ws:
+        specifier: ^8.0.0
+        version: 8.19.0
     devDependencies:
       vitest:
         specifier: ^2.0.0
@@ -2663,7 +2666,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 1.2.0
-      vitest: 2.1.9(@types/node@22.19.13)(@vitest/ui@2.1.9)(jsdom@28.1.0)
+      vitest: 2.1.9(@types/node@22.19.13)(@vitest/ui@2.1.9)(jsdom@25.0.1)
 
   '@vitest/utils@2.1.9':
     dependencies:


### PR DESCRIPTION
## Summary

- Extract transport abstraction from SyncManager with pluggable transports
- BroadcastChannelTransport (same-machine, cross-tab)
- WebSocketTransport (cross-device LAN with auto-reconnect)
- sync-relay in proxy (broadcasts to all other connected clients)
- PWA auto-selects transport based on syncConfig.relayUrl

No additional infrastructure needed — the lead player's proxy server acts as a lightweight message relay.

Closes #221