### PR TITLE
fix: audit bugs — 401 recursion, fetch timeouts, StoreClient errors

### DIFF
--- a/packages/cache/src/cache-proxy.test.js
+++ b/packages/cache/src/cache-proxy.test.js
@@ -52,12 +52,10 @@ describe('StoreClient', () => {
       expect(exists).toBe(false);
     });
 
-    it('should return false on fetch error', async () => {
+    it('should throw on network error (not silently return false)', async () => {
       global.fetch = vi.fn(() => Promise.reject(new Error('Network error')));
 
-      const exists = await store.has('media', '123');
-
-      expect(exists).toBe(false);
+      await expect(store.has('media', '123')).rejects.toThrow('Network error');
     });
   });
 

--- a/packages/cache/src/store-client.js
+++ b/packages/cache/src/store-client.js
@@ -29,9 +29,23 @@ export class StoreClient {
   async has(type, id) {
     try {
       const response = await fetch(`/store/${type}/${id}`, { method: 'HEAD' });
-      return response.ok;
-    } catch {
-      return false;
+      if (response.ok) return true;
+      if (response.status === 404) return false;
+      // Non-404 HTTP errors (500, 502, etc.) indicate proxy/store problems
+      const err = new Error(`Store error: ${response.status}`);
+      err.status = response.status;
+      log.warn(`has(${type}/${id}): unexpected status ${response.status}`);
+      throw err;
+    } catch (error) {
+      // Re-throw errors that are not simple network failures swallowed above
+      // (includes HTTP errors we threw, AbortError, TypeError from fetch)
+      if (error.status || error.name === 'AbortError' || error.name === 'TimeoutError') {
+        throw error;
+      }
+      // Network errors (proxy unreachable) — log and re-throw so callers
+      // can distinguish from "not cached" (which returns false)
+      log.warn(`has(${type}/${id}): network error — ${error.message}`);
+      throw error;
     }
   }
 

--- a/packages/core/src/player-core.js
+++ b/packages/core/src/player-core.js
@@ -1356,7 +1356,8 @@ export class PlayerCore extends EventEmitter {
       try {
         const response = await fetch(url, {
           method: 'POST',
-          headers: { 'Content-Type': contentType }
+          headers: { 'Content-Type': contentType },
+          signal: AbortSignal.timeout(10000),
         });
         const success = response.ok;
         this._lastCommandSuccess = success;

--- a/packages/core/src/player-core.test.js
+++ b/packages/core/src/player-core.test.js
@@ -1169,10 +1169,10 @@ describe('PlayerCore', () => {
 
       await core.executeCommand('restart', commands);
 
-      expect(global.fetch).toHaveBeenCalledWith('http://test.com/restart', {
+      expect(global.fetch).toHaveBeenCalledWith('http://test.com/restart', expect.objectContaining({
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' }
-      });
+        headers: { 'Content-Type': 'application/json' },
+      }));
       expect(spy).toHaveBeenCalledWith({
         code: 'restart',
         success: true,
@@ -1240,10 +1240,10 @@ describe('PlayerCore', () => {
 
       await core.executeCommand('action', commands);
 
-      expect(global.fetch).toHaveBeenCalledWith('http://test.com/action', {
+      expect(global.fetch).toHaveBeenCalledWith('http://test.com/action', expect.objectContaining({
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' }
-      });
+        headers: { 'Content-Type': 'application/json' },
+      }));
     });
   });
 

--- a/packages/proxy/src/proxy.js
+++ b/packages/proxy/src/proxy.js
@@ -236,6 +236,7 @@ export function createProxyApp({ pwaPath, appVersion = '0.0.0', pwaConfig, confi
         method: req.method,
         headers,
         body: req.method !== 'GET' && req.body ? req.body : undefined,
+        signal: AbortSignal.timeout(30000),
       });
 
       const contentType = response.headers.get('content-type');
@@ -245,6 +246,10 @@ export function createProxyApp({ pwaPath, appVersion = '0.0.0', pwaConfig, confi
       res.status(response.status).send(responseText);
       logProxy.info(`${response.status} (${responseText.length} bytes)`);
     } catch (error) {
+      if (error.name === 'TimeoutError' || error.name === 'AbortError') {
+        logProxy.error('XMDS timeout (30s):', redactUrl(xmdsUrl));
+        return res.status(504).json({ error: 'Gateway Timeout', message: 'CMS did not respond within 30s' });
+      }
       logProxy.error('Error:', error.message);
       res.status(500).json({ error: 'Proxy error', message: error.message });
     }
@@ -467,7 +472,7 @@ export function createProxyApp({ pwaPath, appVersion = '0.0.0', pwaConfig, confi
     }
 
     try {
-      const response = await fetch(fullUrl, { headers });
+      const response = await fetch(fullUrl, { headers, signal: AbortSignal.timeout(30000) });
 
       if (!response.ok && response.status !== 206) {
         logFile.warn(`CMS ${response.status} for ${storeKey}`);
@@ -581,7 +586,12 @@ export function createProxyApp({ pwaPath, appVersion = '0.0.0', pwaConfig, confi
         logFile.info(`${response.status} streaming (no store)`);
       }
     } catch (error) {
-      logFile.warn(`CMS fetch failed: ${storeKey} — ${error.message}`);
+      const isTimeout = error.name === 'TimeoutError' || error.name === 'AbortError';
+      if (isTimeout) {
+        logFile.warn(`CMS timeout (30s): ${storeKey}`);
+      } else {
+        logFile.warn(`CMS fetch failed: ${storeKey} — ${error.message}`);
+      }
       // Serve stale cached data if CMS is unreachable
       if (store && !res.headersSent) {
         const staleInfo = store.getMetadata(storeKey);
@@ -592,7 +602,11 @@ export function createProxyApp({ pwaPath, appVersion = '0.0.0', pwaConfig, confi
           return serveFromStore(req, res, storeKey);
         }
       }
-      if (!res.headersSent) res.status(502).json({ error: 'CMS fetch failed', message: error.message });
+      if (!res.headersSent) {
+        const status = isTimeout ? 504 : 502;
+        const msg = isTimeout ? 'CMS did not respond within 30s' : error.message;
+        res.status(status).json({ error: isTimeout ? 'Gateway Timeout' : 'CMS fetch failed', message: msg });
+      }
     }
   }
 
@@ -855,6 +869,7 @@ export function createProxyApp({ pwaPath, appVersion = '0.0.0', pwaConfig, confi
       }
       delete fetchOptions.headers['content-length'];
 
+      fetchOptions.signal = AbortSignal.timeout(30000);
       const response = await fetch(targetUrl, fetchOptions);
       logApi.info(`${req.method} ${req.originalUrl} ← ${response.status} (${Date.now() - t0}ms)`);
 
@@ -873,6 +888,10 @@ export function createProxyApp({ pwaPath, appVersion = '0.0.0', pwaConfig, confi
         res.end();
       }
     } catch (err) {
+      if (err.name === 'TimeoutError' || err.name === 'AbortError') {
+        logApi.error(`API forward timeout (30s): ${req.originalUrl}`);
+        return res.status(504).json({ error: 'Gateway Timeout', message: 'CMS did not respond within 30s' });
+      }
       logApi.error(`Forward failed: ${err.message}`);
       res.status(502).json({ error: err.message });
     }

--- a/packages/xmds/src/rest-client.js
+++ b/packages/xmds/src/rest-client.js
@@ -29,9 +29,10 @@ export class RestClient {
     this._tokenExpiresAt = 0;
     this._displayId = null;
 
-    // ETag-based HTTP caching
+    // ETag-based HTTP caching (capped at _maxCacheSize entries)
     this._etags = new Map();
     this._responseCache = new Map();
+    this._maxCacheSize = 100;
 
     log.info('Using REST transport');
   }
@@ -59,6 +60,19 @@ export class RestClient {
     return typeof window !== 'undefined' &&
       (window.electronAPI?.isElectron ||
        window.location.hostname === 'localhost');
+  }
+
+  /**
+   * Store a response in the ETag cache, evicting the oldest entry if full.
+   */
+  _cacheSet(path, etag, data) {
+    if (this._etags.size >= this._maxCacheSize) {
+      const oldest = this._etags.keys().next().value;
+      this._etags.delete(oldest);
+      this._responseCache.delete(oldest);
+    }
+    this._etags.set(path, etag);
+    this._responseCache.set(path, data);
   }
 
   // ─── JWT auth ─────────────────────────────────────────────────
@@ -108,7 +122,7 @@ export class RestClient {
   /**
    * Make an authenticated GET request with ETag caching.
    */
-  async restGet(path, queryParams = {}) {
+  async restGet(path, queryParams = {}, _retrying = false) {
     const token = await this._getToken();
     const url = new URL(`${this.getRestBaseUrl()}${path}`);
     for (const [key, value] of Object.entries(queryParams)) {
@@ -131,8 +145,11 @@ export class RestClient {
 
     // Token expired mid-flight — re-auth and retry once
     if (response.status === 401) {
+      if (_retrying) {
+        throw new Error(`REST GET ${path} failed: 401 Unauthorized (after re-auth)`);
+      }
       this._token = null;
-      return this.restGet(path, queryParams);
+      return this.restGet(path, queryParams, true);
     }
 
     if (response.status === 304) {
@@ -148,11 +165,6 @@ export class RestClient {
       throw new Error(`REST GET ${path} failed: ${response.status} ${response.statusText} ${errorBody}`);
     }
 
-    const etag = response.headers.get('ETag');
-    if (etag) {
-      this._etags.set(cacheKey, etag);
-    }
-
     const contentType = response.headers.get('Content-Type') || '';
     let data;
     if (contentType.includes('application/json')) {
@@ -161,14 +173,18 @@ export class RestClient {
       data = await response.text();
     }
 
-    this._responseCache.set(cacheKey, data);
+    const etag = response.headers.get('ETag');
+    if (etag) {
+      this._cacheSet(cacheKey, etag, data);
+    }
+
     return data;
   }
 
   /**
    * Make an authenticated POST/PUT request with JSON body.
    */
-  async restSend(method, path, body = {}) {
+  async restSend(method, path, body = {}, _retrying = false) {
     const token = await this._getToken();
     const url = new URL(`${this.getRestBaseUrl()}${path}`);
 
@@ -185,8 +201,11 @@ export class RestClient {
 
     // Token expired mid-flight — re-auth and retry once
     if (response.status === 401) {
+      if (_retrying) {
+        throw new Error(`REST ${method} ${path} failed: 401 Unauthorized (after re-auth)`);
+      }
       this._token = null;
-      return this.restSend(method, path, body);
+      return this.restSend(method, path, body, true);
     }
 
     if (!response.ok) {

--- a/packages/xmds/src/rest-client.test.js
+++ b/packages/xmds/src/rest-client.test.js
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2024-2026 Pau Aliagas <linuxnow@gmail.com>
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock @xiboplayer/utils before importing RestClient
+vi.mock('@xiboplayer/utils', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+  fetchWithRetry: vi.fn(),
+  PLAYER_API: '/player/api/v2',
+}));
+
+import { RestClient } from './rest-client.js';
+import { fetchWithRetry } from '@xiboplayer/utils';
+
+const mockConfig = {
+  cmsUrl: 'https://cms.example.com',
+  cmsKey: 'serverkey123',
+  hardwareKey: 'hw-001',
+  displayName: 'Test Display',
+  xmrChannel: 'xmr-ch',
+};
+
+/** Helper: create a mock Response object */
+function mockResponse(status, body, headers = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : status === 304 ? 'Not Modified' : status === 401 ? 'Unauthorized' : 'Error',
+    headers: {
+      get: (name) => headers[name] || null,
+    },
+    json: vi.fn().mockResolvedValue(body),
+    text: vi.fn().mockResolvedValue(typeof body === 'string' ? body : JSON.stringify(body)),
+  };
+}
+
+/** Helper: mock a successful auth response */
+function mockAuthResponse() {
+  return mockResponse(200, {
+    token: 'jwt-token-123',
+    displayId: 42,
+    expiresIn: 3600,
+  }, { 'Content-Type': 'application/json' });
+}
+
+describe('RestClient', () => {
+  let client;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client = new RestClient(mockConfig);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ─── JWT authentication ─────────────────────────────────────
+
+  describe('JWT authentication', () => {
+    it('authenticates and stores token on first request', async () => {
+      const authResp = mockAuthResponse();
+      const dataResp = mockResponse(200, { ok: true }, { 'Content-Type': 'application/json' });
+
+      fetchWithRetry
+        .mockResolvedValueOnce(authResp)   // POST /auth
+        .mockResolvedValueOnce(dataResp);  // GET /schedule
+
+      const result = await client.restGet('/displays/42/schedule');
+
+      expect(result).toEqual({ ok: true });
+      expect(fetchWithRetry).toHaveBeenCalledTimes(2);
+      // First call is auth
+      expect(fetchWithRetry.mock.calls[0][1].method).toBe('POST');
+      expect(client._token).toBe('jwt-token-123');
+      expect(client._displayId).toBe(42);
+    });
+
+    it('reuses token on subsequent requests', async () => {
+      const authResp = mockAuthResponse();
+      const resp1 = mockResponse(200, { a: 1 }, { 'Content-Type': 'application/json' });
+      const resp2 = mockResponse(200, { b: 2 }, { 'Content-Type': 'application/json' });
+
+      fetchWithRetry
+        .mockResolvedValueOnce(authResp)
+        .mockResolvedValueOnce(resp1)
+        .mockResolvedValueOnce(resp2);
+
+      await client.restGet('/foo');
+      await client.restGet('/bar');
+
+      // Only one auth call, two data calls
+      expect(fetchWithRetry).toHaveBeenCalledTimes(3);
+    });
+
+    it('throws on auth failure', async () => {
+      fetchWithRetry.mockResolvedValueOnce(mockResponse(403, 'Forbidden'));
+
+      await expect(client.restGet('/anything')).rejects.toThrow('Auth failed: 403');
+    });
+  });
+
+  // ─── ETag caching ───────────────────────────────────────────
+
+  describe('ETag caching', () => {
+    it('returns cached response on 304', async () => {
+      const authResp = mockAuthResponse();
+      const firstResp = mockResponse(200, { data: 'fresh' }, {
+        'Content-Type': 'application/json',
+        'ETag': '"etag-1"',
+      });
+      const cachedResp = mockResponse(304, null);
+
+      fetchWithRetry
+        .mockResolvedValueOnce(authResp)
+        .mockResolvedValueOnce(firstResp)
+        .mockResolvedValueOnce(cachedResp);
+
+      // First call populates cache
+      const first = await client.restGet('/resource');
+      expect(first).toEqual({ data: 'fresh' });
+
+      // Second call gets 304, returns cached
+      const second = await client.restGet('/resource');
+      expect(second).toEqual({ data: 'fresh' });
+    });
+
+    it('sends If-None-Match header when ETag is cached', async () => {
+      const authResp = mockAuthResponse();
+      const firstResp = mockResponse(200, { data: 1 }, {
+        'Content-Type': 'application/json',
+        'ETag': '"my-etag"',
+      });
+      const secondResp = mockResponse(304, null);
+
+      fetchWithRetry
+        .mockResolvedValueOnce(authResp)
+        .mockResolvedValueOnce(firstResp)
+        .mockResolvedValueOnce(secondResp);
+
+      await client.restGet('/path');
+      await client.restGet('/path');
+
+      // Third fetchWithRetry call (second GET) should include If-None-Match
+      const secondGetCall = fetchWithRetry.mock.calls[2];
+      expect(secondGetCall[1].headers['If-None-Match']).toBe('"my-etag"');
+    });
+  });
+
+  // ─── 401 retry guard ───────────────────────────────────────
+
+  describe('401 retry guard', () => {
+    it('restGet retries once on 401 then succeeds', async () => {
+      const authResp1 = mockAuthResponse();
+      const unauthorizedResp = mockResponse(401, 'Unauthorized');
+      const authResp2 = mockAuthResponse();
+      const successResp = mockResponse(200, { ok: true }, { 'Content-Type': 'application/json' });
+
+      fetchWithRetry
+        .mockResolvedValueOnce(authResp1)   // first auth
+        .mockResolvedValueOnce(unauthorizedResp) // GET returns 401
+        .mockResolvedValueOnce(authResp2)   // re-auth
+        .mockResolvedValueOnce(successResp); // retry GET succeeds
+
+      const result = await client.restGet('/resource');
+      expect(result).toEqual({ ok: true });
+    });
+
+    it('restGet throws on second consecutive 401 (no infinite recursion)', async () => {
+      const authResp1 = mockAuthResponse();
+      const unauth1 = mockResponse(401, 'Unauthorized');
+      const authResp2 = mockAuthResponse();
+      const unauth2 = mockResponse(401, 'Unauthorized');
+
+      fetchWithRetry
+        .mockResolvedValueOnce(authResp1)
+        .mockResolvedValueOnce(unauth1)
+        .mockResolvedValueOnce(authResp2)
+        .mockResolvedValueOnce(unauth2);
+
+      await expect(client.restGet('/resource'))
+        .rejects.toThrow('401 Unauthorized (after re-auth)');
+    });
+
+    it('restSend retries once on 401 then succeeds', async () => {
+      const authResp1 = mockAuthResponse();
+      const unauth = mockResponse(401, 'Unauthorized');
+      const authResp2 = mockAuthResponse();
+      const success = mockResponse(200, { saved: true }, { 'Content-Type': 'application/json' });
+
+      fetchWithRetry
+        .mockResolvedValueOnce(authResp1)
+        .mockResolvedValueOnce(unauth)
+        .mockResolvedValueOnce(authResp2)
+        .mockResolvedValueOnce(success);
+
+      const result = await client.restSend('PUT', '/resource', { key: 'value' });
+      expect(result).toEqual({ saved: true });
+    });
+
+    it('restSend throws on second consecutive 401 (no infinite recursion)', async () => {
+      const authResp1 = mockAuthResponse();
+      const unauth1 = mockResponse(401, 'Unauthorized');
+      const authResp2 = mockAuthResponse();
+      const unauth2 = mockResponse(401, 'Unauthorized');
+
+      fetchWithRetry
+        .mockResolvedValueOnce(authResp1)
+        .mockResolvedValueOnce(unauth1)
+        .mockResolvedValueOnce(authResp2)
+        .mockResolvedValueOnce(unauth2);
+
+      await expect(client.restSend('POST', '/resource', {}))
+        .rejects.toThrow('401 Unauthorized (after re-auth)');
+    });
+  });
+
+  // ─── Cache eviction ─────────────────────────────────────────
+
+  describe('cache eviction', () => {
+    it('evicts oldest entry when cache exceeds max size', () => {
+      // Fill cache to max
+      for (let i = 0; i < 100; i++) {
+        client._cacheSet(`/path-${i}`, `etag-${i}`, { i });
+      }
+      expect(client._etags.size).toBe(100);
+      expect(client._responseCache.size).toBe(100);
+
+      // Adding one more should evict /path-0
+      client._cacheSet('/path-new', 'etag-new', { new: true });
+      expect(client._etags.size).toBe(100);
+      expect(client._etags.has('/path-0')).toBe(false);
+      expect(client._responseCache.has('/path-0')).toBe(false);
+      expect(client._etags.has('/path-new')).toBe(true);
+      expect(client._responseCache.get('/path-new')).toEqual({ new: true });
+    });
+
+    it('does not evict when under max size', () => {
+      client._cacheSet('/a', 'etag-a', 'data-a');
+      client._cacheSet('/b', 'etag-b', 'data-b');
+      expect(client._etags.size).toBe(2);
+      expect(client._etags.has('/a')).toBe(true);
+      expect(client._etags.has('/b')).toBe(true);
+    });
+
+    it('evicts multiple oldest entries on sequential inserts', () => {
+      for (let i = 0; i < 100; i++) {
+        client._cacheSet(`/p-${i}`, `e-${i}`, i);
+      }
+      // Add 3 more
+      client._cacheSet('/x1', 'ex1', 'x1');
+      client._cacheSet('/x2', 'ex2', 'x2');
+      client._cacheSet('/x3', 'ex3', 'x3');
+
+      expect(client._etags.size).toBe(100);
+      expect(client._etags.has('/p-0')).toBe(false);
+      expect(client._etags.has('/p-1')).toBe(false);
+      expect(client._etags.has('/p-2')).toBe(false);
+      expect(client._etags.has('/p-3')).toBe(true); // still present
+      expect(client._etags.has('/x3')).toBe(true);
+    });
+  });
+
+  // ─── Proxy mode detection ──────────────────────────────────
+
+  describe('proxy mode detection', () => {
+    it('detects proxy mode when electronAPI.isElectron is set', () => {
+      window.electronAPI = { isElectron: true };
+      expect(client._isProxyMode()).toBe(true);
+      delete window.electronAPI;
+    });
+
+    it('detects proxy mode when hostname is localhost', () => {
+      // jsdom defaults to localhost
+      const original = window.location.hostname;
+      expect(client._isProxyMode()).toBe(original === 'localhost');
+    });
+
+    it('returns direct URL in non-proxy mode', () => {
+      // Ensure no proxy indicators
+      delete window.electronAPI;
+      // jsdom hostname is localhost, so override _isProxyMode
+      vi.spyOn(client, '_isProxyMode').mockReturnValue(false);
+
+      const url = client.getRestBaseUrl();
+      expect(url).toBe('https://cms.example.com/player/api/v2');
+    });
+
+    it('returns local origin URL in proxy mode via electronAPI', () => {
+      window.electronAPI = { isElectron: true };
+
+      const url = client.getRestBaseUrl();
+      expect(url).toContain('/player/api/v2');
+      // In proxy mode, uses window.location.origin (which is cms.example.com in vitest)
+      // The key assertion is that _isProxyMode is true and the URL uses origin
+      expect(url).toBe(`${window.location.origin}/player/api/v2`);
+
+      delete window.electronAPI;
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **RestClient 401 recursion guard**: `_retrying` flag prevents infinite re-auth loop on persistent 401
- **RestClient ETag cache eviction**: `_etags`/`_responseCache` Maps capped at 100 entries
- **Proxy cache-through timeout**: `AbortSignal.timeout(30000)` prevents hung CMS from blocking Express
- **executeCommand timeout**: `AbortSignal.timeout(10000)` on HTTP command fetch
- **StoreClient.has()**: throws on network error instead of silently returning `false`
- **16 new RestClient tests**: auth flow, ETag caching, 401 retry, cache eviction, proxy mode

## Test plan

- [x] All 1502 tests pass
- [x] Existing cache-proxy and player-core tests updated for new behavior

Closes #238
Closes #239
Closes #240
Closes #241