### PR TITLE
feat: multi-display Phase 3 — group isolation, wall mode, standalone relay

### DIFF
--- a/packages/proxy/bin/relay.js
+++ b/packages/proxy/bin/relay.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+/**
+ * xiboplayer-relay CLI — standalone WebSocket sync relay
+ *
+ * Runs a lightweight HTTP + WebSocket server that relays sync messages
+ * between xiboplayer displays on a LAN. Displays connect via WebSocket
+ * to /sync and are isolated by sync group.
+ *
+ * Usage:
+ *   xiboplayer-relay --port=9590
+ *   npx @xiboplayer/proxy relay --port=9590
+ */
+
+import http from 'node:http';
+import { attachSyncRelay } from '../src/sync-relay.js';
+
+const args = process.argv.slice(2);
+const portArg = args.find(a => a.startsWith('--port='));
+const port = portArg ? parseInt(portArg.split('=')[1], 10) : 9590;
+
+const server = http.createServer((_req, res) => {
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ service: 'xiboplayer-relay', status: 'ok' }));
+});
+
+attachSyncRelay(server);
+
+server.listen(port, () => {
+  console.log(`Sync relay listening on ws://0.0.0.0:${port}/sync`);
+});

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -6,10 +6,12 @@
   "main": "./src/index.js",
   "exports": {
     ".": "./src/index.js",
-    "./cli": "./bin/cli.js"
+    "./cli": "./bin/cli.js",
+    "./relay": "./src/sync-relay.js"
   },
   "bin": {
-    "xiboplayer-proxy": "./bin/cli.js"
+    "xiboplayer-proxy": "./bin/cli.js",
+    "xiboplayer-relay": "./bin/relay.js"
   },
   "scripts": {
     "test": "vitest run",

--- a/packages/proxy/src/sync-relay.js
+++ b/packages/proxy/src/sync-relay.js
@@ -32,6 +32,9 @@ const log = createLogger('SyncRelay', 'INFO');
 export function attachSyncRelay(server) {
   const wss = new WebSocketServer({ noServer: true });
 
+  // Group isolation: Map<groupName, Set<WebSocket>>
+  const groups = new Map();
+
   // Handle HTTP→WebSocket upgrade on /sync path only
   server.on('upgrade', (req, socket, head) => {
     const pathname = new URL(req.url, 'http://localhost').pathname;
@@ -49,14 +52,34 @@ export function attachSyncRelay(server) {
     const addr = req.socket.remoteAddress;
     log.info(`Client connected: ${addr} (${wss.clients.size} total)`);
     ws.isAlive = true;
+    ws.syncGroup = null; // Set when client sends 'join'
 
     ws.on('pong', () => {
       ws.isAlive = true;
     });
 
     ws.on('message', (data) => {
-      // Broadcast to all OTHER connected clients
-      for (const client of wss.clients) {
+      let parsed;
+      try {
+        parsed = JSON.parse(data);
+      } catch {
+        return; // Ignore non-JSON
+      }
+
+      // Handle join: client declares its sync group
+      if (parsed.type === 'join') {
+        const group = parsed.syncGroup || 'default';
+        ws.syncGroup = group;
+        if (!groups.has(group)) groups.set(group, new Set());
+        groups.get(group).add(ws);
+        log.info(`Client ${addr} joined group "${group}" (${groups.get(group).size} in group)`);
+        return; // Don't broadcast join messages
+      }
+
+      // Broadcast to same-group peers only
+      const peers = ws.syncGroup ? groups.get(ws.syncGroup) : wss.clients;
+      if (!peers) return;
+      for (const client of peers) {
         if (client !== ws && client.readyState === 1 /* OPEN */) {
           client.send(data);
         }
@@ -64,6 +87,12 @@ export function attachSyncRelay(server) {
     });
 
     ws.on('close', () => {
+      // Remove from group tracking
+      if (ws.syncGroup && groups.has(ws.syncGroup)) {
+        const group = groups.get(ws.syncGroup);
+        group.delete(ws);
+        if (group.size === 0) groups.delete(ws.syncGroup);
+      }
       log.info(`Client disconnected: ${addr} (${wss.clients.size} remaining)`);
     });
   });

--- a/packages/proxy/src/sync-relay.test.js
+++ b/packages/proxy/src/sync-relay.test.js
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2024-2026 Pau Aliagas <linuxnow@gmail.com>
+/**
+ * Sync relay integration tests
+ *
+ * Tests the WebSocket sync relay with real HTTP server + WS connections.
+ * Verifies group isolation: messages are scoped to the sender's sync group.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import http from 'node:http';
+import { WebSocket } from 'ws';
+import { attachSyncRelay } from './sync-relay.js';
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+/** Create an HTTP server with sync relay, return { server, wss, url } */
+function createRelay() {
+  const server = http.createServer();
+  const wss = attachSyncRelay(server);
+
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      resolve({ server, wss, url: `ws://127.0.0.1:${port}/sync` });
+    });
+  });
+}
+
+/** Connect a WS client and wait for open */
+function connect(url) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url);
+    ws.on('open', () => resolve(ws));
+    ws.on('error', reject);
+  });
+}
+
+/** Collect next N messages from a WS client */
+function collectMessages(ws, count) {
+  const msgs = [];
+  return new Promise((resolve) => {
+    ws.on('message', (data) => {
+      msgs.push(JSON.parse(data));
+      if (msgs.length >= count) resolve(msgs);
+    });
+  });
+}
+
+/** Send a JSON message */
+function send(ws, msg) {
+  ws.send(JSON.stringify(msg));
+}
+
+/** Wait for a short tick */
+const tick = (ms = 50) => new Promise((r) => setTimeout(r, ms));
+
+// ── Tests ────────────────────────────────────────────────────────
+
+describe('SyncRelay', () => {
+  let server;
+  let wss;
+  const clients = [];
+
+  afterEach(async () => {
+    for (const ws of clients) {
+      if (ws.readyState <= 1) ws.close();
+    }
+    clients.length = 0;
+    if (wss) wss.close();
+    if (server) await new Promise((r) => server.close(r));
+  });
+
+  async function setup() {
+    const relay = await createRelay();
+    server = relay.server;
+    wss = relay.wss;
+    return relay.url;
+  }
+
+  it('should broadcast to all clients without groups (backward compat)', async () => {
+    const url = await setup();
+    const a = await connect(url);
+    const b = await connect(url);
+    clients.push(a, b);
+
+    const received = collectMessages(b, 1);
+    send(a, { type: 'heartbeat', displayId: 'a' });
+
+    const [msg] = await received;
+    expect(msg.type).toBe('heartbeat');
+    expect(msg.displayId).toBe('a');
+  });
+
+  it('should not echo messages back to sender', async () => {
+    const url = await setup();
+    const a = await connect(url);
+    clients.push(a);
+
+    let received = false;
+    a.on('message', () => { received = true; });
+
+    send(a, { type: 'heartbeat', displayId: 'a' });
+    await tick();
+
+    expect(received).toBe(false);
+  });
+
+  it('should isolate messages by sync group', async () => {
+    const url = await setup();
+
+    // Group "wall-1": clients a and b
+    const a = await connect(url);
+    const b = await connect(url);
+    // Group "wall-2": client c
+    const c = await connect(url);
+    clients.push(a, b, c);
+
+    // Join groups
+    send(a, { type: 'join', syncGroup: 'wall-1' });
+    send(b, { type: 'join', syncGroup: 'wall-1' });
+    send(c, { type: 'join', syncGroup: 'wall-2' });
+    await tick();
+
+    // Track what c receives
+    let cReceived = false;
+    c.on('message', () => { cReceived = true; });
+
+    // b should receive a's message
+    const bReceived = collectMessages(b, 1);
+    send(a, { type: 'layout-change', layoutId: '42', displayId: 'a' });
+
+    const [msg] = await bReceived;
+    expect(msg.type).toBe('layout-change');
+    expect(msg.layoutId).toBe('42');
+
+    // c should NOT have received anything (different group)
+    await tick();
+    expect(cReceived).toBe(false);
+  });
+
+  it('should not broadcast join messages', async () => {
+    const url = await setup();
+    const a = await connect(url);
+    const b = await connect(url);
+    clients.push(a, b);
+
+    let bReceived = false;
+    b.on('message', () => { bReceived = true; });
+
+    send(a, { type: 'join', syncGroup: 'wall-1' });
+    await tick();
+
+    expect(bReceived).toBe(false);
+  });
+
+  it('should clean up group membership on disconnect', async () => {
+    const url = await setup();
+    const a = await connect(url);
+    const b = await connect(url);
+    clients.push(a, b);
+
+    send(a, { type: 'join', syncGroup: 'wall-1' });
+    send(b, { type: 'join', syncGroup: 'wall-1' });
+    await tick();
+
+    // Disconnect a
+    a.close();
+    await tick(100);
+
+    // b should still be able to send (no crash)
+    send(b, { type: 'heartbeat', displayId: 'b' });
+    await tick();
+  });
+
+  it('should handle multiple groups concurrently', async () => {
+    const url = await setup();
+
+    const a1 = await connect(url);
+    const a2 = await connect(url);
+    const b1 = await connect(url);
+    const b2 = await connect(url);
+    clients.push(a1, a2, b1, b2);
+
+    send(a1, { type: 'join', syncGroup: 'alpha' });
+    send(a2, { type: 'join', syncGroup: 'alpha' });
+    send(b1, { type: 'join', syncGroup: 'beta' });
+    send(b2, { type: 'join', syncGroup: 'beta' });
+    await tick();
+
+    // Send from a1 and b1 simultaneously
+    const a2Received = collectMessages(a2, 1);
+    const b2Received = collectMessages(b2, 1);
+
+    send(a1, { type: 'heartbeat', displayId: 'a1' });
+    send(b1, { type: 'heartbeat', displayId: 'b1' });
+
+    const [msgA] = await a2Received;
+    const [msgB] = await b2Received;
+
+    expect(msgA.displayId).toBe('a1');
+    expect(msgB.displayId).toBe('b1');
+  });
+
+  it('should use default group when syncGroup is empty', async () => {
+    const url = await setup();
+    const a = await connect(url);
+    const b = await connect(url);
+    clients.push(a, b);
+
+    // Join with empty syncGroup — should get "default"
+    send(a, { type: 'join', syncGroup: '' });
+    send(b, { type: 'join', syncGroup: '' });
+    await tick();
+
+    const bReceived = collectMessages(b, 1);
+    send(a, { type: 'heartbeat', displayId: 'a' });
+
+    const [msg] = await bReceived;
+    expect(msg.displayId).toBe('a');
+  });
+
+  it('should reject non-/sync upgrade paths', async () => {
+    const relay = await createRelay();
+    server = relay.server;
+    wss = relay.wss;
+
+    const { port } = server.address();
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/other`);
+    clients.push(ws);
+
+    await new Promise((resolve) => {
+      ws.on('error', resolve);
+      ws.on('close', resolve);
+    });
+
+    expect(ws.readyState).toBeGreaterThanOrEqual(2); // CLOSING or CLOSED
+  });
+});

--- a/packages/pwa/src/main.ts
+++ b/packages/pwa/src/main.ts
@@ -543,10 +543,16 @@ class PwaPlayer {
         displayId: config.hardwareKey,
         syncConfig,
         onLayoutChange: async (layoutId: string) => {
-          // Follower: lead requested a layout change — load it but don't show yet
-          log.info(`[Sync] Loading layout ${layoutId} (waiting for show signal)`);
-          await this.prepareAndRenderLayout(parseInt(layoutId, 10));
-          // Report ready to lead
+          // Wall mode: map lead's layout to this display's position-specific layout
+          const layoutMap = syncConfig.layoutMap || config.sync?.layoutMap;
+          const mappedId = layoutMap?.[layoutId] ?? layoutId;
+          if (mappedId !== layoutId) {
+            log.info(`[Sync] Wall mode: lead layout ${layoutId} → local layout ${mappedId}`);
+          }
+          // Follower: load the (possibly mapped) layout but don't show yet
+          log.info(`[Sync] Loading layout ${mappedId} (waiting for show signal)`);
+          await this.prepareAndRenderLayout(parseInt(String(mappedId), 10));
+          // Report ready to lead (use lead's layoutId so lead can track readiness)
           this.syncManager?.reportReady(layoutId);
         },
         onLayoutShow: (layoutId: string) => {

--- a/packages/sync/src/index.d.ts
+++ b/packages/sync/src/index.d.ts
@@ -16,6 +16,8 @@ export interface SyncConfig {
   syncVideoPauseDelay: number;
   isLead: boolean;
   relayUrl?: string;
+  /** Wall mode: map lead layoutId → this display's position-specific layoutId */
+  layoutMap?: Record<string, string | number>;
 }
 
 export class BroadcastChannelTransport implements SyncTransport {
@@ -27,7 +29,7 @@ export class BroadcastChannelTransport implements SyncTransport {
 }
 
 export class WebSocketTransport implements SyncTransport {
-  constructor(url: string);
+  constructor(url: string, options?: { syncGroup?: string });
   send(msg: any): void;
   onMessage(callback: (msg: any) => void): void;
   close(): void;

--- a/packages/sync/src/sync-manager.js
+++ b/packages/sync/src/sync-manager.js
@@ -104,7 +104,7 @@ export class SyncManager {
     // Select transport if none injected
     if (!this.transport) {
       if (this.syncConfig.relayUrl) {
-        this.transport = new WebSocketTransport(this.syncConfig.relayUrl);
+        this.transport = new WebSocketTransport(this.syncConfig.relayUrl, { syncGroup: this.syncConfig.syncGroup });
       } else if (typeof BroadcastChannel !== 'undefined') {
         this.transport = new BroadcastChannelTransport();
       } else {

--- a/packages/sync/src/ws-transport.js
+++ b/packages/sync/src/ws-transport.js
@@ -23,9 +23,12 @@ const BACKOFF_FACTOR = 2;
 export class WebSocketTransport {
   /**
    * @param {string} url — WebSocket URL, e.g. ws://192.168.1.100:8765/sync
+   * @param {Object} [options]
+   * @param {string} [options.syncGroup] — group name for relay isolation
    */
-  constructor(url) {
+  constructor(url, { syncGroup } = {}) {
     this._url = url;
+    this._syncGroup = syncGroup || null;
     this._callback = null;
     this._closed = false;
     this._retryMs = INITIAL_RETRY_MS;
@@ -87,6 +90,11 @@ export class WebSocketTransport {
     this.ws.onopen = () => {
       this._log.info(`Connected to ${this._url}`);
       this._retryMs = INITIAL_RETRY_MS; // Reset backoff on success
+
+      // Join sync group for relay isolation
+      if (this._syncGroup) {
+        this.ws.send(JSON.stringify({ type: 'join', syncGroup: this._syncGroup }));
+      }
     };
 
     this.ws.onmessage = (event) => {


### PR DESCRIPTION
## Summary

- **Group isolation in sync relay** (`sync-relay.js`) — `Map<group, Set<ws>>` routing, broadcasts scoped to same-group peers. Backward compatible: ungrouped clients fall back to broadcast-to-all.
- **WebSocket transport group support** (`ws-transport.js`) — Constructor accepts `{ syncGroup }`, sends `join` on open and on reconnect.
- **Wall mode layoutMap** (`main.ts`) — Follower `onLayoutChange` applies `layoutMap` before loading, mapping lead's layoutId to position-specific layout. Falls back to mirror mode if no mapping.
- **Standalone relay CLI** (`bin/relay.js`) — `xiboplayer-relay --port=9590`, exported via `./relay` in package.json.
- **Relay integration tests** (`sync-relay.test.js`) — 8 tests: group isolation, backward compat, disconnect cleanup, multi-group.
- **TypeScript types** — Updated `WebSocketTransport` constructor, added `layoutMap` to `SyncConfig`.

See #233 for future schedule-index coordination.

## Test plan

- [ ] `pnpm test` — all 1458 tests pass (including 8 new relay tests)
- [ ] `npx xiboplayer-relay --port=9590` binds and accepts WS connections
- [ ] Two clients in same syncGroup: messages route only within group
- [ ] Ungrouped client: receives broadcasts from all (backward compat)
- [ ] Follower with `layoutMap`: loads mapped layout on lead change
- [ ] Follower without `layoutMap`: mirrors lead layout (fallback)