### PR TITLE
docs: expand package READMEs and fix stale doc counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,53 +13,51 @@ All packages are published to npm under the [`@xiboplayer`](https://www.npmjs.co
 
 ## Features
 
-- **Full Xibo protocol support** — XMDS SOAP v3–v7, REST API, and XMR WebSocket
-- **Rich media rendering** — video (MP4/HLS), images (scaleType, align/valign), audio (with overlay visualization), PDF, text/ticker, web pages, clock, calendar, weather, and all CMS widget types
-- **Offline-first** — ContentStore (filesystem via proxy) + IndexedDB storage with automatic fallback to cached schedule when network is unavailable
-- **Parallel chunk downloads** — large files (100MB+) split into 50MB chunks, header+trailer first for instant MP4 playback start
-- **Layout preloading** — 2-layout pool pre-builds upcoming layouts at 75% of current duration for instant zero-gap transitions
-- **Campaign scheduling** — priority-based campaigns, daily/weekly/monthly dayparting with midnight-crossing, geo-fencing, and criteria evaluation
-- **Download window enforcement** — respects CMS-configured download time windows to avoid bandwidth during peak hours
-- **Schedule conflict detection** — identifies and flags overlapping schedule entries
-- **Interrupts / share of voice** — percentage-based interrupt scheduling with even interleaving across the hour
-- **Interleaved default layouts** — cycles through multiple default layouts instead of repeating one
-- **Overlay support** — multiple simultaneous overlay layouts with independent scheduling and priority
-- **Transitions** — fade and fly (8-direction compass) transitions via Web Animations API, including region exit transitions
-- **Interactive actions** — touch/click and keyboard triggers for widget navigation, layout jumps, and command execution
-- **Scheduled commands** — timed command execution from CMS schedule entries
-- **Real-time CMS commands** — collectNow, screenshot, changeLayout, overlayLayout, revertToSchedule, purgeAll, dataUpdate via XMR WebSocket
-- **Proof of play** — per-layout and per-widget duration tracking with individual or aggregated submission
-- **Event-based stats** — widget duration events (widgetAction) and recordEvent for proof of play
-- **Log batching** — aggregated log submission aligned with upstream CMS spec
-- **Multi-display sync** — BroadcastChannel-based lead/follower synchronization for video walls
-- **Timeline prediction** — deterministic future schedule simulation for proactive content preloading
-- **Accurate timeline durations** — probes video metadata and sums sequential widgets per region for correct layout timing, with remaining-duration display for the currently playing layout
-- **Weather criteria** — weather-based schedule evaluation for conditional content display
-- **Geolocation fallback chain** — browser Geolocation API → Google API → IP-based lookup
-- **CMS tag config parsing** — display tag configuration (e.g. geoApiKey|value) from RegisterDisplay
-- **Network resilience** — exponential backoff with jitter, CRC32-based skip optimization, ETag HTTP caching
-- **CORS proxy** — shared Express server for Electron and Chromium shells with XMDS, REST, and file download proxying plus PWA static serving
-- **RSA key pair generation** for XMR display registration via Web Crypto API
-- **Renderer state query** — isPaused() for pause/resume control from shells
-- **Drawer regions** — hidden regions revealed via navigateToWidget, auto-hidden after widget cycle
-- **Sub-playlist cycle playback** — round-robin or random widget selection per group per layout cycle
-- **Widget time-gating** — per-widget fromDt/toDt expiry filtering at region creation
-- **Dynamic duration** — parses NUMITEMS/DURATION HTML comments from GetResource for DataSet tickers and RSS feeds
-- **Region loop control** — `loop=0` keeps single media visible after expiry instead of cycling
-- **Purge file handling** — processes CMS purge directives from RequiredFiles
-- **HTTP 429 retry** — respects Retry-After header (delta-seconds and HTTP-date) for rate-limited CMS responses
-- **Spec-compliant logging** — SubmitLog XML with child elements per upstream format
-- **Configurable client identity** — clientType/clientVersion/clientCode in RegisterDisplay
-- **Fault reporting agent** — independent 60s fault submission cycle for faster CMS alerts
-- **Layout blacklisting** — tracks consecutive render failures, auto-blacklists after 3 failures, reports to CMS via BlackList XMDS
-- **Canvas regions** — full canvas region support alongside standard regions
-- **Protocol auto-detection** — probes REST API at startup, auto-selects REST or SOAP transport
-- **Persistent layout durations** — durations cached in IndexedDB for correct timeline on restart
-- **XIC event handlers** — renderer fires XIC interactive control events for widget interactions
-- **Download resume** — incomplete chunked downloads resume from last successful chunk
-- **Missing media overlay** — timeline highlights layouts with uncached media in red
+### CMS Communication
+- **Dual transport** — XMDS SOAP v3–v7 and REST API v2 with automatic protocol detection
+- **XMR real-time commands** — collectNow, screenshot, changeLayout, overlayLayout, revertToSchedule, purgeAll, dataUpdate via WebSocket with auto-reconnect
+- **Network resilience** — exponential backoff with jitter, CRC32-based skip optimization, ETag HTTP caching, HTTP 429 Retry-After support
 - **CMS REST API client** — 77 methods covering layouts, campaigns, schedules, commands, displays, playlists, datasets, notifications, folders, tags, and display group actions
-- **1345 tests** across 35 test suites
+- **RSA key pair generation** for XMR display registration via Web Crypto API
+
+### Rendering
+- **Rich media** — video (MP4/HLS), images (scaleType, align/valign), audio (with overlay visualization), PDF, text/ticker, web pages, clock, calendar, weather, and all CMS widget types
+- **Layout preloading** — 2-layout pool pre-builds upcoming layouts at 75% of current duration for instant zero-gap transitions
+- **Transitions** — fade and fly (8-direction compass) via Web Animations API, including region exit transitions
+- **Interactive actions** — touch/click and keyboard triggers for widget navigation, layout jumps, and command execution
+- **Canvas regions, drawer regions, sub-playlists** — full support for advanced CMS layout features
+- **Shell commands** — native command execution via Electron IPC and Chromium HTTP endpoint
+
+### Scheduling
+- **Campaign scheduling** — priority-based campaigns, daily/weekly/monthly dayparting with midnight-crossing, geo-fencing, and criteria evaluation
+- **Interrupts / share of voice** — percentage-based interrupt scheduling with even interleaving across the hour
+- **Overlays** — multiple simultaneous overlay layouts with independent scheduling and priority
+- **Timeline prediction** — deterministic future schedule simulation for proactive content preloading
+- **Weather criteria** — weather-based schedule evaluation with geolocation fallback chain (browser API → Google API → IP lookup)
+
+### Downloads & Offline
+- **Offline-first** — ContentStore (filesystem via proxy) + IndexedDB storage with automatic fallback to cached schedule
+- **Parallel chunk downloads** — large files split into 50MB chunks, header+trailer first for instant MP4 playback start
+- **Download resume** — incomplete chunked downloads resume from last successful chunk
+- **Download window enforcement** — respects CMS-configured time windows to avoid bandwidth during peak hours
+
+### Cross-Device Video Walls
+- **Multi-display sync** — lead/follower synchronization with coordinated layout transitions and video start
+- **Same-machine** — BroadcastChannel for multi-tab/multi-window setups
+- **Cross-device** — WebSocket relay on the lead's proxy server for LAN video walls (each screen a separate PC)
+- **Stats delegation** — followers delegate proof-of-play through the lead, avoiding duplicate CMS traffic
+
+### Analytics & Monitoring
+- **Proof of play** — per-layout and per-widget duration tracking with individual or aggregated submission
+- **Event-based stats** — widget interactions and recordEvent for engagement analytics
+- **Fault reporting** — independent 60s cycle for faster CMS alerts, layout blacklisting after 3 consecutive failures
+- **Screenshot capture** — periodic and on-demand via getDisplayMedia + html2canvas fallback
+
+### Infrastructure
+- **CORS proxy** — shared Express server for Electron and Chromium shells with XMDS, REST, and file download proxying plus PWA static serving
+- **Protocol auto-detection** — probes REST API at startup, auto-selects REST or SOAP transport
+- **Persistent layout durations** — cached in IndexedDB for correct timeline on restart
+- **1412 tests** across 36 test suites
 
 ## Packages
 
@@ -76,7 +74,7 @@ All packages are published to npm under the [`@xiboplayer`](https://www.npmjs.co
 | [`@xiboplayer/crypto`](packages/crypto) | [![npm](https://img.shields.io/npm/v/@xiboplayer/crypto?style=flat-square)](https://www.npmjs.com/package/@xiboplayer/crypto) | RSA key generation for XMR registration (Web Crypto API) |
 | [`@xiboplayer/utils`](packages/utils) | [![npm](https://img.shields.io/npm/v/@xiboplayer/utils?style=flat-square)](https://www.npmjs.com/package/@xiboplayer/utils) | EventEmitter, logger, fetchWithRetry, CMS REST API client, config |
 | [`@xiboplayer/sw`](packages/sw) | [![npm](https://img.shields.io/npm/v/@xiboplayer/sw?style=flat-square)](https://www.npmjs.com/package/@xiboplayer/sw) | Service Worker — media caching, range requests, widget HTML serving |
-| [`@xiboplayer/sync`](packages/sync) | [![npm](https://img.shields.io/npm/v/@xiboplayer/sync?style=flat-square)](https://www.npmjs.com/package/@xiboplayer/sync) | Multi-display synchronization — lead/follower, synchronized video start |
+| [`@xiboplayer/sync`](packages/sync) | [![npm](https://img.shields.io/npm/v/@xiboplayer/sync?style=flat-square)](https://www.npmjs.com/package/@xiboplayer/sync) | Cross-device video walls — BroadcastChannel + WebSocket relay, lead/follower sync |
 | [`@xiboplayer/proxy`](packages/proxy) | [![npm](https://img.shields.io/npm/v/@xiboplayer/proxy?style=flat-square)](https://www.npmjs.com/package/@xiboplayer/proxy) | CORS proxy + PWA server — shared by Electron and Chromium shells |
 
 ## Quick start
@@ -114,7 +112,7 @@ npm install @xiboplayer/proxy   # CORS proxy + PWA server for shells
 ├─────────────────────────────────────────────────────────┤
 │ @xiboplayer/proxy  @xiboplayer/utils  @xiboplayer/sync crypto│
 │  CORS proxy · PWA    logger · events   video wall    RSA  │
-│  static server       fetch · config    lead/follow   keys │
+│  sync relay          fetch · config    BC + WebSocket keys │
 └─────────────────────────────────────────────────────────┘
 ```
 
@@ -176,7 +174,7 @@ pnpm install
 ### Testing
 
 ```bash
-pnpm test              # run all tests (1345 tests across 35 suites)
+pnpm test              # run all tests (1412 tests across 36 suites)
 pnpm test:watch        # watch mode
 pnpm test:coverage     # with coverage report
 ```

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -102,7 +102,7 @@ Renderer process: XLR library (shared npm module)
 | **HLS** | ✅ (native browser) | ✅ (Edge WebView2) | ❌ | ✅ |
 | **Sub-playlists** | ✅ (cycle + playCount) | ✅ (cycle playback) | ❌ | ✅ |
 | **Data connectors** | ✅ (polling + IC) | ✅ (DataAgent) | ❌ | ✅ |
-| **Multi-display sync** | ✅ (BroadcastChannel) | ❌ | ❌ | ❌ |
+| **Multi-display sync** | ✅ (BC + WebSocket LAN) | ❌ | ❌ | ❌ |
 | **Offline mode** | ✅ (SW + IndexedDB) | ✅ (filesystem) | ✅ (filesystem) | ✅ (filesystem) |
 | **Layout pre-loading** | ✅ (LayoutPool hot/warm) | ❌ | ❌ | ✅ (XLR) |
 | **Blacklist/fault** | ✅ (3-strike) | ✅ (unsafe items) | ❌ | ❌ |
@@ -131,9 +131,9 @@ Upstream players all use SOAP/XML. Our REST API provides:
 
 Only our player and XLR have this. The .NET and C++ players tear down and rebuild the DOM/widget tree on every layout switch. Our LayoutPool keeps 2 layouts ready (hot + warm) for instant transitions.
 
-### 3c. Multi-Display Sync (BroadcastChannel)
+### 3c. Cross-Device Video Walls (BroadcastChannel + WebSocket)
 
-No upstream player has this. Our SyncManager coordinates layout transitions across multiple displays via BroadcastChannel with a lead/follower protocol.
+No upstream player has this. Our SyncManager coordinates layout transitions across multiple displays with a lead/follower protocol. Two transport layers: BroadcastChannel for same-machine sync (multi-tab), and a WebSocket relay on the lead's proxy server for cross-device LAN sync. Auto-reconnect, stats delegation, and synchronized video start across all screens.
 
 ### 3d. Advanced Schedule Features
 
@@ -179,9 +179,9 @@ pre-flattens sub-playlists so the player receives a simple ordered widget list.
 
 ### 4d. Shell Commands / Native Commands
 
-The .NET and C++ players can execute shell commands from widgets (type `shellcommand`). Our Electron wrapper could support this but currently doesn't expose it.
+~~The .NET and C++ players can execute shell commands from widgets (type `shellcommand`).~~
 
-**Priority**: LOW — security risk, only for controlled environments
+**DONE** (#202): Electron uses IPC (`execute-shell-command`), Chromium uses HTTP endpoint (`POST /shell-command`). Gated by `allowShellCommands: true` in config.json. 30-second timeout per command.
 
 ### 4e. Engagement Tracking
 
@@ -301,7 +301,7 @@ CmsClient interface:
 
 ### Nice to Have
 
-11. **Shell command execution** in Electron (#202)
+11. ~~**Shell command execution**~~ — ✅ Electron IPC + Chromium HTTP (#202)
 12. **Engagement tracking** in StatsCollector (#203)
 13. **Config system documentation** — platform-specific key reference (#204)
 14. **Ad exchange support** (SSP widget type) (#84)

--- a/packages/cache/README.md
+++ b/packages/cache/README.md
@@ -1,22 +1,57 @@
 # @xiboplayer/cache
 
-**Offline caching and download management with durable filesystem storage.**
+**Offline caching and download management with parallel chunk downloads, resume support, and storage health monitoring.**
 
 ## Overview
 
-Manages media downloads and offline storage for Xibo players:
+Manages the complete lifecycle of media files from CMS to local storage:
 
-- **StoreClient** — pure REST client for reading/writing content in the ContentStore (filesystem via proxy)
-- **DownloadClient** — Service Worker postMessage client for managing background downloads
-- **Parallel chunk downloads** — large files (100MB+) split into configurable chunks, downloaded concurrently
-- **Header+trailer first** — MP4 moov atom fetched first for instant playback start before full download
-- **MD5 verification** — integrity checking with CRC32-based skip optimization
-- **Download queue** — flat queue with barriers for layout-ordered downloading
-- **CacheAnalyzer** — stale media detection and storage-pressure eviction
-- **Widget data via enriched RequiredFiles** — RSS/dataset widget data is fetched through server-side enriched RequiredFiles paths (CMS adds download URLs), not via client-side pre-fetching
-- **Dynamic BASE path** — widget HTML `<base>` tag uses a dynamic path within the Service Worker scope for correct relative URL resolution
+- **REST-based file store** -- StoreClient provides CRUD operations (has, get, put, remove, list) via proxy endpoints
+- **Flat-queue download orchestration** -- DownloadManager with per-file and global concurrency limits
+- **Intelligent chunking** -- files > 100MB split into 50MB chunks with prioritized headers and trailers for fast video start
+- **Download resume** -- partial downloads resume automatically; expired URLs defer to next collection cycle
+- **Stale media detection** -- CacheAnalyzer identifies orphaned files and evicts when storage exceeds threshold
+- **Widget HTML preprocessing** -- base tag injection, dependency rewriting for iframe sandboxing
 
-No Cache API is used anywhere. All content is stored on the filesystem via the proxy's ContentStore.
+No Cache API is used. All content is stored on the filesystem via the proxy's ContentStore.
+
+## Architecture
+
+```
+CMS (RequiredFiles: size, URL, MD5)
+        |
+        v
++-------------------------------------+
+|      DownloadManager (Facade)       |
+|  +- enqueue(fileInfo)               |
+|  +- prioritizeLayoutFiles(mediaIds) |
+|  +- urgentChunk(type, id, idx)      |
++-------------------------------------+
+             |
+             v
+      DownloadQueue (Flat)
+    +-----------------------------+
+    | [Task, Task, BARRIER,       |
+    |  Task, Task, Task]          |
+    |                             |
+    | Global concurrency: 6       |
+    | Per-file chunks: 2-3        |
+    +-----------------------------+
+       |
+       +-> DownloadTask (chunk-0, high priority)
+       +-> DownloadTask (chunk-last, high priority)
+       +-> BARRIER (gate: waits for above to finish)
+       +-> DownloadTask (bulk chunks, normal priority)
+               |
+               v
+         HTTP Range GET
+               |
+               v
+       ContentStore (proxy)
+         /store/media/{id}
+         /store/layout/{id}
+         /store/widget/{L}/{R}/{M}
+```
 
 ## Installation
 
@@ -26,35 +61,176 @@ npm install @xiboplayer/cache
 
 ## Usage
 
+### StoreClient -- direct REST access to ContentStore
+
 ```javascript
-import { StoreClient, DownloadClient } from '@xiboplayer/cache';
+import { StoreClient } from '@xiboplayer/cache';
 
-// Storage operations (pure REST, no SW needed)
 const store = new StoreClient();
-const { exists, size } = await store.has('media', '123');
-const blob = await store.get('media', '123');
-await store.put('widget', '472/221/190', htmlBlob, 'text/html');
 
-// Download management (SW postMessage)
-const downloads = new DownloadClient();
-await downloads.init();
-await downloads.download(files);
-const progress = await downloads.getProgress();
+// Check existence
+const exists = await store.has('media', '123');
+
+// Retrieve file
+const blob = await store.get('media', '456');
+
+// Store widget HTML
+const html = new Blob(['<h1>Widget</h1>'], { type: 'text/html' });
+await store.put('widget', 'layout/1/region/2/media/3', html, 'text/html');
+
+// List all cached files
+const files = await store.list();
+
+// Delete orphaned files
+await store.remove([
+  { type: 'media', id: '999' },
+  { type: 'media', id: '1000' },
+]);
 ```
 
-## Exports
+### DownloadManager -- orchestrated downloads
 
-| Export | Description |
-|--------|-------------|
-| `StoreClient` | Pure REST client for ContentStore — has/get/put/remove/list |
-| `DownloadClient` | SW postMessage client for background downloads |
-| `DownloadManager` | Core download queue with barrier-based ordering |
-| `CacheAnalyzer` | Stale media detection and eviction |
+```javascript
+import { DownloadManager } from '@xiboplayer/cache';
+
+const dm = new DownloadManager({
+  concurrency: 6,
+  chunkSize: 50 * 1024 * 1024,
+  chunksPerFile: 2,
+});
+
+// Enqueue a file
+const media = dm.enqueue({
+  id: '123',
+  type: 'media',
+  path: 'https://cdn.example.com/video.mp4',
+  size: 250 * 1024 * 1024,
+  md5: 'abc123def456',
+});
+
+// Wait for completion
+const blob = await media.wait();
+
+// Get progress
+const progress = dm.getProgress();
+// { 'media/123': { downloaded: 50M, total: 250M, percent: '20.0', state: 'downloading' } }
+```
+
+### Prioritization and emergency chunks
+
+```javascript
+// Boost files needed by current layout
+dm.prioritizeLayoutFiles(['123', '456']);
+
+// Emergency: chunk needed for video playback is stalled
+// Moves to front of queue, reduces global concurrency to 2
+dm.urgentChunk('media', '789', 3);
+```
+
+### CacheAnalyzer -- storage health
+
+```javascript
+import { CacheAnalyzer } from '@xiboplayer/cache';
+
+const analyzer = new CacheAnalyzer(store, { threshold: 80 });
+
+const report = await analyzer.analyze(requiredFiles);
+console.log(`Storage: ${report.storage.percent}%`);
+console.log(`Orphaned: ${report.files.orphaned} files`);
+console.log(`Evicted: ${report.evicted.length} files`);
+```
+
+## Download Pipeline
+
+Files flow through stages:
+
+1. **Enqueueing** -- deduplication via `type/id` key, URL refresh if new URL has longer expiry
+2. **Preparation** -- HEAD request determines chunking (> 100MB = chunked)
+3. **Task creation** -- chunk-0 and chunk-last get high priority (video headers/trailers); BARRIER separates from bulk chunks
+4. **Processing** -- concurrency-aware: 6 global connections, 2-3 per file
+5. **Execution** -- HTTP Range GET with retries and exponential backoff
+6. **Storage** -- proxy ContentStore saves chunks to filesystem
+7. **Assembly** -- chunks concatenated; progressive callback enables playback before full download
+
+### Chunk strategy
+
+- **Default chunk size:** 50MB
+- **Threshold:** files > 100MB get chunked
+- **Header+trailer first:** MP4 moov atom in chunk-0 and chunk-last allows instant playback start
+- **Barriers:** critical chunks download before bulk chunks begin
+- **Resume:** cached chunks tracked in `skipChunks` Set; only missing chunks downloaded
+- **Expired URLs:** deferred (not failed) -- next collection provides fresh URL
+
+### Retry strategy by type
+
+| Type | Max retries | Backoff | Notes |
+|------|------------|---------|-------|
+| media | 3 | 500ms | Large, cacheable files |
+| layout | 3 | 500ms | Layout XML, stable URL |
+| dataset | 4 | 15s, 30s, 60s, 120s | Re-enqueues 5x for "cache not ready" |
+| static | 3 | 500ms | Widget dependencies (CSS, fonts) |
+
+## API Reference
+
+### StoreClient
+
+| Method | Signature | Returns | Description |
+|--------|-----------|---------|-------------|
+| `has()` | `has(type, id)` | `Promise<boolean>` | Check if file exists |
+| `get()` | `get(type, id)` | `Promise<Blob \| null>` | Retrieve file as Blob |
+| `put()` | `put(type, id, body, contentType?)` | `Promise<boolean>` | Store file |
+| `remove()` | `remove(files)` | `Promise<{deleted, total}>` | Delete files |
+| `list()` | `list()` | `Promise<Array>` | List all cached files |
+
+### DownloadManager
+
+```javascript
+new DownloadManager({ concurrency?, chunkSize?, chunksPerFile? })
+```
+
+| Method | Signature | Returns | Description |
+|--------|-----------|---------|-------------|
+| `enqueue()` | `enqueue(fileInfo)` | `FileDownload` | Add file to download queue |
+| `getTask()` | `getTask(key)` | `FileDownload \| null` | Get task by "type/id" key |
+| `getProgress()` | `getProgress()` | `Record<string, Progress>` | All in-progress downloads |
+| `prioritizeLayoutFiles()` | `prioritizeLayoutFiles(mediaIds)` | `void` | Boost priority for layout files |
+| `urgentChunk()` | `urgentChunk(type, id, chunkIndex)` | `boolean` | Move chunk to front, reduce concurrency |
+| `clear()` | `clear()` | `void` | Cancel all, clear queue |
+
+### CacheAnalyzer
+
+```javascript
+new CacheAnalyzer(storeClient, { threshold: 80 })
+```
+
+| Method | Signature | Returns | Description |
+|--------|-----------|---------|-------------|
+| `analyze()` | `analyze(requiredFiles)` | `Promise<Report>` | Compare cache vs required, evict if needed |
+
+**Report:**
+```javascript
+{
+  storage: { usage, quota, percent },
+  files: { required, orphaned, total },
+  orphaned: [{ id, type, size, cachedAt }],
+  evicted: [{ id, type, size }],
+  threshold: 80
+}
+```
+
+### CacheManager
+
+| Method | Signature | Returns | Description |
+|--------|-----------|---------|-------------|
+| `getCacheKey()` | `getCacheKey(type, id)` | `string` | Get cache key path |
+| `addDependant()` | `addDependant(mediaId, layoutId)` | `void` | Track layout -> media reference |
+| `removeLayoutDependants()` | `removeLayoutDependants(layoutId)` | `string[]` | Remove layout, return orphaned media IDs |
+| `isMediaReferenced()` | `isMediaReferenced(mediaId)` | `boolean` | Check if media is still used |
 
 ## Dependencies
 
-- `@xiboplayer/utils` — logger, events
-- `spark-md5` — MD5 hashing for file verification
+- `@xiboplayer/utils` -- logger
+- `spark-md5` -- MD5 hashing for file verification
 
 ---
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,15 +1,60 @@
 # @xiboplayer/core
 
-**Player orchestration, collection cycle, and lifecycle management for Xibo digital signage.**
+**Pure orchestration engine for Xibo players — manages collection cycles, layout state machines, offline mode, and lifecycle events.**
 
 ## Overview
 
-The core package is the central coordinator of a Xibo player. It manages:
+The core package is the central orchestrator of a Xibo player. It manages:
 
-- **Collection cycle** — periodic CMS polling for schedule, required files, and display settings
-- **Layout state machine** — controls which layout is playing, handles transitions and interrupts
-- **Offline mode** — falls back to cached schedule and media when the CMS is unreachable
-- **Event bus** — emits lifecycle events (`schedule-updated`, `download-request`, `layout-changed`, etc.)
+- **Collection cycle** — periodic CMS polling (RegisterDisplay, RequiredFiles, Schedule) with CRC32 optimization to skip redundant downloads
+- **Layout scheduling** — builds a playback queue from CMS schedule with support for campaigns, dayparting, priorities, and maxPlaysPerHour constraints
+- **Layout state machine** — controls which layout is playing, handles XMR interrupts (changeLayout, overlayLayout), layout overrides with auto-revert, and synchronized transitions in multi-display setups
+- **Offline mode** — falls back to IndexedDB-cached schedule and media when CMS is unreachable, with exponential backoff retry (30s -> 60s -> 120s -> normal interval)
+- **Event bus** — emits 50+ lifecycle events (collection-start, register-complete, layout-prepare-request, layout-current, offline-mode, timeline-updated, etc.)
+- **XMR integration** — WebSocket-based real-time messaging for remote commands (layout changes, purge, screenshots, geo-location, commands, triggers)
+- **Multi-display sync** — coordinates synchronized layout transitions and video playback across multiple displays via optional SyncManager
+- **Layout blacklisting** — automatic fallback when a layout fails to render 3+ times
+- **Data connectors** — real-time polling of external data sources (weather, feeds, APIs) for dynamic content widgets
+- **Timeline calculation** — predicts next 2 hours of layout playback with duration estimation and missing media detection
+
+## Architecture
+
+```
++-----------------------------------------------------------------+
+| PlayerCore (Pure Orchestration)                                 |
+|                                                                 |
+|  +-------------+--------------+--------------+                  |
+|  | Collection  | Layout State | Offline      |                  |
+|  | Cycle       | Machine      | Cache (IDB)  |                  |
+|  +-------------+--------------+--------------+                  |
+|                                                                 |
+|  Events emitted (NO DOM manipulation):                          |
+|  collection-start, schedule-received, download-request,         |
+|  layout-prepare-request, layout-current, layout-expire-current, |
+|  offline-mode, timeline-updated, sync-config, xmr-connected    |
++-----------------------------------------------------------------+
+                             |
++-----------------------------------------------------------------+
+| Dependencies (injected)                                         |
++-----------------------------------------------------------------+
+| @xiboplayer/xmds     -> XMDS client (RegisterDisplay, etc.)    |
+| @xiboplayer/schedule  -> Schedule queue builder, layout eval    |
+| @xiboplayer/cache     -> Blob storage (media files, XLFs)      |
+| @xiboplayer/renderer  -> Layout rendering (platform-specific)  |
+| @xiboplayer/utils     -> Logger, EventEmitter, config          |
+| @xiboplayer/sync      -> Multi-display SyncManager (optional)  |
++-----------------------------------------------------------------+
+                             |
++-----------------------------------------------------------------+
+| Platform Layer (PWA / Electron / Chromium / Mobile)             |
+| - Renders layouts via renderer                                  |
+| - Handles UI updates, status display, progress indicators       |
+| - Manages storage, downloads via cache pkg                      |
+| - Listens to core events and updates the DOM                    |
++-----------------------------------------------------------------+
+```
+
+**Key principle:** PlayerCore emits events; it does not manipulate the UI. The platform layer listens to these events and implements the actual rendering, DOM updates, and platform-specific behaviors.
 
 ## Installation
 
@@ -19,36 +64,214 @@ npm install @xiboplayer/core
 
 ## Usage
 
+### Basic setup
+
 ```javascript
 import { PlayerCore } from '@xiboplayer/core';
 
-const player = new PlayerCore({
-  transport,   // XMDS or REST transport from @xiboplayer/xmds
-  schedule,    // Schedule instance from @xiboplayer/schedule
-  renderer,    // Renderer instance from @xiboplayer/renderer
-  cache,       // StoreClient + DownloadClient from @xiboplayer/cache
+const core = new PlayerCore({
+  config: displayConfig,
+  xmds: xmdsClient,
+  cache: cacheClient,
+  schedule: scheduleManager,
+  renderer: rendererInstance,
+  xmrWrapper: XmrClass,
+  statsCollector: statsClient,
+  displaySettings: dsManager,
 });
 
-player.on('download-request', ({ layoutOrder, files }) => {
-  // Handle media downloads in layout priority order
+core.on('collection-start', () => console.log('Polling CMS...'));
+core.on('schedule-received', (schedule) => console.log('Schedule updated'));
+core.on('download-request', ({ files, layoutOrder }) => {
+  downloadQueue(files, layoutOrder);
 });
 
-await player.init();
+core.on('layout-prepare-request', (layoutId) => {
+  renderer.renderLayout(layoutId);
+});
+
+core.on('offline-mode', (isOffline) => {
+  updateStatusDisplay(isOffline ? 'Offline' : 'Online');
+});
+
+await core.collect();
 ```
 
-## Key Events
+### Event handling
+
+```javascript
+// Layout lifecycle
+core.on('layout-prepare-request', (layoutId) => showLoadingBar());
+core.on('layout-current', (layoutId) => hideLoadingBar());
+core.on('layout-expire-current', () => fadeOutAndCleanup());
+
+// Timeline/schedule preview
+core.on('timeline-updated', (timeline) => {
+  // timeline: [{ layoutFile, startTime, endTime, duration, missingMedia, isDefault }]
+  updateTimelineOverlay(timeline);
+});
+
+// Offline
+core.on('offline-mode', (isOffline) => {
+  if (isOffline) showOfflineBanner('Using cached schedule');
+  else hideOfflineBanner();
+});
+```
+
+### Layout overrides (XMR)
+
+```javascript
+// Change to a specific layout, auto-revert after duration
+core.changeLayout(layoutId, { duration: 30 });
+
+// Overlay: push a layout on top of current content
+core.overlayLayout(layoutId, { duration: 10 });
+
+// Manual revert
+await core.revertToSchedule();
+```
+
+### Multi-display sync
+
+```javascript
+import { SyncManager } from '@xiboplayer/sync';
+
+const syncManager = new SyncManager({
+  displayId: 'screen-1',
+  syncConfig: regResult.syncConfig,
+  onLayoutChange: async (layoutId) => {
+    await renderer.prepareLayout(layoutId);
+    syncManager.reportReady(layoutId);
+  },
+  onLayoutShow: (layoutId) => renderer.show(layoutId),
+});
+
+syncManager.start();
+core.setSyncManager(syncManager);
+```
+
+## Collection Cycle
+
+The collection cycle runs every 300 seconds (configurable via CMS settings):
+
+```
+1. REGISTERDISPLAY
+   +- Authenticates display (hardware key)
+   +- Returns: settings, syncConfig, commands, checkRf/checkSchedule CRC32
+   +- Saves to IndexedDB for offline use
+
+2. CRC32 SKIP OPTIMIZATION
+   +- If checkRf unchanged -> skip RequiredFiles
+   +- If checkSchedule unchanged -> skip Schedule
+
+3. REQUIREDFILES (if checkRf changed)
+   +- Gets media, layouts, resources, dependencies, widgets
+   +- Checks for purge items (deleted media to remove)
+   +- Resets blacklist (CMS may have fixed layouts)
+
+4. SCHEDULE (if checkSchedule changed)
+   +- Gets CMS schedule (layouts, campaigns, dayparting, criteria)
+   +- Evaluates criteria (location, time, device, weather, custom)
+   +- Builds playback queue with priorities, maxPlaysPerHour, durations
+
+5. LAYOUT QUEUE EVALUATION
+   +- Calculates queue from schedule + durations + constraints
+   +- If current layout still valid -> keep playing
+   +- If expired -> emit layout-expire-current
+   +- If no current layout -> emit layout-prepare-request
+
+6. DOWNLOAD MANAGEMENT
+   +- Check download window (CMS can restrict to off-peak hours)
+   +- Emit download-request with files + layout priority order
+
+7. SUBMIT STATS & LOGS
+   +- Proof-of-play, diagnostic logs, fault reports
+   +- Multi-display: followers delegate to lead via SyncManager
+
+8. FINALIZE
+   +- Calculate timeline (next 2 hours)
+   +- Emit timeline-updated, collection-complete
+   +- Schedule next cycle
+
+OFFLINE FALLBACK:
+   If XMDS fails AND cached schedule exists:
+   +- Use cached schedule + cached media
+   +- Retry with backoff: 30s -> 60s -> 120s -> normal
+```
+
+## Events
 
 | Event | Payload | Description |
 |-------|---------|-------------|
-| `schedule-updated` | `{ schedule }` | New schedule received from CMS |
-| `download-request` | `{ layoutOrder, files }` | Media files needed, ordered by layout priority |
-| `layout-changed` | `{ layoutId }` | Currently playing layout changed |
-| `collection-error` | `{ error }` | CMS communication failed |
-| `status` | `{ message }` | Human-readable status update |
+| `collection-start` | -- | Collection cycle beginning |
+| `collection-complete` | -- | Collection cycle finished |
+| `collection-error` | `(error)` | CMS communication failed |
+| `register-complete` | `(regResult)` | RegisterDisplay succeeded |
+| `files-received` | `(files)` | RequiredFiles call succeeded |
+| `schedule-received` | `(schedule)` | Schedule call succeeded |
+| `download-request` | `(layoutOrder, files)` | Download needed files in layout priority order |
+| `layout-prepare-request` | `(layoutId)` | Next layout ready for rendering |
+| `layout-current` | `(layoutId)` | Layout is now playing |
+| `layout-pending` | `(layoutId, requiredMediaIds)` | Layout waiting for media downloads |
+| `layout-expire-current` | -- | Current layout duration ended |
+| `layout-already-playing` | `(layoutId)` | Schedule changed but current layout still valid |
+| `no-layouts-scheduled` | -- | No layouts match current time |
+| `layout-blacklisted` | `({ layoutId, reason, failures })` | Layout failed 3+ times, skipped |
+| `offline-mode` | `(isOffline)` | Entered/exited offline mode |
+| `xmr-connected` | `(xmrUrl)` | XMR WebSocket connected |
+| `sync-config` | `(syncConfig)` | Display is in a sync group |
+| `timeline-updated` | `(timeline)` | Schedule preview for next 2 hours |
+| `screenshot-request` | -- | XMR requested screenshot |
+| `revert-to-schedule` | -- | Layout override ended |
+| `overlay-layout-request` | `(layoutId)` | Overlay layout requested |
+| `execute-native-command` | `({ code, commandString })` | Non-HTTP command for platform |
+| `scheduled-command` | `(command)` | Scheduled command ready |
+| `submit-stats-request` | -- | Submit proof-of-play stats |
+| `submit-logs-request` | -- | Submit player logs |
+| `submit-faults-request` | -- | Submit faults (~60s cycle) |
+
+## API Reference
+
+### Constructor
+
+```javascript
+new PlayerCore({
+  config,              // Display configuration (cmsUrl, hardwareKey, displayName, etc.)
+  xmds,                // XMDS client instance
+  cache,               // Cache/storage client
+  schedule,            // Schedule manager
+  renderer,            // Layout renderer
+  xmrWrapper,          // XMR WebSocket wrapper class
+  statsCollector?,     // Optional proof-of-play tracker
+  displaySettings?,    // Optional display settings manager
+})
+```
+
+### Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `collect()` | `Promise<void>` | Start collection cycle |
+| `collectNow()` | `Promise<void>` | Force immediate collection (clears CRC32 cache) |
+| `collectOffline()` | `void` | Use cached schedule |
+| `getNextLayout()` | `object \| null` | Get next layout from queue, skip blacklisted |
+| `advanceToNextLayout()` | `void` | Pop next layout, emit layout-prepare-request |
+| `advanceToPreviousLayout()` | `void` | Go back in schedule |
+| `setCurrentLayout(layoutId)` | `void` | Mark layout as currently playing |
+| `getCurrentLayoutId()` | `number \| null` | Get currently playing layout ID |
+| `changeLayout(layoutId, opts)` | `Promise<void>` | XMR: change layout with optional duration |
+| `overlayLayout(layoutId, opts)` | `Promise<void>` | XMR: push overlay layout |
+| `revertToSchedule()` | `Promise<void>` | Exit layout override |
+| `reportLayoutFailure(id, reason)` | `void` | Report render failure; blacklist after 3 |
+| `reportLayoutSuccess(id)` | `void` | Clear failure counter |
+| `setSyncManager(syncManager)` | `void` | Attach SyncManager for multi-display |
+| `isSyncLead()` | `boolean` | Check if this display is sync lead |
+| `purgeAll()` | `Promise<void>` | Delete all cache and re-download |
+| `cleanup()` | `void` | Stop all timers, close XMR, remove listeners |
 
 ## Dependencies
 
-- `@xiboplayer/utils` — logger, events, config
+- `@xiboplayer/utils` -- logger, events, config
 
 ---
 

--- a/packages/docs/AUDIT.md
+++ b/packages/docs/AUDIT.md
@@ -134,7 +134,7 @@ All handlers implemented: `collectNow`, `screenShot`, `licenceCheck`, `changeLay
 | Renderer | Browser DOM | GTK4/WebView | Different approach |
 | Offline mode | ✅ (IndexedDB) | ✅ (SQLite) | Both robust |
 | Package system | npm monorepo | Single binary | Different trade-offs |
-| Test coverage | 1345 tests | ~200 tests | SDK more tested |
+| Test coverage | 1412 tests | ~200 tests | SDK more tested |
 
 ## Prioritized Gap List — Resolution Status
 

--- a/packages/docs/CONFIGURATION.md
+++ b/packages/docs/CONFIGURATION.md
@@ -44,9 +44,10 @@ See [PER_CMS_CACHE.md](PER_CMS_CACHE.md) for the full design rationale and cache
 
 ### Server
 
-| Key          | Type   | Default          | Description                          |
-|--------------|--------|------------------|--------------------------------------|
-| `serverPort` | number | `8765` (Electron) / `8766` (Chromium) | Local proxy server port |
+| Key              | Type   | Default          | Description                          |
+|------------------|--------|------------------|--------------------------------------|
+| `serverPort`     | number | `8765` (Electron) / `8766` (Chromium) | Local proxy server port |
+| `listenAddress`  | string | `"localhost"`    | Network interface to bind the proxy server. Set to `"0.0.0.0"` to allow LAN connections (required for cross-device video wall sync). |
 
 ### Window & Display
 
@@ -170,6 +171,7 @@ Not all keys apply to every platform. Shell-only keys are filtered out by `extra
 | `cmsKey`            | yes | yes      | yes      |                          |
 | `displayName`       | yes | yes      | yes      |                          |
 | `serverPort`        | —   | yes      | yes      | Shell-only               |
+| `listenAddress`     | —   | yes      | yes      | Shell-only, default `localhost` |
 | `kioskMode`         | —   | yes      | yes      | Shell-only               |
 | `fullscreen`        | —   | yes      | yes      | Shell-only               |
 | `hideMouseCursor`   | —   | yes      | yes      | Shell-only               |
@@ -247,6 +249,20 @@ In the browser (PWA), `localStorage` is the primary source; env vars are not ava
 ```
 
 All other defaults (kiosk mode, fullscreen, hidden cursor, WARNING log level) apply automatically.
+
+## Example: Video Wall Lead
+
+```json
+{
+  "cmsUrl": "https://cms.example.com",
+  "cmsKey": "yourKey",
+  "displayName": "videowall-lead",
+  "listenAddress": "0.0.0.0",
+  "preventSleep": true
+}
+```
+
+The `listenAddress: "0.0.0.0"` opens the proxy server to LAN connections, allowing follower devices to connect to the WebSocket sync relay at `ws://<lead-ip>:8765/sync`. Sync group and publisher port are configured in the CMS display settings. Follower devices only need standard CMS connection settings — no `listenAddress` override needed.
 
 ## CLI Flags
 

--- a/packages/docs/STATUS.md
+++ b/packages/docs/STATUS.md
@@ -162,9 +162,9 @@ All 15 audit issues resolved (PRs #86–#90). 8 implemented, 5 closed as already
 ## Test Suite
 
 ```
-Tests:  1345 passed | 5 skipped (1350 total)
-Files:  35 test files (all passed)
-Time:   ~12s
+Tests:  1412 passed | 5 skipped (1417 total)
+Files:  36 test files (all passed)
+Time:   ~10s
 ```
 
 ## Performance

--- a/packages/renderer/README.md
+++ b/packages/renderer/README.md
@@ -1,19 +1,53 @@
 # @xiboplayer/renderer
 
-**XLF layout rendering engine for Xibo digital signage.**
+**Fast, memory-efficient XLF layout rendering engine for digital signage.**
 
 ## Overview
 
-RendererLite parses Xibo Layout Format (XLF) files and builds a live DOM with:
+Parses Xibo Layout Format (XLF) files and builds a live DOM with element reuse, instant transitions, and a 2-layout preload pool:
 
-- **Rich media** — video (MP4/HLS), images, PDF (via PDF.js), text/ticker, web pages, clock, calendar, weather
-- **Transitions** — fade and fly (8-direction compass) via Web Animations API
-- **Interactive actions** — touch/click and keyboard triggers for widget navigation, layout jumps, and commands
-- **Layout preloading** — 2-layout pool pre-builds upcoming layouts at 75% of current duration for zero-gap transitions
-- **Proportional scaling** — ResizeObserver-based scaling to fit any screen resolution
-- **Overlay support** — multiple simultaneous overlay layouts with independent z-index (1000+)
-- **Absolute widget positioning** — widget elements use `position: absolute` within regions to layer correctly in multi-widget regions
-- **Animation cleanup** — `fill: forwards` animations cancelled between widgets to prevent stale visual state (e.g. video hidden after PDF)
+- **Rich media** -- video (MP4/HLS), images (scaleType, align/valign), audio (with visualization), PDF (PDF.js), text/ticker, web pages, clock, calendar, weather, and all CMS widget types
+- **Instant layout transitions** -- 2-layout preload pool keeps the next layout DOM-ready for zero-gap swap
+- **Element reuse** -- pre-creates all widget elements upfront; cycling reuses them instead of destroying/rebuilding
+- **Transitions** -- fade and fly animations with 8 compass directions via Web Animations API
+- **Canvas regions** -- simultaneous multi-widget rendering (stacked layers)
+- **Drawer regions** -- hidden action-triggered areas for interactive controls
+- **Overlays** -- multiple floating layouts with priority z-indexing
+- **Interactive actions** -- touch/click and keyboard triggers for widget navigation, layout jumps, and command execution
+- **Shell commands** -- native command execution via Electron IPC and Chromium HTTP endpoint
+- **Sub-playlist cycling** -- round-robin or random selection from widget groups
+- **Dynamic duration** -- video/audio metadata overrides for accurate timing
+- **Scale-to-fit** -- responsive scaling for any screen size via ResizeObserver
+
+## Architecture
+
+```
+XLF XML -> RendererLite
+            +- parseXlf() -> Layout object {width, height, regions: []}
+            +- renderLayout()
+                +- createRegion() for each region
+                |   +- createWidgetElement() for each widget
+                |       +- renderImage()        [<img>]
+                |       +- renderVideo()        [<video>] (HLS/DASH)
+                |       +- renderAudio()        [<audio> + visual]
+                |       +- renderTextWidget()   [<iframe>] (GetResource)
+                |       +- renderPdf()          [<canvas>] (multi-page)
+                |       +- renderWebpage()      [<iframe>]
+                |       +- renderVideoIn()      [<video>] (webcam)
+                |       +- renderGenericWidget() [<iframe>] (clock, etc.)
+                |
+                +- attachActionListeners() for touch/click/keyboard
+                +- startRegion() -> _startRegionCycle()
+                |   +- renderWidget() / stopWidget() cycling
+                |
+                +- startLayoutTimerWhenReady()
+                    +- Waits for all initial widgets to load
+                    +- Starts layout duration timer
+
+Layout Pool (2 entries max):
+  +- Hot entry    (visible, currently playing)
+  +- Warm entry   (preloaded, hidden, ready for instant swap)
+```
 
 ## Installation
 
@@ -23,33 +57,214 @@ npm install @xiboplayer/renderer
 
 ## Usage
 
+### Basic rendering
+
 ```javascript
 import { RendererLite } from '@xiboplayer/renderer';
 
-const renderer = new RendererLite({
-  container: document.getElementById('player'),
+const renderer = new RendererLite(
+  { cmsUrl: 'https://cms.example.com', hardwareKey: 'DISPLAY-001' },
+  document.getElementById('player')
+);
+
+renderer.on('layoutStart', (layoutId, layout) => {
+  console.log(`Layout ${layoutId} started (${layout.duration}s)`);
 });
 
-// Render a layout from parsed XLF
-await renderer.renderLayout(xlf, { mediaBaseUrl: '/cache/' });
+renderer.on('layoutEnd', (layoutId) => {
+  console.log(`Layout ${layoutId} ended`);
+});
+
+await renderer.renderLayout(xlfXmlContent, 42);
+```
+
+### Preloading for instant transitions
+
+```javascript
+// At 75% of current layout duration, renderer emits:
+renderer.on('request-next-layout-preload', async () => {
+  const nextLayout = await getNextLayoutFromSchedule();
+  if (nextLayout && !renderer.hasPreloadedLayout(nextLayout.id)) {
+    await renderer.preloadLayout(nextLayout.xlf, nextLayout.id);
+  }
+});
+
+// When it's time to show next layout, swap is INSTANT if preloaded
+await renderer.renderLayout(nextXlfXml, nextLayoutId);
+```
+
+### Overlays
+
+```javascript
+// Render an overlay on top of the main layout
+await renderer.renderOverlay(alertXlfXml, 101, 10);
+
+renderer.on('overlayEnd', (overlayId) => console.log('Overlay done'));
+
+// Stop overlay
+renderer.stopOverlay(101);
 ```
 
 ## Widget Types
 
-| Widget | Implementation |
-|--------|---------------|
-| Video | `<video>` with native HLS (Safari) + hls.js fallback, pause-on-last-frame |
-| Image | `<img>` with CMS scaleType mapping (center->contain, stretch->fill, fit->cover), blob URL from cache |
-| PDF | PDF.js canvas rendering (dynamically imported) |
-| Text / Ticker | iframe with CMS-rendered HTML via GetResource |
-| Web page | bare `<iframe src="...">` |
-| Clock, Calendar, Weather | iframe via GetResource (server-rendered) |
-| All other CMS widgets | Generic iframe via GetResource |
+| Type | Element | Source | Notes |
+|------|---------|--------|-------|
+| **image** | `<img>` | Media file | Object-fit: center/stretch/fit. objectPosition: top/middle/bottom, left/center/right |
+| **video** | `<video>` | Media file | HLS via native (Safari) + hls.js fallback. Pause-on-last-frame. Duration detection |
+| **audio** | `<audio>` + visual | Media file | Gradient visualization + music note icon. Volume control. Loop option |
+| **videoin** | `<video>` | getUserMedia() | Webcam/mic capture with mirror mode |
+| **text** | `<iframe>` | GetResource | CMS-rendered HTML. Parses NUMITEMS/DURATION comments |
+| **ticker** | `<iframe>` | GetResource | Data feeds with dynamic cycling |
+| **pdf** | `<canvas>` | Media file | PDF.js multi-page cycling. Page indicator. Time-per-page = duration / pages |
+| **webpage** | `<iframe>` | Direct URL | modeId=1 (URL), modeId=0 (GetResource) |
+| **clock** | `<iframe>` | GetResource | Digital/analogue variants |
+| **calendar** | `<iframe>` | GetResource | Calendar widget HTML |
+| **weather** | `<iframe>` | GetResource | Weather service HTML |
+| **global** | Stacked iframes | GetResource | Canvas region auto-detect for multi-layer content |
+| **all others** | `<iframe>` | GetResource | Generic CMS widget HTML |
+
+## Layout Lifecycle
+
+```
+XLF XML
+  |
+  +- parseXlf() -> {width, height, regions: [{widgets: [...]}]}
+  |
+  +- calculateScale() -> fit layout to screen
+  |
+  +- createRegion() for each region
+  |   +- Filter widgets (fromDt/toDt time-gating)
+  |   +- Apply sub-playlist cycling
+  |
+  +- createWidgetElement() for each widget (pre-creation)
+  |   +- Create DOM element, position absolute, hidden
+  |   +- Track blob URLs for cleanup
+  |
+  +- startRegion() for each region
+  |   +- Canvas: show ALL widgets at once, timer = max duration
+  |   +- Normal: cycle widgets with transitions
+  |
+  +- startLayoutTimerWhenReady()
+  |   +- Wait for video.playing / img.load (or 10s timeout)
+  |   +- Start layout duration timer
+  |
+  +- At 75%: emit 'request-next-layout-preload'
+  |
+  +- Layout duration expires
+      +- emit('layoutEnd', layoutId)
+```
+
+### Element reuse flow
+
+1. All widget elements pre-created during `renderLayout()` -- hidden, opacity 0
+2. Cycling: `renderWidget()` shows current, `stopWidget()` hides (same elements)
+3. No DOM destruction/recreation -- smooth transitions, instant replay
+4. When layout evicted from pool: blob URLs revoked, elements removed
+
+### Ready-wait gating
+
+Layout timer starts only when all initial widgets are loaded:
+- Video: waits for `playing` event
+- Image: waits for `load` event
+- Text/embedded: ready immediately
+- Timeout: 10s per widget (don't block on broken media)
+
+## Transitions
+
+Defined per-widget in XLF options:
+
+**Fade:** `fade`, `fadein`, `fadeout` -- opacity animation
+
+**Fly:** `fly`, `flyin`, `flyout` -- translate animation with compass direction:
+- `N`, `NE`, `E`, `SE`, `S`, `SW`, `W`, `NW`
+
+```xml
+<media duration="5">
+  <options>
+    <transIn>fly</transIn>
+    <transInDuration>1000</transInDuration>
+    <transInDirection>NE</transInDirection>
+    <transOut>fade</transOut>
+    <transOutDuration>500</transOutDuration>
+  </options>
+</media>
+```
+
+## Interactive Actions
+
+Actions defined in XLF at layout, region, or widget level:
+
+**Trigger types:** `touch` (click), `keyboard:KEY` (e.g., `keyboard:n`, `keyboard:Enter`)
+
+**Action types:** `navWidget` (jump to widget), `nextWidget`, `previousWidget`, `shellCommand`
+
+```javascript
+renderer.on('action-trigger', (actionData) => {
+  console.log(`Action: ${actionData.actionType}`, actionData);
+});
+
+// Programmatic navigation
+renderer.navigateToWidget('target-widget-id');
+renderer.nextWidget('region-id');
+renderer.previousWidget('region-id');
+```
+
+## Events
+
+| Event | Args | Description |
+|-------|------|-------------|
+| `layoutStart` | `(layoutId, layout)` | Layout DOM built and playback started |
+| `layoutEnd` | `(layoutId)` | Layout duration expired |
+| `layoutDurationUpdated` | `(layoutId, newDuration)` | Video metadata revealed actual duration |
+| `widgetStart` | `({ widgetId, regionId, layoutId, type, duration, enableStat })` | Widget now visible |
+| `widgetEnd` | `({ widgetId, regionId, layoutId, type, enableStat })` | Widget hidden/cycled |
+| `widgetCommand` | `({ commandCode, commandString, widgetId, regionId, layoutId })` | Shell command triggered |
+| `widgetAction` | `({ type, widgetId, layoutId, regionId, url })` | Widget webhook URL |
+| `videoError` | `({ storedAs, fileId, errorCode, errorMessage })` | Video playback error |
+| `overlayStart` | `(overlayId, layout)` | Overlay rendered |
+| `overlayEnd` | `(overlayId)` | Overlay finished |
+| `action-trigger` | `({ actionType, triggerType, targetId, commandCode })` | Touch/keyboard action fired |
+| `request-next-layout-preload` | `()` | 75% through layout -- preload next |
+| `error` | `({ type, error, layoutId, widgetId })` | Generic error |
+
+## API Reference
+
+### Constructor
+
+```javascript
+new RendererLite(config, container, options?)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `config` | Object | `{ cmsUrl, hardwareKey }` |
+| `container` | HTMLElement | DOM element to render into |
+| `options.getWidgetHtml` | Function? | `(widget) => htmlString` -- fetch widget HTML from cache |
+| `options.fileIdToSaveAs` | Map? | Map of fileId to storedAs filename |
+
+### Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `renderLayout(xlfXml, layoutId)` | Promise | Parse, build, and start layout. Instant swap if preloaded. |
+| `preloadLayout(xlfXml, layoutId)` | Promise<bool> | Pre-build layout as hidden warm entry |
+| `hasPreloadedLayout(layoutId)` | boolean | Check if layout is in preload pool |
+| `renderOverlay(xlfXml, layoutId, priority)` | Promise | Render overlay on top |
+| `stopCurrentLayout()` | void | Stop main layout |
+| `stopOverlay(layoutId)` | void | Stop and remove overlay |
+| `stopAllOverlays()` | void | Stop all active overlays |
+| `navigateToWidget(widgetId)` | void | Jump to specific widget |
+| `nextWidget(regionId?)` | void | Advance to next widget |
+| `previousWidget(regionId?)` | void | Go back to previous widget |
+| `pause()` | void | Pause media and widget cycling |
+| `resume()` | void | Resume playback |
+| `cleanup()` | void | Stop all, clear pool, revoke blob URLs |
 
 ## Dependencies
 
-- `@xiboplayer/utils` — logger, events
-- `pdfjs-dist` — PDF rendering
+- `@xiboplayer/utils` -- logger, events
+- `pdfjs-dist` -- PDF rendering (dynamic import)
+- `hls.js` -- HLS streaming (dynamic import)
 
 ---
 

--- a/packages/schedule/README.md
+++ b/packages/schedule/README.md
@@ -1,17 +1,59 @@
 # @xiboplayer/schedule
 
-**Campaign scheduling with dayparting, interrupts, overlays, and timeline prediction.**
+**Complete scheduling solution: campaigns, dayparting, interrupts, overlays, and timeline prediction.**
 
 ## Overview
 
-Complete scheduling solution for Xibo digital signage:
+Manages all aspects of digital signage scheduling to determine which layouts play when:
 
-- **Campaign scheduling** — priority-based campaign rotation with configurable play counts
-- **Dayparting** — weekly time slots with midnight-crossing support
-- **Interrupts** — percentage-based share-of-voice scheduling with even interleaving across the hour
-- **Overlays** — multiple simultaneous overlay layouts with independent scheduling and priority
-- **Geo-fencing** — location-based schedule filtering with criteria evaluation
-- **Timeline prediction** — deterministic future schedule simulation for proactive content preloading
+- **Campaign scheduling** -- groups of layouts with time windows and priorities
+- **Dayparting** -- weekly time slots (Mon-Fri 09:00-17:00, evenings, weekends) with midnight-crossing support
+- **Priority fallback** -- higher-priority layouts hide lower-priority ones; rate limiting triggers automatic fallback
+- **Rate limiting** -- `maxPlaysPerHour` with even distribution (prevents bursts, ensures spacing)
+- **Interrupts (Share of Voice)** -- layouts that must play X% of each hour, interleaved with normal content
+- **Overlays** -- layouts that appear on top of main layouts without interrupting playback
+- **Criteria evaluation** -- conditional display based on time, weather, custom display properties
+- **Geo-fencing** -- location-based filtering (point + radius, Haversine distance)
+- **Timeline prediction** -- deterministic simulation of future playback for UI overlays
+- **Default layout** -- fallback when no campaigns are active
+
+## Architecture
+
+```
+CMS Schedule XML
+        |
+        v
++-------------------------------------+
+|  Schedule Parser                    |
+|  +- campaigns[]                     |
+|  +- layouts[]                       |
+|  +- overlays[]                      |
+|  +- default layout                  |
++-------------------------------------+
+        |
+        v
++-------------------------------------+
+|  Evaluation Engine                  |
+|  +- Recurrence (Week/Day/Month)     |
+|  +- Time windows (dayparting)       |
+|  +- Criteria (weather, properties)  |
+|  +- Geo-fencing                     |
+|  +- Priority + rate-limit filtering |
++-------------------------------------+
+        |
+        v
++-------------------------------------+
+|  Schedule Queue Builder (LCM-based) |
+|  Deterministic round-robin with:    |
+|  +- Rate-limited slots (even spaced)|
+|  +- Priority fallback               |
+|  +- Default fills gaps              |
++-------------------------------------+
+        |
+        +-> getCurrentLayouts()        -> Renderer
+        +-> getLayoutsInTimeRange()    -> Timeline Overlay
+        +-> Track play history         -> Rate limiting
+```
 
 ## Installation
 
@@ -21,19 +63,245 @@ npm install @xiboplayer/schedule
 
 ## Usage
 
+### Basic scheduling
+
 ```javascript
-import { Schedule } from '@xiboplayer/schedule';
+import { ScheduleManager } from '@xiboplayer/schedule';
 
-const schedule = new Schedule();
-schedule.update(scheduleXml);
+const schedule = new ScheduleManager();
 
-const currentLayouts = schedule.getCurrentLayouts();
-const timeline = schedule.getTimeline(now, now + 3600000); // next hour
+schedule.setSchedule({
+  campaigns: [
+    {
+      id: 1,
+      priority: 100,
+      fromdt: '2025-01-01 09:00',
+      todt: '2025-12-31 17:00',
+      recurrenceType: 'Week',
+      recurrenceRepeatsOn: '1,2,3,4,5', // Mon-Fri
+      layouts: [
+        { id: 10, file: '10.xlf', duration: 30 },
+        { id: 11, file: '11.xlf', duration: 30 },
+      ],
+    },
+  ],
+  default: '99.xlf',
+});
+
+const layoutsToPlay = schedule.getCurrentLayouts();
+// Business hours: ['10.xlf', '11.xlf']
+// After hours: ['99.xlf'] (default)
+```
+
+### Dayparting with midnight crossing
+
+```javascript
+schedule.setSchedule({
+  layouts: [
+    {
+      id: 1,
+      file: '1.xlf',
+      recurrenceType: 'Week',
+      recurrenceRepeatsOn: '1,2,3,4,5,6,7',
+      fromdt: '1970-01-01 22:00:00', // 10 PM
+      todt: '1970-01-01 02:00:00',   // 2 AM (next day)
+    },
+  ],
+});
+
+// Friday 23:00: returns ['1.xlf']
+// Saturday 01:00: returns ['1.xlf'] (midnight crossing works)
+```
+
+### Rate limiting with even distribution
+
+```javascript
+schedule.setSchedule({
+  layouts: [
+    {
+      id: 1,
+      file: '1.xlf',
+      maxPlaysPerHour: 3, // 3 times per hour, evenly spaced
+    },
+  ],
+});
+
+schedule.recordPlay('1'); // Play at 09:00
+// Can't play again until 09:20 (60 / 3 = 20 min minimum gap)
+```
+
+### Interrupts (Share of Voice)
+
+```javascript
+schedule.setSchedule({
+  layouts: [
+    { id: 1, file: '1.xlf', duration: 30 },
+    { id: 2, file: '2.xlf', duration: 30, shareOfVoice: 20 }, // 20% of each hour
+  ],
+});
+
+const layouts = schedule.getCurrentLayouts();
+// Interleaved: normal, normal, interrupt, normal, normal, interrupt, ...
+```
+
+### Criteria-based display
+
+```javascript
+schedule.setSchedule({
+  layouts: [
+    {
+      id: 1,
+      file: '1.xlf',
+      criteria: [
+        { metric: 'weatherTemp', condition: 'greaterThan', value: '25', type: 'number' },
+      ],
+    },
+  ],
+});
+
+schedule.setWeatherData({ temperature: 28, humidity: 65 });
+// Layout 1 displays only when temperature > 25
+```
+
+### Geo-fencing
+
+```javascript
+schedule.setLocation(37.7749, -122.4194);
+
+schedule.setSchedule({
+  layouts: [
+    {
+      id: 1,
+      file: '1.xlf',
+      isGeoAware: true,
+      geoLocation: '37.7749,-122.4194,500', // lat,lng,radius_meters
+    },
+  ],
+});
+
+// Returns ['1.xlf'] only if player is within 500m
+```
+
+### Timeline prediction
+
+```javascript
+const timeline = calculateTimeline(queue, queuePosition, {
+  from: new Date(),
+  hours: 2,
+  defaultLayout: schedule.schedule.default,
+  durations: durations,
+});
+
+// Returns:
+// [
+//   { layoutFile: '10.xlf', startTime, endTime, duration: 30, isDefault: false },
+//   { layoutFile: '11.xlf', startTime, endTime, duration: 30, isDefault: false },
+//   ...
+// ]
+```
+
+## Campaign Evaluation Algorithm
+
+When `getCurrentLayouts()` is called:
+
+1. **Filter time-active items** -- campaigns and standalone layouts within their date/time window and recurrence rules
+2. **Apply criteria** -- filter by weather, display properties, geo-fencing
+3. **Apply rate limiting** -- exclude layouts that exceeded `maxPlaysPerHour`
+4. **Find max priority** -- only max priority items win
+5. **Extract layouts** -- campaigns return all their layouts; standalone layouts contribute themselves
+6. **Process interrupts** -- separate interrupt layouts, calculate share-of-voice, interleave
+7. **Return layout files** -- ready for the renderer
+
+## Key Concepts
+
+### Schedule Queue (LCM-based)
+
+The queue is a pre-computed, deterministic round-robin cycle:
+
+- **LCM period** -- Least Common Multiple of all `maxPlaysPerHour` intervals (capped at 2 hours)
+- **Simulation** -- walks the period applying priority and rate-limit rules at each step
+- **Caching** -- reused until the active layout set changes
+- **Predictable** -- answers "what's playing in 30 minutes?" offline
+
+### Dayparting
+
+| Type | Pattern | Example |
+|------|---------|---------|
+| Week | Specific days + time-of-day | Mon-Fri 09:00-17:00 |
+| Day | Daily with optional interval | Every 2 days |
+| Month | Specific days of month | 1st, 15th (monthly) |
+
+Midnight crossing: `22:00 - 02:00` works across day boundaries.
+
+### Criteria Evaluation
+
+**Built-in metrics:** `dayOfWeek`, `dayOfMonth`, `month`, `hour`, `isoDay`
+
+**Weather metrics:** `weatherTemp`, `weatherHumidity`, `weatherWindSpeed`, `weatherCondition`, `weatherCloudCover`
+
+**Operators:** `equals`, `notEquals`, `greaterThan`, `greaterThanOrEquals`, `lessThan`, `lessThanOrEquals`, `contains`, `startsWith`, `endsWith`, `in`
+
+### Geo-fencing
+
+- Format: `"lat,lng,radius"` (e.g., `"37.7749,-122.4194,500"`)
+- Default radius: 500 meters
+- Calculation: Haversine formula (great-circle distance)
+- Permissive: if no location available, layout displays (fail-open for offline)
+
+## API Reference
+
+### Constructor
+
+```javascript
+new ScheduleManager(options?)
+```
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `interruptScheduler` | InterruptScheduler? | Optional interrupt handler |
+| `displayProperties` | Object? | Custom display fields from CMS |
+
+### Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `setSchedule(schedule)` | void | Load schedule from XMDS response |
+| `getCurrentLayouts()` | string[] | Layouts active now |
+| `getLayoutsAtTime(date)` | string[] | Layouts at specific time |
+| `getAllLayoutsAtTime(date)` | Array | All time-active layouts with metadata |
+| `getScheduleQueue(durations)` | {queue, periodSeconds} | Pre-computed round-robin queue |
+| `popNextFromQueue(durations)` | {layoutId, duration} | Pop next entry, advance position |
+| `peekNextInQueue(durations)` | {layoutId, duration} | Peek without advancing |
+| `recordPlay(layoutId)` | void | Track a play for rate limiting |
+| `canPlayLayout(layoutId, max)` | boolean | Check if layout can play now |
+| `setWeatherData(data)` | void | Update weather for criteria |
+| `setLocation(lat, lng)` | void | Set GPS location for geo-fencing |
+| `setDisplayProperties(props)` | void | Set custom display fields |
+| `detectConflicts(options)` | Array | Find priority-shadowing conflicts |
+
+### Overlay Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `setOverlays(overlays)` | void | Update overlay list |
+| `getCurrentOverlays()` | Array | Active overlays (sorted by priority) |
+| `shouldCheckOverlays(lastCheck)` | boolean | Check interval (every 60s) |
+
+### Timeline Functions
+
+```javascript
+import { calculateTimeline, parseLayoutDuration, buildScheduleQueue } from '@xiboplayer/schedule';
+
+const { duration } = parseLayoutDuration(xlfXml, videoDurations?);
+const { queue, periodSeconds } = buildScheduleQueue(allLayouts, durations);
+const timeline = calculateTimeline(queue, position, { from, hours, defaultLayout, durations });
 ```
 
 ## Dependencies
 
-- `@xiboplayer/utils` — logger, events
+No external dependencies -- fully self-contained scheduling engine.
+
+- `@xiboplayer/utils` -- logging only
 
 ---
 

--- a/packages/settings/README.md
+++ b/packages/settings/README.md
@@ -1,17 +1,37 @@
 # @xiboplayer/settings
 
-**CMS display settings management for Xibo Player.**
+**CMS display settings management for Xibo players.**
 
 ## Overview
 
-Manages display configuration received from the CMS:
+Parses and applies display configuration received from the CMS RegisterDisplay response:
 
-- **Resolution** — screen dimensions and orientation
-- **Collection interval** — how often to poll the CMS
-- **Download windows** — time-of-day restrictions for media downloads
-- **Screenshot config** — screenshot dimensions, quality, and interval
-- **Log level** — remote log verbosity control
-- **Stats config** — proof of play aggregation mode and submission interval
+- **Collection interval** -- how often to poll the CMS (60s-86400s, default 300s)
+- **Display info** -- name, resolution (sizeX/sizeY)
+- **Stats config** -- enable/disable, aggregation mode (Individual/Aggregate)
+- **Log level** -- remote log verbosity (error, audit, info, debug)
+- **XMR config** -- WebSocket address and CMS key for real-time commands
+- **Download windows** -- time-of-day restrictions with overnight crossing support
+- **Screenshot config** -- interval and quality settings
+- **Event-driven** -- emits `interval-changed` and `settings-applied` on updates
+
+## Architecture
+
+```
+CMS RegisterDisplay response
+        |
+        v
+DisplaySettings.applySettings(raw)
+  +- Parse all settings (handles both camelCase and PascalCase)
+  +- Validate and normalize values
+  +- Detect changes (collectInterval)
+  +- Emit events
+        |
+        v
+Platform Layer listens to events
+  +- 'interval-changed' -> update collection timer
+  +- 'settings-applied' -> update UI, screenshot config, etc.
+```
 
 ## Installation
 
@@ -22,18 +42,96 @@ npm install @xiboplayer/settings
 ## Usage
 
 ```javascript
-import { SettingsManager } from '@xiboplayer/settings';
+import { DisplaySettings } from '@xiboplayer/settings';
 
-const settings = new SettingsManager();
-settings.apply(cmsSettings);
+const settings = new DisplaySettings();
 
-const interval = settings.get('collectInterval');
-const screenshotEnabled = settings.get('screenshotRequested');
+// Apply settings from CMS (RegisterDisplay response)
+const { changed, settings: applied } = settings.applySettings(regResult.settings);
+console.log('Changed:', changed); // e.g., ['collectInterval']
+
+// Read settings
+const interval = settings.getCollectInterval(); // 300 (seconds)
+const displayName = settings.getDisplayName();   // 'Lobby Display'
+const { width, height } = settings.getDisplaySize(); // { width: 1920, height: 1080 }
+const statsOn = settings.isStatsEnabled();        // true/false
+
+// Check download window
+if (settings.isInDownloadWindow()) {
+  startDownloads();
+} else {
+  const next = settings.getNextDownloadWindow();
+  console.log(`Downloads paused, next window at ${next}`);
+}
+
+// Check screenshot timing
+if (settings.shouldTakeScreenshot(lastScreenshotDate)) {
+  captureScreenshot();
+}
+
+// Listen for changes
+settings.on('interval-changed', (newInterval) => {
+  updateCollectionTimer(newInterval);
+});
+
+settings.on('settings-applied', (allSettings, changedKeys) => {
+  console.log('Settings updated:', changedKeys);
+});
 ```
+
+## Settings
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `collectInterval` | number | 300 | CMS polling interval (seconds, min 60, max 86400) |
+| `displayName` | string | 'Unknown Display' | Human-readable display name |
+| `sizeX` / `sizeY` | number | 1920 / 1080 | Display resolution |
+| `statsEnabled` | boolean | false | Enable proof-of-play tracking |
+| `aggregationLevel` | string | 'Individual' | Stats mode: 'Individual' or 'Aggregate' |
+| `logLevel` | string | 'error' | Remote log level |
+| `xmrNetworkAddress` | string | null | XMR network address |
+| `xmrWebSocketAddress` | string | null | XMR WebSocket URL |
+| `xmrCmsKey` | string | null | XMR authentication key |
+| `preventSleep` | boolean | true | Keep screen awake |
+| `screenshotInterval` | number | 120 | Seconds between screenshots |
+| `downloadStartWindow` | string | null | Download window start (HH:MM) |
+| `downloadEndWindow` | string | null | Download window end (HH:MM) |
+
+## API Reference
+
+### Constructor
+
+```javascript
+new DisplaySettings()
+```
+
+Extends EventEmitter -- supports `on()`, `off()`, `emit()`.
+
+### Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `applySettings(raw)` | `{ changed, settings }` | Parse and apply CMS settings |
+| `getCollectInterval()` | `number` | Collection interval in seconds |
+| `getDisplayName()` | `string` | Display name |
+| `getDisplaySize()` | `{ width, height }` | Display resolution |
+| `isStatsEnabled()` | `boolean` | Stats enabled flag |
+| `getAllSettings()` | `Object` | All settings (copy) |
+| `getSetting(key, default?)` | `any` | Get specific setting |
+| `isInDownloadWindow()` | `boolean` | Check if downloads are allowed now |
+| `getNextDownloadWindow()` | `Date \| null` | Next download window start |
+| `shouldTakeScreenshot(last)` | `boolean` | Check if screenshot interval elapsed |
+
+### Events
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `interval-changed` | `(seconds)` | Collection interval changed |
+| `settings-applied` | `(settings, changedKeys)` | Settings applied from CMS |
 
 ## Dependencies
 
-- `@xiboplayer/utils` — logger, events
+- `@xiboplayer/utils` -- EventEmitter, logger
 
 ---
 

--- a/packages/stats/README.md
+++ b/packages/stats/README.md
@@ -1,15 +1,50 @@
 # @xiboplayer/stats
 
-**Proof of play tracking, stats reporting, and CMS logging.**
+**Proof of play tracking, log reporting, and fault alerts for Xibo CMS.**
 
 ## Overview
 
 Collects and reports display analytics to the Xibo CMS:
 
-- **Proof of play** — per-layout and per-widget duration tracking
-- **Aggregation modes** — individual or aggregated stat submission (configurable from CMS)
-- **Log reporting** — display logs batched and submitted to CMS
-- **Fault alerts** — error deduplication and fault reporting
+- **Proof of play** -- per-layout and per-widget duration tracking with IndexedDB persistence
+- **Hour-boundary splitting** -- stats crossing hour boundaries are split for correct CMS aggregation
+- **Aggregation modes** -- individual or aggregated submission (configurable from CMS)
+- **Event stats** -- point-in-time engagement data (touch, webhook, interactive triggers)
+- **Log reporting** -- display logs batched and submitted to CMS (max 50 per batch)
+- **Fault alerts** -- error deduplication with 5-minute cooldown, triggers CMS dashboard alerts
+- **enableStat** -- per-layout/per-widget stat suppression via XLF flags
+- **Quota resilience** -- auto-cleans oldest 100 submitted records on IndexedDB quota exceeded
+
+## Architecture
+
+```
+Renderer events                StatsCollector              CMS
+(widgetStart/widgetEnd)        (IndexedDB)                (XMDS)
+                                    |
+widgetStart(id, layout) -----> startWidget() -----> [in-progress Map]
+                                    |
+widgetEnd(id, layout) -------> endWidget() -------> [split at hour]
+                                    |                      |
+                                    v                      v
+                               IndexedDB            getStatsForSubmission(50)
+                               (xibo-player-stats)         |
+                                    |                formatStats() -> XML
+                                    |                      |
+                                    v               submitStats() -----> CMS
+                               clearSubmittedStats()
+
+Renderer events                LogReporter                 CMS
+(errors, status)               (IndexedDB)                (XMDS)
+                                    |
+log('error', msg) -----------> _saveLog() -------> IndexedDB
+reportFault(code, reason) ---> [dedup 5min] -----> [alertType field]
+                                    |
+                               getLogsForSubmission(50)
+                                    |
+                               formatLogs() -> XML
+                                    |
+                               submitLog() ---------> CMS
+```
 
 ## Installation
 
@@ -19,19 +54,141 @@ npm install @xiboplayer/stats
 
 ## Usage
 
+### StatsCollector -- proof of play
+
 ```javascript
-import { StatsCollector } from '@xiboplayer/stats';
+import { StatsCollector, formatStats } from '@xiboplayer/stats';
 
-const stats = new StatsCollector({ transport });
-stats.init();
+const stats = new StatsCollector();
+await stats.init();
 
-// Stats are collected automatically from player events
-// and submitted during each collection cycle
+// Track layout playback
+await stats.startLayout(123, 456); // layoutId, scheduleId
+// ... layout plays for 30 seconds ...
+await stats.endLayout(123, 456);
+
+// Track widget playback
+await stats.startWidget(789, 123, 456); // mediaId, layoutId, scheduleId
+// ... widget plays ...
+await stats.endWidget(789, 123, 456);
+
+// Record interactive event
+await stats.recordEvent('touch', 123, 789, 456); // tag, layoutId, widgetId, scheduleId
+
+// Submit to CMS
+const pending = await stats.getStatsForSubmission(50);
+if (pending.length > 0) {
+  const xml = formatStats(pending);
+  await xmds.submitStats(xml);
+  await stats.clearSubmittedStats(pending);
+}
 ```
+
+### Aggregated submission
+
+```javascript
+// When CMS aggregationLevel is 'Aggregate':
+const aggregated = await stats.getAggregatedStatsForSubmission(50);
+// Groups by (type, layoutId, mediaId, scheduleId, hour) and sums durations
+const xml = formatStats(aggregated);
+await xmds.submitStats(xml);
+// Clear using _rawIds from aggregated records
+```
+
+### LogReporter -- CMS logging
+
+```javascript
+import { LogReporter, formatLogs, formatFaults } from '@xiboplayer/stats';
+
+const reporter = new LogReporter();
+await reporter.init();
+
+// Log messages (stored in IndexedDB, submitted in batches)
+await reporter.error('Failed to load layout', 'PLAYER');
+await reporter.info('Layout loaded successfully', 'PLAYER');
+await reporter.debug('Rendering widget 42', 'RENDERER');
+
+// Report fault (triggers CMS dashboard alert)
+await reporter.reportFault('LAYOUT_LOAD_FAILED', 'Layout 123 failed to render');
+// Same code won't be reported again within 5 minutes (deduplication)
+
+// Submit logs to CMS
+const logs = await reporter.getLogsForSubmission(50);
+if (logs.length > 0) {
+  const xml = formatLogs(logs);
+  await xmds.submitLog(xml);
+  await reporter.clearSubmittedLogs(logs);
+}
+
+// Submit faults (faster cycle, ~60s)
+const faults = await reporter.getFaultsForSubmission(10);
+if (faults.length > 0) {
+  const json = formatFaults(faults);
+  await xmds.reportFaults(json);
+  await reporter.clearSubmittedLogs(faults);
+}
+```
+
+## Stat Types
+
+| Type | Tracked by | Fields |
+|------|------------|--------|
+| `layout` | startLayout/endLayout | layoutId, scheduleId, start, end, duration, count |
+| `media` | startWidget/endWidget | mediaId, widgetId, layoutId, scheduleId, start, end, duration |
+| `event` | recordEvent | tag, layoutId, widgetId, scheduleId, start (point-in-time) |
+
+## API Reference
+
+### StatsCollector
+
+```javascript
+new StatsCollector(cmsId?)
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `init()` | Promise | Initialize IndexedDB (idempotent) |
+| `startLayout(layoutId, scheduleId, opts?)` | Promise | Start tracking layout |
+| `endLayout(layoutId, scheduleId)` | Promise | End layout, save to DB |
+| `startWidget(mediaId, layoutId, scheduleId, widgetId?, opts?)` | Promise | Start tracking widget |
+| `endWidget(mediaId, layoutId, scheduleId)` | Promise | End widget, save to DB |
+| `recordEvent(tag, layoutId, widgetId, scheduleId)` | Promise | Record instant event |
+| `getStatsForSubmission(limit?)` | Promise<Array> | Get unsubmitted stats (default 50) |
+| `getAggregatedStatsForSubmission(limit?)` | Promise<Array> | Get grouped stats |
+| `clearSubmittedStats(stats)` | Promise | Delete submitted records |
+| `getAllStats()` | Promise<Array> | All stats (debugging) |
+| `clearAllStats()` | Promise | Clear everything (testing) |
+
+### LogReporter
+
+```javascript
+new LogReporter(cmsId?)
+```
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `init()` | Promise | Initialize IndexedDB |
+| `log(level, message, category?, extra?)` | Promise | Store log entry |
+| `error(message, category?)` | Promise | Shorthand for log('error', ...) |
+| `audit(message, category?)` | Promise | Shorthand for log('audit', ...) |
+| `info(message, category?)` | Promise | Shorthand for log('info', ...) |
+| `debug(message, category?)` | Promise | Shorthand for log('debug', ...) |
+| `reportFault(code, reason, cooldownMs?)` | Promise | Report fault with dedup (default 5min cooldown) |
+| `getLogsForSubmission(limit?)` | Promise<Array> | Get unsubmitted logs (default 50) |
+| `getFaultsForSubmission(limit?)` | Promise<Array> | Get unsubmitted faults (default 10) |
+| `clearSubmittedLogs(logs)` | Promise | Delete submitted records |
+
+### Formatters
+
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `formatStats(stats)` | string | Format stats as XML for XMDS SubmitStats |
+| `formatLogs(logs)` | string | Format logs as XML for XMDS SubmitLog |
+| `formatFaults(faults)` | string | Format faults as JSON for XMDS ReportFaults |
 
 ## Dependencies
 
-- `@xiboplayer/utils` — logger, events
+- `@xiboplayer/utils` -- logger
 
 ---
 

--- a/packages/sw/README.md
+++ b/packages/sw/README.md
@@ -1,17 +1,40 @@
 # @xiboplayer/sw
 
-**Service Worker toolkit for chunk streaming and offline caching.**
+**Service Worker toolkit for chunk streaming, media caching, and offline content serving.**
 
 ## Overview
 
 Provides Service Worker building blocks for Xibo players:
 
-- **Chunk streaming** — progressive download with Range request support for large media files
-- **BlobCache** — in-memory cache for assembled chunks with LRU eviction
-- **Widget HTML serving** — intercepts GetResource requests and serves from cache
-- **Version-aware activation** — prevents re-activation of same SW version to preserve in-flight streams
-- **XLF-driven media resolution** — parses layout XLF to determine exactly which media each layout needs, including data widget IDs extracted from media tags without a fileId
-- **Unclaimed media downloads** — media files not claimed by any layout (widget data, non-XLF assets) are enqueued for download instead of being skipped
+- **Chunk streaming** -- progressive download with Range request support for large media files
+- **BlobCache** -- in-memory cache for assembled chunks with LRU eviction
+- **Widget HTML serving** -- intercepts GetResource requests and serves from ContentStore
+- **Version-aware activation** -- prevents re-activation of same SW version to preserve in-flight streams
+- **XLF-driven media resolution** -- parses layout XLF to determine exactly which media each layout needs
+- **Adaptive chunk sizing** -- adjusts chunk size and concurrency based on device RAM (4GB/8GB+ tiers)
+- **Unclaimed media** -- media files not claimed by any layout are enqueued for download
+
+## Architecture
+
+```
+Browser fetch()                   Service Worker                    Proxy ContentStore
+     |                                 |                                   |
+     +-- GET /media/video.mp4 ------> RequestHandler.handleMedia()         |
+     |                                 +- Check BlobCache (in-memory) ---> [hit: return blob]
+     |                                 +- Miss: stream from chunks         |
+     |                                 |  +- GET /store/media/video.mp4 ---+
+     |                                 |  +- Assemble chunks, cache blob   |
+     |                                 +- Return Response with Range support
+     |
+     +-- GET /widgets/1/2/3 --------> RequestHandler.handleWidget()        |
+     |                                 +- GET /store/widget/1/2/3 ---------+
+     |                                 +- Return HTML response             |
+     |
+     +-- postMessage(download) ------> MessageHandler.handleMessage()      |
+                                       +- Parse XLF for media IDs          |
+                                       +- Enqueue downloads                |
+                                       +- Report progress                  |
+```
 
 ## Installation
 
@@ -19,14 +42,58 @@ Provides Service Worker building blocks for Xibo players:
 npm install @xiboplayer/sw
 ```
 
-## Features
+## Exports
 
-This package provides the core logic used by the PWA Service Worker (`sw-pwa.js`). The SW handles:
+| Export | Description |
+|--------|-------------|
+| `RequestHandler` | Fetch event handler: media streaming, widget serving, Range support |
+| `MessageHandler` | PostMessage handler: download orchestration, progress reporting |
+| `extractMediaIdsFromXlf` | Parse XLF XML to extract all required media file IDs |
+| `calculateChunkConfig` | Adaptive chunk/concurrency config based on device RAM |
 
-1. **Static caching** — PWA shell files cached on install
-2. **Media caching** — layout media downloaded via parallel chunks
-3. **Range requests** — video seeking served from cached chunks
-4. **Download queue** — flat queue with barriers for layout-ordered downloads
+## Usage
+
+```javascript
+// In sw-pwa.js (Service Worker entry point)
+import { RequestHandler, MessageHandler } from '@xiboplayer/sw';
+
+const requestHandler = new RequestHandler();
+const messageHandler = new MessageHandler();
+
+self.addEventListener('fetch', (event) => {
+  const response = requestHandler.handle(event.request);
+  if (response) event.respondWith(response);
+});
+
+self.addEventListener('message', (event) => {
+  messageHandler.handle(event);
+});
+```
+
+### XLF media extraction
+
+```javascript
+import { extractMediaIdsFromXlf } from '@xiboplayer/sw';
+
+const mediaIds = extractMediaIdsFromXlf(xlfXmlString);
+// Returns: Set<string> of media file IDs needed by this layout
+// Includes: fileId from media tags, data widget IDs (no fileId), background images
+```
+
+### Adaptive chunk config
+
+```javascript
+import { calculateChunkConfig } from '@xiboplayer/sw';
+
+const config = calculateChunkConfig();
+// 4GB RAM: { chunkSize: 25MB, concurrency: 4 }
+// 8GB+ RAM: { chunkSize: 50MB, concurrency: 6 }
+```
+
+## Dependencies
+
+- `@xiboplayer/utils` -- PLAYER_API constant
+- `@xiboplayer/cache` -- StoreClient, DownloadManager
 
 ---
 

--- a/packages/sync/README.md
+++ b/packages/sync/README.md
@@ -1,17 +1,44 @@
 # @xiboplayer/sync
 
-**Multi-display synchronization for Xibo video walls.**
+**Multi-display synchronization for Xibo video walls — same-machine and cross-device.**
 
 ## Overview
 
-BroadcastChannel-based lead/follower synchronization:
+Coordinates layout transitions and video playback across multiple displays:
 
-- **Lead election** — automatic leader selection among browser tabs/windows
-- **Synchronized playback** — video start coordinated across displays
-- **Layout sync** — all displays transition to the same layout simultaneously
-- **Stats/logs delegation** — follower tabs delegate proof-of-play stats and log submission to the sync lead via BroadcastChannel, avoiding duplicate CMS traffic in video wall setups
+- **Same-machine sync** (Phase 2) — BroadcastChannel for multi-tab/multi-window setups on a single device
+- **Cross-device sync** (Phase 3) — WebSocket relay for LAN video walls where each screen is a separate mini-PC
 
-Designed for video wall setups where multiple screens show synchronized content.
+Both modes share the same sync protocol — only the transport layer differs.
+
+### Capabilities
+
+- **Synchronized layout transitions** — lead signals followers to change layout, waits for all to be ready, then sends a simultaneous "show" signal
+- **Coordinated video start** — video playback begins at the same moment on all displays
+- **Stats/logs delegation** — followers delegate proof-of-play stats and log submission through the lead, avoiding duplicate CMS traffic
+- **Automatic follower discovery** — heartbeats every 5s, stale detection after 15s
+- **Graceful degradation** — if a follower is unresponsive, the lead proceeds after a 10s timeout
+- **Auto-reconnect** — WebSocket transport reconnects with exponential backoff (1s → 30s)
+
+## Architecture
+
+```
+Same-machine (BroadcastChannel):       Cross-device (WebSocket relay):
+
+  Tab 1 (Lead)    Tab 2 (Follower)      PC 1 (Lead)         PC 2 (Follower)
+  ┌──────────┐    ┌──────────┐          ┌──────────┐        ┌──────────┐
+  │SyncMgr   │    │SyncMgr   │          │SyncMgr   │        │SyncMgr   │
+  │ └─BC     │◄──►│ └─BC     │          │ └─WS     │        │ └─WS     │
+  └──────────┘    └──────────┘          └────┬─────┘        └────┬─────┘
+       BroadcastChannel                      │                    │
+                                             ▼                    │
+                                      ┌────────────┐             │
+                                      │Proxy :8765 │◄────────────┘
+                                      │ └─SyncRelay│  (LAN WebSocket)
+                                      └────────────┘
+```
+
+The relay is a dumb pipe — it broadcasts each message to all other connected clients. The sync protocol (heartbeats, ready-waits, layout changes) runs entirely in SyncManager.
 
 ## Installation
 
@@ -21,13 +48,170 @@ npm install @xiboplayer/sync
 
 ## Usage
 
+### Same-machine sync (default)
+
+No extra configuration needed. When multiple tabs/windows run on the same origin, BroadcastChannel handles message passing automatically.
+
 ```javascript
 import { SyncManager } from '@xiboplayer/sync';
 
-const sync = new SyncManager({ displayId: 'screen-1' });
-sync.on('layout-sync', ({ layoutId }) => renderer.show(layoutId));
-sync.init();
+// Lead display
+const lead = new SyncManager({
+  displayId: 'screen-1',
+  syncConfig: { isLead: true, syncGroup: 'lead', syncSwitchDelay: 750 },
+  onLayoutShow: (layoutId) => renderer.show(layoutId),
+});
+lead.start();
+
+// Request synchronized layout change (waits for followers)
+await lead.requestLayoutChange('42');
 ```
+
+```javascript
+// Follower display (different tab)
+const follower = new SyncManager({
+  displayId: 'screen-2',
+  syncConfig: { isLead: false, syncGroup: '192.168.1.100', syncSwitchDelay: 750 },
+  onLayoutChange: async (layoutId) => {
+    await renderer.prepareLayout(layoutId);
+    follower.reportReady(layoutId);
+  },
+  onLayoutShow: (layoutId) => renderer.show(layoutId),
+});
+follower.start();
+```
+
+### Cross-device sync (LAN video wall)
+
+When `syncGroup` is an IP address (not `"lead"`) and `syncPublisherPort` is set, the PWA automatically builds a WebSocket relay URL. The lead connects to its own proxy at `ws://localhost:<port>/sync`; followers connect to `ws://<lead-ip>:<port>/sync`.
+
+**Lead config.json** (e.g. `~/.config/xiboplayer/electron/config.json`):
+
+```json
+{
+  "cmsUrl": "https://cms.example.com",
+  "cmsKey": "yourKey",
+  "displayName": "videowall-lead",
+  "listenAddress": "0.0.0.0"
+}
+```
+
+The `listenAddress: "0.0.0.0"` makes the proxy reachable from the LAN. The CMS sync settings (`syncGroup`, `syncPublisherPort`) are sent via the RegisterDisplay response.
+
+**CMS Display Settings:**
+
+| Setting | Lead | Follower |
+|---------|------|----------|
+| Sync Group | `lead` | `192.168.1.100` (lead's IP) |
+| Sync Publisher Port | `8765` | `8765` |
+
+The SyncManager detects this configuration and selects the WebSocket transport:
+
+```javascript
+// This happens automatically in packages/pwa/src/main.ts:
+if (syncConfig.syncPublisherPort && syncConfig.syncGroup !== 'lead') {
+  const host = syncConfig.isLead ? 'localhost' : syncConfig.syncGroup;
+  syncConfig.relayUrl = `ws://${host}:${syncConfig.syncPublisherPort}/sync`;
+}
+```
+
+### Injecting a custom transport
+
+For testing or custom setups, you can inject any object that implements the transport interface:
+
+```javascript
+const transport = {
+  send(msg) { /* ... */ },
+  onMessage(callback) { /* ... */ },
+  close() { /* ... */ },
+  get connected() { return true; },
+};
+
+const sync = new SyncManager({
+  displayId: 'test-1',
+  syncConfig: { isLead: true },
+  transport,
+});
+sync.start();
+```
+
+## Transport Interface
+
+Both `BroadcastChannelTransport` and `WebSocketTransport` implement:
+
+```typescript
+interface SyncTransport {
+  send(msg: any): void;           // Send message to peers
+  onMessage(cb: (msg) => void);   // Register message handler
+  close(): void;                   // Clean up resources
+  readonly connected: boolean;     // Connection status
+}
+```
+
+## Sync Protocol
+
+```
+Lead                              Follower(s)
+────                              ──────────
+heartbeat (every 5s)            → discovers peers
+layout-change(layoutId, showAt) → loads layout, prepares DOM
+                                ← layout-ready(layoutId, displayId)
+(waits for all or timeout 10s)
+layout-show(layoutId)           → shows layout simultaneously
+video-start(layoutId, regionId) → unpauses video
+stats-report / logs-report      ← delegates stats to lead
+stats-ack / logs-ack            → confirms submission
+```
+
+## Example: 4-screen video wall
+
+```
+┌─────────────┬─────────────┐
+│ Screen 1    │ Screen 2    │
+│ (LEAD)      │ (follower)  │
+│ 192.168.1.10│ 192.168.1.11│
+├─────────────┼─────────────┤
+│ Screen 3    │ Screen 4    │
+│ (follower)  │ (follower)  │
+│ 192.168.1.12│ 192.168.1.13│
+└─────────────┴─────────────┘
+```
+
+**CMS setup:** Create 4 displays. Set Screen 1's sync group to `lead`. Set Screens 2-4's sync group to `192.168.1.10`. Set sync publisher port to `8765` on all four.
+
+**Screen 1 config.json:** Add `"listenAddress": "0.0.0.0"` so the proxy listens on all interfaces.
+
+All four screens run the same Electron/Chromium player. The lead drives layout transitions; followers load content in parallel and show simultaneously when all are ready.
+
+## API
+
+### `new SyncManager(options)`
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `displayId` | string | This display's unique hardware key |
+| `syncConfig` | SyncConfig | Sync configuration from CMS RegisterDisplay |
+| `transport` | SyncTransport? | Optional pre-built transport (for testing) |
+| `onLayoutChange` | Function? | Called when lead requests layout change |
+| `onLayoutShow` | Function? | Called when lead gives show signal |
+| `onVideoStart` | Function? | Called when lead gives video start signal |
+| `onStatsReport` | Function? | (Lead) Called when follower sends stats |
+| `onLogsReport` | Function? | (Lead) Called when follower sends logs |
+| `onStatsAck` | Function? | (Follower) Called when lead confirms stats |
+| `onLogsAck` | Function? | (Follower) Called when lead confirms logs |
+
+### Methods
+
+| Method | Role | Description |
+|--------|------|-------------|
+| `start()` | Both | Opens transport, begins heartbeats |
+| `stop()` | Both | Closes transport, clears timers |
+| `requestLayoutChange(layoutId)` | Lead | Sends layout-change, waits for ready, sends show |
+| `requestVideoStart(layoutId, regionId)` | Lead | Signals synchronized video start |
+| `reportReady(layoutId)` | Follower | Reports layout is loaded and ready |
+| `reportStats(statsXml)` | Follower | Delegates stats submission to lead |
+| `reportLogs(logsXml)` | Follower | Delegates logs submission to lead |
+| `getStatus()` | Both | Returns sync status including follower details |
 
 ---
 

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -6,11 +6,13 @@
 
 Foundation utilities used across the SDK:
 
-- **Logger** — structured logging with configurable levels (`DEBUG`, `INFO`, `WARNING`, `ERROR`) and per-module tags
-- **EventEmitter** — lightweight pub/sub event system
-- **fetchWithRetry** — HTTP fetch with exponential backoff, jitter, and configurable retries
-- **CMS REST client** — JSON API client with ETag caching
-- **Config** — hardware key management and IndexedDB-backed configuration
+- **Logger** -- structured logging with configurable levels (DEBUG, INFO, WARNING, ERROR, NONE) and per-module tags
+- **Log sinks** -- pluggable log destinations (console, LogReporter for CMS submission)
+- **EventEmitter** -- lightweight pub/sub event system
+- **fetchWithRetry** -- HTTP fetch with exponential backoff, jitter, and configurable retries
+- **Config** -- hardware key management, IndexedDB-backed configuration, CMS ID computation
+- **CMS REST API client** -- 77-method JSON API client with ETag caching and JWT auth
+- **PLAYER_API** -- configurable base path for media/widget/dependency URLs
 
 ## Installation
 
@@ -20,17 +22,104 @@ npm install @xiboplayer/utils
 
 ## Usage
 
+### Logger
+
 ```javascript
-import { createLogger, EventEmitter, fetchWithRetry } from '@xiboplayer/utils';
+import { createLogger, setLogLevel, applyCmsLogLevel, registerLogSink } from '@xiboplayer/utils';
 
 const log = createLogger('my-module');
 log.info('Starting...');
-log.debug('Detailed info');
+log.debug('Detailed info', { key: 'value' });
+log.warn('Something unexpected');
+log.error('Critical failure', error);
 
-const emitter = new EventEmitter();
-emitter.on('event', (data) => console.log(data));
+// Set global log level
+setLogLevel('DEBUG');  // DEBUG, INFO, WARNING, ERROR, NONE
 
-const response = await fetchWithRetry(url, { retries: 3 });
+// Apply CMS log level (maps CMS values to SDK levels)
+applyCmsLogLevel('audit'); // maps to DEBUG
+
+// Register a custom log sink (e.g., CMS log reporter)
+registerLogSink({
+  log(level, tag, ...args) {
+    cmsReporter.log(level, args.join(' '), tag);
+  }
+});
+```
+
+### EventEmitter
+
+```javascript
+import { EventEmitter } from '@xiboplayer/utils';
+
+class MyClass extends EventEmitter {
+  doSomething() {
+    this.emit('done', { result: 42 });
+  }
+}
+
+const obj = new MyClass();
+obj.on('done', (data) => console.log(data));
+obj.once('done', (data) => console.log('First time only'));
+obj.off('done', handler);
+```
+
+### fetchWithRetry
+
+```javascript
+import { fetchWithRetry } from '@xiboplayer/utils';
+
+const response = await fetchWithRetry(url, {
+  retries: 3,        // Max retry attempts (default: 2)
+  baseDelay: 2000,   // Base delay in ms (default: 2000)
+  // Backoff: baseDelay * 2^attempt + random jitter
+  headers: { 'Content-Type': 'application/json' },
+  method: 'POST',
+  body: JSON.stringify(data),
+});
+```
+
+### Config
+
+```javascript
+import { config, computeCmsId } from '@xiboplayer/utils';
+
+// Read config values (from localStorage / IndexedDB)
+const cmsUrl = config.data.cmsUrl;
+const hardwareKey = config.data.hardwareKey;
+
+// Compute CMS ID for namespacing databases
+const cmsId = computeCmsId('https://cms.example.com', 'display-key');
+// Returns FNV hash string for unique IndexedDB names per CMS+display pair
+```
+
+### CMS REST API client
+
+```javascript
+import { CmsApiClient } from '@xiboplayer/utils';
+
+const api = new CmsApiClient({
+  baseUrl: 'https://cms.example.com',
+  clientId: 'oauth-client-id',
+  clientSecret: 'oauth-client-secret',
+});
+
+// 77 methods covering all CMS entities
+const displays = await api.getDisplays();
+const layouts = await api.getLayouts();
+await api.authorizeDisplay(displayId);
+```
+
+### PLAYER_API
+
+```javascript
+import { PLAYER_API, setPlayerApi } from '@xiboplayer/utils';
+
+// Default: '/api/v2/player'
+console.log(PLAYER_API); // '/api/v2/player'
+
+// Override before route registration (e.g., in proxy setup)
+setPlayerApi('/custom/player/path');
 ```
 
 ## Exports
@@ -38,9 +127,28 @@ const response = await fetchWithRetry(url, { retries: 3 });
 | Export | Description |
 |--------|-------------|
 | `createLogger(tag)` | Create a tagged logger instance |
-| `EventEmitter` | Pub/sub event emitter |
+| `setLogLevel(level)` | Set global log level |
+| `getLogLevel()` | Get current log level |
+| `isDebug()` | Check if DEBUG level is active |
+| `applyCmsLogLevel(cmsLevel)` | Map CMS log level to SDK level |
+| `registerLogSink(sink)` | Add custom log destination |
+| `unregisterLogSink(sink)` | Remove log destination |
+| `LOG_LEVELS` | Level constants: DEBUG, INFO, WARNING, ERROR, NONE |
+| `EventEmitter` | Pub/sub event emitter class |
 | `fetchWithRetry(url, opts)` | Fetch with exponential backoff |
-| `Config` | Hardware key and IndexedDB config management |
+| `config` | Global config instance (localStorage/IndexedDB) |
+| `extractPwaConfig(config)` | Extract PWA-relevant keys from shell config |
+| `computeCmsId(url, key)` | FNV hash for CMS+display namespacing |
+| `SHELL_ONLY_KEYS` | Config keys not forwarded to PWA |
+| `CmsApiClient` | CMS REST API client (77 methods) |
+| `CmsApiError` | API error class with status code |
+| `PLAYER_API` | Media/widget base path (configurable) |
+| `setPlayerApi(base)` | Override PLAYER_API at runtime |
+| `VERSION` | Package version from package.json |
+
+## Dependencies
+
+No external runtime dependencies.
 
 ---
 

--- a/packages/xmds/README.md
+++ b/packages/xmds/README.md
@@ -1,15 +1,42 @@
 # @xiboplayer/xmds
 
-**XMDS SOAP + REST client for Xibo CMS communication.**
+**XMDS/REST dual-transport CMS client for Xibo digital signage -- auto-detects REST or SOAP based on CMS capabilities.**
 
 ## Overview
 
-Dual-transport client supporting both Xibo communication protocols:
+Unified abstraction over Xibo's two communication protocols:
 
-- **XMDS SOAP** (v3-v7) — standard Xibo player protocol with XML encoding
-- **REST API** — lighter JSON transport (~30% smaller payloads) with ETag caching
+- **REST API v2** -- JSON-based, JWT auth, ETag caching, ~30% smaller payloads
+- **XMDS SOAP** (v3-v7) -- XML-based, universal compatibility with all Xibo CMS versions
 
-Both transports expose the same API. The REST client is preferred when available.
+Both expose an identical public API. At startup, `ProtocolDetector` probes the CMS to select the optimal transport -- fallback to SOAP if REST is unavailable.
+
+### Capabilities
+
+- **Dual-transport abstraction** -- RestClient and XmdsClient implement the same interface
+- **Auto-detection** -- quick health probe (3s timeout) to select REST or SOAP
+- **HTTP caching** -- REST client uses ETags to avoid redundant GETs
+- **Retry & backoff** -- exponential backoff with jitter (default: 2 retries, 2s base delay)
+- **JWT auth** -- REST client auto-refreshes tokens 60s before expiry
+- **CRC checksums** -- `checkRf` and `checkSchedule` allow skipping unchanged data
+- **Delegated reporting** -- stats/logs can be submitted on behalf of other displays (follower -> lead delegation)
+
+## Architecture
+
+```
+Player Core                        Transport Selection                CMS
+-----------                       --------------------              -----
+
+registerDisplay()                  Is REST available?
+requiredFiles()     Same API       (GET /api/v2/player/health)
+schedule()                 Yes --> RestClient (JWT, ETag)   --> /api/v2/player/*
+getResource()              No  --> XmdsClient (SOAP XML)    --> /xmds.php
+notify()
+submitStats()
+submitLog()
+```
+
+Both clients share the same return types. The scheduler, renderer, and sync modules consume only the CmsClient interface -- they're transport-agnostic.
 
 ## Installation
 
@@ -19,37 +46,164 @@ npm install @xiboplayer/xmds
 
 ## Usage
 
-```javascript
-import { RestClient } from '@xiboplayer/xmds';
+### Auto-detect and instantiate
 
-const client = new RestClient({
-  cmsUrl: 'https://your-cms.example.com',
-  serverKey: 'your-key',
-  hardwareKey: 'display-id',
+```javascript
+import { ProtocolDetector, RestClient, XmdsClient } from '@xiboplayer/xmds';
+
+const detector = new ProtocolDetector(cmsUrl, RestClient, XmdsClient);
+const { client, protocol } = await detector.detect({
+  cmsUrl: 'https://cms.example.com',
+  cmsKey: 'your-server-key',
+  hardwareKey: 'display-123',
+  displayName: 'Main Screen',
 });
 
-const result = await client.registerDisplay();
+console.log(`Using ${protocol} transport`);
+
+const display = await client.registerDisplay();
 const files = await client.requiredFiles();
 const schedule = await client.schedule();
 ```
 
+### Force a specific transport
+
+```javascript
+const { client } = await detector.detect(config, 'xmds');  // Force SOAP
+const { client } = await detector.detect(config, 'rest');   // Force REST
+```
+
+### Direct RestClient usage
+
+```javascript
+import { RestClient } from '@xiboplayer/xmds';
+
+const client = new RestClient({
+  cmsUrl: 'https://cms.example.com',
+  cmsKey: 'server-key',
+  hardwareKey: 'display-key',
+  displayName: 'Display 1',
+});
+
+const { code, message, settings, syncConfig } = await client.registerDisplay();
+const { files, purge } = await client.requiredFiles();
+```
+
+### Direct XmdsClient usage
+
+```javascript
+import { XmdsClient } from '@xiboplayer/xmds';
+
+const client = new XmdsClient({
+  cmsUrl: 'https://cms.example.com',
+  cmsKey: 'server-key',
+  hardwareKey: 'display-key',
+  displayName: 'Display 1',
+  xmrChannel: 'ch-123',
+  xmrPubKey: '-----BEGIN PUBLIC KEY-----\n...',
+});
+
+const display = await client.registerDisplay();
+```
+
+### Parse schedule without network call
+
+```javascript
+import { parseScheduleResponse } from '@xiboplayer/xmds';
+
+const parsed = parseScheduleResponse(scheduleXml);
+// { default, layouts, campaigns, overlays, actions, commands, dataConnectors }
+```
+
 ## Methods
 
-| Method | Description |
-|--------|-------------|
-| `registerDisplay()` | Register/authorize the display with the CMS |
-| `requiredFiles()` | Get list of required media files and layouts |
-| `schedule()` | Get the current schedule XML |
-| `getResource(regionId, mediaId)` | Get rendered widget HTML |
-| `notifyStatus(status)` | Report display status to CMS |
-| `mediaInventory(inventory)` | Report cached media inventory |
-| `submitStats(stats, hardwareKeyOverride?)` | Submit proof of play statistics (optional `hardwareKeyOverride` for delegated submissions on behalf of another display) |
-| `submitScreenShot(base64)` | Upload a screenshot to the CMS |
-| `submitLog(logs, hardwareKeyOverride?)` | Submit display logs (optional `hardwareKeyOverride` for delegated submissions on behalf of another display) |
+All methods available on both `RestClient` and `XmdsClient` with identical signatures:
+
+| Method | Parameters | Returns | Description |
+|--------|------------|---------|-------------|
+| `registerDisplay()` | -- | `RegisterDisplayResult` | Authenticate, get settings, tags, commands, sync config |
+| `requiredFiles()` | -- | `RequiredFilesResult` | Get media, layouts, widgets, and files to purge |
+| `schedule()` | -- | `ScheduleObject` | Get complete schedule |
+| `getResource(layoutId, regionId, mediaId)` | number x 3 | `string` | Get rendered widget HTML |
+| `notifyStatus(status)` | Object | JSON/XML | Report display status |
+| `mediaInventory(inventoryXml)` | string/Array | JSON/XML | Report cached media |
+| `submitStats(statsXml, hardwareKeyOverride?)` | string, string? | boolean | Submit proof-of-play (optional override for delegated reporting) |
+| `submitLog(logXml, hardwareKeyOverride?)` | string, string? | boolean | Submit logs (optional override for delegated reporting) |
+| `submitScreenShot(base64Image)` | string | boolean | Upload screenshot |
+| `reportFaults(faultJson)` | string/Object | boolean | Report hardware/software faults |
+| `blackList(mediaId, type, reason)` | string, string, string | boolean | Blacklist broken media |
+| `getWeather()` | -- | JSON/XML | Get weather data for schedule criteria |
+
+### Key Response Types
+
+**RegisterDisplayResult:**
+```typescript
+{
+  code: 'READY' | 'WRONG_SCHEDULE_KEY' | 'DISPLAY_NOT_LICENSED' | ...,
+  message: string,
+  settings: { [key: string]: any },
+  tags: string[],
+  commands: Array<{ commandCode, commandString }>,
+  checkRf: string,         // CRC32 of RequiredFiles (skip if unchanged)
+  checkSchedule: string,   // CRC32 of Schedule (skip if unchanged)
+  syncConfig: {             // Multi-display sync (null if not enabled)
+    syncGroup: string,
+    syncPublisherPort: number,
+    syncSwitchDelay: number,
+    isLead: boolean
+  } | null
+}
+```
+
+## Transport Comparison
+
+| Aspect | REST (v2) | XMDS (SOAP) |
+|--------|-----------|-------------|
+| **Protocol** | JSON over HTTP | XML-RPC over HTTP |
+| **Auth** | JWT (Bearer token) | Per-request params (serverKey) |
+| **Payload size** | ~30% smaller | Baseline |
+| **Caching** | ETags + response cache | No caching |
+| **Availability** | Custom CMS images (Xibo 3.0+) | All Xibo versions (v3-v7+) |
+| **Fallback** | SOAP (automatic) | None |
+
+## Error Handling
+
+**Retry:** Both clients use `fetchWithRetry()` with exponential backoff (2 retries, 2s base delay).
+
+**Token expiry (REST):** 401 response triggers automatic re-authentication and request retry.
+
+**SOAP faults:** XmdsClient parses `<soap:Fault>` and throws with fault message.
+
+**Custom retry strategy:**
+```javascript
+const client = new RestClient({
+  ...config,
+  retryOptions: { maxRetries: 5, baseDelayMs: 5000 }
+});
+```
+
+## Constructor Options
+
+```typescript
+{
+  cmsUrl: string,                // Base URL of Xibo CMS
+  cmsKey: string,                // Server authentication key
+  hardwareKey: string,           // Unique display identifier
+  displayName?: string,          // Human-readable display name
+  clientVersion?: string,        // Default: '0.1.0'
+  clientType?: string,           // Default: 'linux'
+  xmrChannel?: string,           // XMR channel ID
+  xmrPubKey?: string,            // XMR public key (PEM)
+  retryOptions?: {
+    maxRetries?: number,         // Default: 2
+    baseDelayMs?: number         // Default: 2000
+  }
+}
+```
 
 ## Dependencies
 
-- `@xiboplayer/utils` — logger, events, fetchWithRetry
+- `@xiboplayer/utils` -- logger, fetchWithRetry
 
 ---
 

--- a/packages/xmr/README.md
+++ b/packages/xmr/README.md
@@ -1,21 +1,29 @@
 # @xiboplayer/xmr
 
-**XMR WebSocket client for real-time Xibo CMS commands.**
+**XMR WebSocket client for real-time Xibo CMS push commands.**
 
 ## Overview
 
 Listens for push commands from the CMS over WebSocket with automatic reconnection:
 
-- **collectNow** — trigger an immediate collection cycle
-- **screenshot** — request a display screenshot
-- **changeLayout** — switch to a specific layout
-- **overlayLayout** — show an overlay layout
-- **revertToSchedule** — return to the scheduled playlist
-- **purgeAll** — clear all cached content
-- **dataUpdate** — notify of updated widget data
-- **triggerWebhook** — fire a webhook action
-- **commandAction** — execute a shell command
-- **criteriaUpdate** — update geo/criteria filters
+- **13 command handlers** -- collectNow, screenshot, changeLayout, overlayLayout, revertToSchedule, purgeAll, commandAction, triggerWebhook, dataUpdate, rekeyAction, criteriaUpdate, currentGeoLocation, licenceCheck
+- **Auto-reconnect** -- exponential backoff (5s base, up to 10 attempts), resumes on next collection cycle
+- **Intentional shutdown** -- clean disconnect without triggering reconnection
+- **Dual-path geo-location** -- CMS can push coordinates or request the player to report its position
+
+## Architecture
+
+```
+CMS (Push)                     XmrWrapper                    PlayerCore
+    |                              |                              |
+    +--- WebSocket message ------> xmr.on('collectNow') -------> player.collect()
+    +--- WebSocket message ------> xmr.on('changeLayout') -----> player.changeLayout()
+    +--- WebSocket message ------> xmr.on('screenshot') -------> player.captureScreenshot()
+    +--- WebSocket message ------> xmr.on('purgeAll') ---------> player.purgeAll()
+    |                              |                              |
+    +--- disconnect -------------> scheduleReconnect() ---------> [5s, 10s, 15s, ...]
+    +--- reconnect --------------> xmr.on('connected') --------> updateStatus('XMR connected')
+```
 
 ## Installation
 
@@ -26,22 +34,77 @@ npm install @xiboplayer/xmr
 ## Usage
 
 ```javascript
-import { XmrClient } from '@xiboplayer/xmr';
+import { XmrWrapper } from '@xiboplayer/xmr';
 
-const xmr = new XmrClient({
-  wsUrl: 'wss://your-cms.example.com/xmr',
-  channel: 'display-channel-key',
-  rsaKey: 'display-rsa-key',
-});
+const xmr = new XmrWrapper(config, player);
 
-xmr.on('collectNow', () => player.collect());
-xmr.on('screenshot', () => captureScreenshot());
-xmr.connect();
+// Start connection (from RegisterDisplay result)
+const success = await xmr.start(xmrWebSocketAddress, xmrCmsKey);
+
+if (success) {
+  console.log('XMR connected - real-time commands active');
+} else {
+  console.log('XMR failed - falling back to polling mode');
+}
+
+// Check status
+xmr.isConnected(); // true/false
+
+// Stop cleanly
+await xmr.stop();
 ```
+
+## Commands
+
+| Command | Payload | Action |
+|---------|---------|--------|
+| `collectNow` | -- | Trigger immediate XMDS collection cycle |
+| `screenShot` / `screenshot` | -- | Capture and upload display screenshot |
+| `changeLayout` | `{ layoutId, duration?, downloadRequired?, changeMode? }` | Switch to specific layout |
+| `overlayLayout` | `{ layoutId, duration?, downloadRequired? }` | Push overlay on top |
+| `revertToSchedule` | -- | Return to normal scheduled content |
+| `purgeAll` | -- | Clear all cached files and re-download |
+| `commandAction` | `{ commandCode, commands? }` | Execute player command (HTTP only in browser) |
+| `triggerWebhook` | `{ triggerCode }` | Fire a webhook trigger action |
+| `dataUpdate` | -- | Force refresh data connectors |
+| `rekeyAction` | -- | Rotate RSA key pair and re-register |
+| `criteriaUpdate` | `data` | Update display criteria, trigger collection |
+| `currentGeoLocation` | `{ latitude?, longitude? }` | Push coordinates or request location report |
+| `licenceCheck` | -- | No-op for Linux clients |
+
+## Reconnection
+
+- **Base delay:** 5 seconds, linear increase (5s, 10s, 15s, ...)
+- **Max attempts:** 10 per disconnect event
+- **After max:** stops trying until next collection cycle calls `start()` again
+- **Intentional stop:** `stop()` sets a flag that prevents reconnection on disconnect
+
+## API Reference
+
+### Constructor
+
+```javascript
+new XmrWrapper(config, player)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `config` | Object | Player config with `hardwareKey`, `xmrChannel` |
+| `player` | Object | PlayerCore instance with command methods |
+
+### Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `start(xmrUrl, cmsKey)` | `Promise<boolean>` | Connect to XMR WebSocket |
+| `stop()` | `Promise<void>` | Disconnect cleanly (no reconnect) |
+| `isConnected()` | `boolean` | Check connection status |
+| `send(action, data)` | `Promise<boolean>` | Send message to CMS |
 
 ## Dependencies
 
-- `@xiboplayer/utils` — logger, events
+- `@xibosignage/xibo-communication-framework` -- XMR protocol implementation
+- `@xiboplayer/utils` -- logger
 
 ---
 


### PR DESCRIPTION
## Summary

- Expand 10 sparse package READMEs (core, renderer, schedule, xmds, cache, stats, xmr, settings, sw, utils) to match the sync README gold standard
- Each README now includes: architecture diagram, usage examples, API reference tables, dependency list
- Fix stale test count 1345→1412 (36 suites) in STATUS.md and AUDIT.md

Closes #222