### PR TITLE
fix: DataConnectorManager circuit breaker + overlay/connector tests

### DIFF
--- a/packages/core/src/data-connectors.js
+++ b/packages/core/src/data-connectors.js
@@ -24,11 +24,14 @@ import { EventEmitter, createLogger, fetchWithRetry } from '@xiboplayer/utils';
 
 const log = createLogger('DataConnector');
 
+const MAX_BACKOFF_MS = 300000; // 5 minutes
+const CIRCUIT_BREAKER_THRESHOLD = 3;
+
 export class DataConnectorManager extends EventEmitter {
   constructor() {
     super();
 
-    // dataKey -> { config, data, timer, lastFetch }
+    // dataKey -> { config, data, timer, lastFetch, failures }
     this.connectors = new Map();
   }
 
@@ -60,7 +63,8 @@ export class DataConnectorManager extends EventEmitter {
         config: connector,
         data: null,
         timer: null,
-        lastFetch: null
+        lastFetch: null,
+        failures: 0
       });
 
       log.info(`Registered data connector: ${connector.dataKey} (interval: ${connector.updateInterval}s)`);
@@ -171,8 +175,12 @@ export class DataConnectorManager extends EventEmitter {
       const previousData = entry.data;
       entry.data = data;
       entry.lastFetch = Date.now();
+      entry.failures = 0; // Reset on success
 
       log.debug(`Data updated for ${dataKey} (fetched at ${new Date(entry.lastFetch).toISOString()})`);
+
+      // Restore normal polling interval if it was backed off
+      this._ensureNormalPolling(entry);
 
       // Emit event for listeners (IC route, platform layer)
       this.emit('data-updated', dataKey, data);
@@ -183,8 +191,40 @@ export class DataConnectorManager extends EventEmitter {
       }
 
     } catch (error) {
-      log.error(`Failed to fetch data for ${dataKey}:`, error);
+      entry.failures = (entry.failures || 0) + 1;
+      log.error(`Failed to fetch data for ${dataKey} (${entry.failures}x):`, error);
       this.emit('fetch-error', dataKey, error);
+
+      // Circuit breaker: slow down polling after repeated failures
+      if (entry.failures >= CIRCUIT_BREAKER_THRESHOLD && entry.timer) {
+        const baseMs = (config.updateInterval || 300) * 1000;
+        const backoffMs = Math.min(baseMs * Math.pow(2, entry.failures - CIRCUIT_BREAKER_THRESHOLD + 1), MAX_BACKOFF_MS);
+        clearInterval(entry.timer);
+        entry.timer = setTimeout(() => {
+          this.fetchData(entry).catch(() => {});
+          // Re-arm with backoff interval
+          entry.timer = setInterval(() => {
+            this.fetchData(entry).catch(() => {});
+          }, backoffMs);
+        }, backoffMs);
+        log.warn(`Circuit breaker: ${dataKey} backing off to ${Math.round(backoffMs / 1000)}s`);
+      }
+    }
+  }
+
+  /**
+   * Restore normal polling interval after circuit breaker backoff.
+   * @private
+   */
+  _ensureNormalPolling(entry) {
+    if (entry.failures === 0 && entry.timer) {
+      const baseMs = (entry.config.updateInterval || 300) * 1000;
+      // Clear any backed-off timer and restore the normal interval
+      clearInterval(entry.timer);
+      clearTimeout(entry.timer);
+      entry.timer = setInterval(() => {
+        this.fetchData(entry).catch(() => {});
+      }, baseMs);
     }
   }
 

--- a/packages/core/src/data-connectors.test.js
+++ b/packages/core/src/data-connectors.test.js
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2024-2026 Pau Aliagas <linuxnow@gmail.com>
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { DataConnectorManager } from './data-connectors.js';
+
+// Mock fetchWithRetry (used by DataConnectorManager internally)
+vi.mock('@xiboplayer/utils', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    fetchWithRetry: vi.fn(),
+  };
+});
+
+import { fetchWithRetry } from '@xiboplayer/utils';
+
+function jsonResponse(data) {
+  return {
+    ok: true,
+    status: 200,
+    headers: { get: (h) => h === 'Content-Type' ? 'application/json' : null },
+    json: () => Promise.resolve(data),
+    text: () => Promise.resolve(JSON.stringify(data)),
+  };
+}
+
+describe('DataConnectorManager', () => {
+  let manager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    manager = new DataConnectorManager();
+  });
+
+  afterEach(() => {
+    manager.cleanup();
+  });
+
+  // ── setConnectors ──────────────────────────────────────────────
+
+  describe('setConnectors', () => {
+    it('registers connectors with valid dataKey and url', () => {
+      manager.setConnectors([
+        { dataKey: 'weather', url: 'https://api.test/weather', updateInterval: 60 },
+      ]);
+      expect(manager.connectors.size).toBe(1);
+      expect(manager.connectors.has('weather')).toBe(true);
+    });
+
+    it('skips connectors missing dataKey or url', () => {
+      manager.setConnectors([
+        { url: 'https://api.test/no-key' },
+        { dataKey: 'no-url' },
+        { dataKey: 'ok', url: 'https://api.test/ok', updateInterval: 30 },
+      ]);
+      expect(manager.connectors.size).toBe(1);
+    });
+
+    it('clears previous connectors on reconfigure', () => {
+      manager.setConnectors([{ dataKey: 'a', url: 'https://a.test' }]);
+      manager.setConnectors([{ dataKey: 'b', url: 'https://b.test' }]);
+      expect(manager.connectors.size).toBe(1);
+      expect(manager.connectors.has('a')).toBe(false);
+      expect(manager.connectors.has('b')).toBe(true);
+    });
+
+    it('handles null/empty input', () => {
+      manager.setConnectors(null);
+      expect(manager.connectors.size).toBe(0);
+      manager.setConnectors([]);
+      expect(manager.connectors.size).toBe(0);
+    });
+  });
+
+  // ── startPolling / stopPolling ─────────────────────────────────
+
+  describe('polling', () => {
+    it('fetches immediately on start', async () => {
+      fetchWithRetry.mockResolvedValue(jsonResponse({ temp: 20 }));
+
+      manager.setConnectors([{ dataKey: 'weather', url: 'https://api.test/w', updateInterval: 60 }]);
+      manager.startPolling();
+
+      // Wait for the immediate fetch to resolve
+      await new Promise(r => setTimeout(r, 50));
+
+      expect(fetchWithRetry).toHaveBeenCalledTimes(1);
+      expect(manager.getData('weather')).toEqual({ temp: 20 });
+    });
+
+    it('sets up interval timer', () => {
+      fetchWithRetry.mockResolvedValue(jsonResponse({ v: 1 }));
+
+      manager.setConnectors([{ dataKey: 'data', url: 'https://api.test/d', updateInterval: 10 }]);
+      manager.startPolling();
+
+      const entry = manager.connectors.get('data');
+      expect(entry.timer).not.toBeNull();
+    });
+
+    it('stops polling on stopPolling', () => {
+      fetchWithRetry.mockResolvedValue(jsonResponse({}));
+
+      manager.setConnectors([{ dataKey: 'data', url: 'https://api.test/d', updateInterval: 5 }]);
+      manager.startPolling();
+
+      const entry = manager.connectors.get('data');
+      expect(entry.timer).not.toBeNull();
+
+      manager.stopPolling();
+      expect(entry.timer).toBeNull();
+    });
+  });
+
+  // ── fetchData + events ─────────────────────────────────────────
+
+  describe('fetchData', () => {
+    it('emits data-updated on success', async () => {
+      fetchWithRetry.mockResolvedValue(jsonResponse({ x: 1 }));
+      const spy = vi.fn();
+      manager.on('data-updated', spy);
+
+      manager.setConnectors([{ dataKey: 'k', url: 'https://api.test/k', updateInterval: 60 }]);
+      const entry = manager.connectors.get('k');
+      await manager.fetchData(entry);
+
+      expect(spy).toHaveBeenCalledWith('k', { x: 1 });
+    });
+
+    it('emits data-changed when data differs', async () => {
+      fetchWithRetry.mockResolvedValue(jsonResponse({ v: 1 }));
+      const spy = vi.fn();
+      manager.on('data-changed', spy);
+
+      manager.setConnectors([{ dataKey: 'k', url: 'https://api.test/k', updateInterval: 60 }]);
+      const entry = manager.connectors.get('k');
+
+      await manager.fetchData(entry);
+      expect(spy).toHaveBeenCalledTimes(1); // null → {v:1} is a change
+
+      fetchWithRetry.mockResolvedValue(jsonResponse({ v: 1 }));
+      await manager.fetchData(entry);
+      expect(spy).toHaveBeenCalledTimes(1); // same data, no change event
+
+      fetchWithRetry.mockResolvedValue(jsonResponse({ v: 2 }));
+      await manager.fetchData(entry);
+      expect(spy).toHaveBeenCalledTimes(2); // changed
+    });
+
+    it('emits fetch-error on failure', async () => {
+      fetchWithRetry.mockRejectedValue(new Error('Network timeout'));
+      const spy = vi.fn();
+      manager.on('fetch-error', spy);
+
+      manager.setConnectors([{ dataKey: 'k', url: 'https://api.test/k', updateInterval: 60 }]);
+      const entry = manager.connectors.get('k');
+      await manager.fetchData(entry);
+
+      expect(spy).toHaveBeenCalledWith('k', expect.any(Error));
+    });
+  });
+
+  // ── Circuit breaker ────────────────────────────────────────────
+
+  describe('circuit breaker', () => {
+    it('increments failure counter on fetch error', async () => {
+      fetchWithRetry.mockRejectedValue(new Error('fail'));
+
+      manager.setConnectors([{ dataKey: 'k', url: 'https://api.test/k', updateInterval: 60 }]);
+      const entry = manager.connectors.get('k');
+      await manager.fetchData(entry);
+
+      expect(entry.failures).toBe(1);
+    });
+
+    it('resets failure counter on success', async () => {
+      fetchWithRetry.mockRejectedValue(new Error('fail'));
+
+      manager.setConnectors([{ dataKey: 'k', url: 'https://api.test/k', updateInterval: 60 }]);
+      const entry = manager.connectors.get('k');
+
+      await manager.fetchData(entry);
+      await manager.fetchData(entry);
+      expect(entry.failures).toBe(2);
+
+      fetchWithRetry.mockResolvedValue(jsonResponse({ ok: true }));
+      await manager.fetchData(entry);
+      expect(entry.failures).toBe(0);
+    });
+
+    it('backs off after 3 consecutive failures', async () => {
+      fetchWithRetry.mockRejectedValue(new Error('fail'));
+
+      manager.setConnectors([{ dataKey: 'k', url: 'https://api.test/k', updateInterval: 10 }]);
+      const entry = manager.connectors.get('k');
+      // Simulate an active polling timer
+      entry.timer = setInterval(() => {}, 10000);
+
+      // 3 consecutive failures triggers circuit breaker
+      await manager.fetchData(entry);
+      expect(entry.failures).toBe(1);
+      await manager.fetchData(entry);
+      expect(entry.failures).toBe(2);
+      await manager.fetchData(entry);
+      expect(entry.failures).toBe(3);
+      // Timer was replaced by backed-off setTimeout
+      expect(entry.timer).not.toBeNull();
+    });
+  });
+
+  // ── getData / getAvailableKeys ────────────────────────────────
+
+  describe('getData', () => {
+    it('returns null for unknown key', () => {
+      expect(manager.getData('nonexistent')).toBeNull();
+    });
+
+    it('returns stored data after fetch', async () => {
+      fetchWithRetry.mockResolvedValue(jsonResponse({ temp: 25 }));
+      manager.setConnectors([{ dataKey: 'w', url: 'https://api.test/w', updateInterval: 60 }]);
+      await manager.fetchData(manager.connectors.get('w'));
+      expect(manager.getData('w')).toEqual({ temp: 25 });
+    });
+  });
+
+  describe('getAvailableKeys', () => {
+    it('returns empty array when no data', () => {
+      manager.setConnectors([{ dataKey: 'k', url: 'https://api.test', updateInterval: 60 }]);
+      expect(manager.getAvailableKeys()).toEqual([]);
+    });
+
+    it('returns keys with data', async () => {
+      fetchWithRetry.mockResolvedValue(jsonResponse({ v: 1 }));
+      manager.setConnectors([
+        { dataKey: 'a', url: 'https://a.test', updateInterval: 60 },
+        { dataKey: 'b', url: 'https://b.test', updateInterval: 60 },
+      ]);
+      await manager.fetchData(manager.connectors.get('a'));
+      expect(manager.getAvailableKeys()).toEqual(['a']);
+    });
+  });
+
+  // ── refreshAll / cleanup ──────────────────────────────────────
+
+  describe('refreshAll', () => {
+    it('restarts polling for all connectors', async () => {
+      fetchWithRetry.mockResolvedValue(jsonResponse({}));
+      manager.setConnectors([{ dataKey: 'k', url: 'https://api.test', updateInterval: 60 }]);
+      manager.startPolling();
+      await new Promise(r => setTimeout(r, 50));
+
+      fetchWithRetry.mockClear();
+      manager.refreshAll();
+      await new Promise(r => setTimeout(r, 50));
+      expect(fetchWithRetry).toHaveBeenCalled();
+    });
+  });
+
+  describe('cleanup', () => {
+    it('stops polling and clears all state', () => {
+      manager.setConnectors([{ dataKey: 'k', url: 'https://api.test', updateInterval: 60 }]);
+      manager.cleanup();
+      expect(manager.connectors.size).toBe(0);
+    });
+  });
+});

--- a/packages/schedule/src/overlays.test.js
+++ b/packages/schedule/src/overlays.test.js
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2024-2026 Pau Aliagas <linuxnow@gmail.com>
+import { describe, it, expect, beforeEach } from 'vitest';
+import { OverlayScheduler } from './overlays.js';
+
+function makeOverlay(overrides = {}) {
+  return {
+    file: 100,
+    fromdt: '2026-01-01T00:00:00',
+    todt: '2026-12-31T23:59:59',
+    priority: 0,
+    ...overrides,
+  };
+}
+
+describe('OverlayScheduler', () => {
+  let scheduler;
+
+  beforeEach(() => {
+    scheduler = new OverlayScheduler();
+  });
+
+  // ── Constructor ────────────────────────────────────────────────
+
+  describe('constructor', () => {
+    it('initializes with empty overlays', () => {
+      expect(scheduler.overlays).toEqual([]);
+      expect(scheduler.displayProperties).toEqual({});
+    });
+  });
+
+  // ── setOverlays ───────────────────────────────────────────────
+
+  describe('setOverlays', () => {
+    it('stores overlay list', () => {
+      scheduler.setOverlays([makeOverlay()]);
+      expect(scheduler.overlays).toHaveLength(1);
+    });
+
+    it('handles null/undefined', () => {
+      scheduler.setOverlays(null);
+      expect(scheduler.overlays).toEqual([]);
+    });
+
+    it('replaces previous overlays', () => {
+      scheduler.setOverlays([makeOverlay({ file: 1 })]);
+      scheduler.setOverlays([makeOverlay({ file: 2 }), makeOverlay({ file: 3 })]);
+      expect(scheduler.overlays).toHaveLength(2);
+      expect(scheduler.overlays[0].file).toBe(2);
+    });
+  });
+
+  // ── isTimeActive ──────────────────────────────────────────────
+
+  describe('isTimeActive', () => {
+    it('returns true when now is within time window', () => {
+      const overlay = makeOverlay({
+        fromdt: '2026-03-01T00:00:00',
+        todt: '2026-03-31T23:59:59',
+      });
+      const now = new Date('2026-03-15T12:00:00');
+      expect(scheduler.isTimeActive(overlay, now)).toBe(true);
+    });
+
+    it('returns false when now is before fromdt', () => {
+      const overlay = makeOverlay({ fromdt: '2026-06-01T00:00:00' });
+      const now = new Date('2026-05-01T12:00:00');
+      expect(scheduler.isTimeActive(overlay, now)).toBe(false);
+    });
+
+    it('returns false when now is after todt', () => {
+      const overlay = makeOverlay({ todt: '2026-01-01T00:00:00' });
+      const now = new Date('2026-06-01T12:00:00');
+      expect(scheduler.isTimeActive(overlay, now)).toBe(false);
+    });
+
+    it('returns true when no time bounds set', () => {
+      const overlay = { file: 1 }; // no fromdt/todt
+      expect(scheduler.isTimeActive(overlay, new Date())).toBe(true);
+    });
+
+    it('supports toDt (camelCase) alias', () => {
+      const overlay = { file: 1, fromDt: '2026-01-01', toDt: '2026-12-31' };
+      expect(scheduler.isTimeActive(overlay, new Date('2026-06-15'))).toBe(true);
+    });
+  });
+
+  // ── getCurrentOverlays ────────────────────────────────────────
+
+  describe('getCurrentOverlays', () => {
+    it('returns empty array when no overlays set', () => {
+      expect(scheduler.getCurrentOverlays()).toEqual([]);
+    });
+
+    it('returns only overlays within time window', () => {
+      scheduler.setOverlays([
+        makeOverlay({ file: 1, fromdt: '2026-01-01', todt: '2026-06-30' }),
+        makeOverlay({ file: 2, fromdt: '2026-07-01', todt: '2026-12-31' }),
+      ]);
+
+      // Mock Date to be in Q1
+      const origDate = global.Date;
+      global.Date = class extends origDate {
+        constructor(...args) {
+          if (args.length === 0) return new origDate('2026-03-15T12:00:00');
+          return new origDate(...args);
+        }
+      };
+
+      const active = scheduler.getCurrentOverlays();
+      expect(active).toHaveLength(1);
+      expect(active[0].file).toBe(1);
+
+      global.Date = origDate;
+    });
+
+    it('sorts by priority descending', () => {
+      scheduler.setOverlays([
+        makeOverlay({ file: 1, priority: 5 }),
+        makeOverlay({ file: 2, priority: 10 }),
+        makeOverlay({ file: 3, priority: 1 }),
+      ]);
+
+      // All overlays are within 2026 time window
+      const origDate = global.Date;
+      global.Date = class extends origDate {
+        constructor(...args) {
+          if (args.length === 0) return new origDate('2026-06-15T12:00:00');
+          return new origDate(...args);
+        }
+      };
+
+      const active = scheduler.getCurrentOverlays();
+      expect(active[0].priority).toBe(10);
+      expect(active[1].priority).toBe(5);
+      expect(active[2].priority).toBe(1);
+
+      global.Date = origDate;
+    });
+
+    it('defaults priority to 0 when not set', () => {
+      scheduler.setOverlays([
+        makeOverlay({ file: 1 }), // no priority
+        makeOverlay({ file: 2, priority: 5 }),
+      ]);
+
+      const origDate = global.Date;
+      global.Date = class extends origDate {
+        constructor(...args) {
+          if (args.length === 0) return new origDate('2026-06-15T12:00:00');
+          return new origDate(...args);
+        }
+      };
+
+      const active = scheduler.getCurrentOverlays();
+      expect(active[0].file).toBe(2); // priority 5 first
+      expect(active[1].file).toBe(1); // priority 0
+
+      global.Date = origDate;
+    });
+
+    it('filters by geo-fence when isGeoAware', () => {
+      const mockScheduleManager = {
+        isWithinGeoFence: () => false,
+      };
+      scheduler.setScheduleManager(mockScheduleManager);
+
+      scheduler.setOverlays([
+        makeOverlay({ file: 1, isGeoAware: true, geoLocation: { lat: 41, lng: 2 } }),
+        makeOverlay({ file: 2 }), // not geo-aware
+      ]);
+
+      const origDate = global.Date;
+      global.Date = class extends origDate {
+        constructor(...args) {
+          if (args.length === 0) return new origDate('2026-06-15T12:00:00');
+          return new origDate(...args);
+        }
+      };
+
+      const active = scheduler.getCurrentOverlays();
+      expect(active).toHaveLength(1);
+      expect(active[0].file).toBe(2);
+
+      global.Date = origDate;
+    });
+  });
+
+  // ── getOverlayByFile ──────────────────────────────────────────
+
+  describe('getOverlayByFile', () => {
+    it('finds overlay by file ID', () => {
+      scheduler.setOverlays([makeOverlay({ file: 42 })]);
+      expect(scheduler.getOverlayByFile(42)).not.toBeNull();
+      expect(scheduler.getOverlayByFile(42).file).toBe(42);
+    });
+
+    it('returns null for unknown file', () => {
+      expect(scheduler.getOverlayByFile(999)).toBeNull();
+    });
+  });
+
+  // ── shouldCheckOverlays ───────────────────────────────────────
+
+  describe('shouldCheckOverlays', () => {
+    it('returns true when no last check', () => {
+      expect(scheduler.shouldCheckOverlays(null)).toBe(true);
+      expect(scheduler.shouldCheckOverlays(undefined)).toBe(true);
+    });
+
+    it('returns true after 60+ seconds', () => {
+      const lastCheck = Date.now() - 61000;
+      expect(scheduler.shouldCheckOverlays(lastCheck)).toBe(true);
+    });
+
+    it('returns false within 60 seconds', () => {
+      const lastCheck = Date.now() - 30000;
+      expect(scheduler.shouldCheckOverlays(lastCheck)).toBe(false);
+    });
+  });
+
+  // ── clear / processOverlays ───────────────────────────────────
+
+  describe('clear', () => {
+    it('removes all overlays', () => {
+      scheduler.setOverlays([makeOverlay()]);
+      scheduler.clear();
+      expect(scheduler.overlays).toHaveLength(0);
+    });
+  });
+
+  describe('processOverlays', () => {
+    it('sets overlays and returns layouts unchanged', () => {
+      const layouts = [{ id: 1 }, { id: 2 }];
+      const overlays = [makeOverlay({ file: 10 })];
+      const result = scheduler.processOverlays(layouts, overlays);
+      expect(result).toBe(layouts);
+      expect(scheduler.overlays).toHaveLength(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Circuit breaker**: After 3 consecutive fetch failures, polling interval doubles (capped at 5min). Resets on success.
- **19 DataConnectorManager tests**: setConnectors, polling, fetchData events, circuit breaker, recovery
- **21 OverlayScheduler tests**: time windows, priority ordering, geo-fence filtering, edge cases

## Test plan

- [x] All 1542 tests pass

Closes #242
Closes #244 (partial)