### PR TITLE
refactor: remove dead code, unify nanoevents version

### DIFF
--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -26,7 +26,7 @@
     "@xiboplayer/xmds": "workspace:*",
     "@xiboplayer/xmr": "workspace:*",
     "html2canvas": "^1.4.1",
-    "nanoevents": "^9.0.0",
+    "nanoevents": "^9.1.0",
     "xml2js": "^0.6.2"
   },
   "devDependencies": {

--- a/packages/utils/src/config.js
+++ b/packages/utils/src/config.js
@@ -510,34 +510,6 @@ export class Config {
     console.log('[Config] RSA key pair generated and saved');
   }
 
-  hash(str) {
-    // FNV-1a hash algorithm (better distribution than simple hash)
-    // Produces high-entropy 32-character hex string
-    let hash = 2166136261; // FNV offset basis
-
-    for (let i = 0; i < str.length; i++) {
-      hash ^= str.charCodeAt(i);
-      hash += (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24);
-    }
-
-    // Convert to unsigned 32-bit integer
-    hash = hash >>> 0;
-
-    // Extend to 32 characters by hashing multiple times with different seeds
-    let result = '';
-    for (let round = 0; round < 4; round++) {
-      let roundHash = hash + round * 1234567;
-      for (let i = 0; i < str.length; i++) {
-        roundHash ^= str.charCodeAt(i) + round;
-        roundHash += (roundHash << 1) + (roundHash << 4) + (roundHash << 7) + (roundHash << 8) + (roundHash << 24);
-      }
-      roundHash = roundHash >>> 0;
-      result += roundHash.toString(16).padStart(8, '0');
-    }
-
-    return result.substring(0, 32);
-  }
-
   get cmsUrl() { return this.data.cmsUrl; }
   set cmsUrl(val) { this.data.cmsUrl = val; this.save(); }
 

--- a/packages/utils/src/config.test.js
+++ b/packages/utils/src/config.test.js
@@ -224,51 +224,6 @@ describe('Config', () => {
     });
   });
 
-  describe('Hash Function (FNV-1a)', () => {
-    beforeEach(() => {
-      config = new Config();
-    });
-
-    it('should generate 32-character hex hash', () => {
-      const hash = config.hash('test string');
-
-      expect(hash).toMatch(/^[0-9a-f]{32}$/);
-    });
-
-    it('should be deterministic for same input', () => {
-      const hash1 = config.hash('test');
-      const hash2 = config.hash('test');
-
-      expect(hash1).toBe(hash2);
-    });
-
-    it('should produce different hashes for different inputs', () => {
-      const hash1 = config.hash('test1');
-      const hash2 = config.hash('test2');
-
-      expect(hash1).not.toBe(hash2);
-    });
-
-    it('should handle empty string', () => {
-      const hash = config.hash('');
-
-      expect(hash).toMatch(/^[0-9a-f]{32}$/);
-    });
-
-    it('should produce good entropy for similar inputs', () => {
-      const hash1 = config.hash('a');
-      const hash2 = config.hash('b');
-
-      // Hashes should be completely different (not just 1 character difference)
-      let differences = 0;
-      for (let i = 0; i < hash1.length; i++) {
-        if (hash1[i] !== hash2[i]) differences++;
-      }
-
-      expect(differences).toBeGreaterThan(15); // At least half different
-    });
-  });
-
   describe('Canvas Fingerprint', () => {
     let createElementSpy;
 
@@ -482,22 +437,6 @@ describe('Config', () => {
       expect(config.cmsUrl).toBe('');
     });
 
-    it('should handle very long strings', () => {
-      config = new Config();
-
-      const longString = 'a'.repeat(10000);
-      const hash = config.hash(longString);
-
-      expect(hash).toMatch(/^[0-9a-f]{32}$/);
-    });
-
-    it('should handle unicode in hash', () => {
-      config = new Config();
-
-      const hash = config.hash('测试中文🎉');
-
-      expect(hash).toMatch(/^[0-9a-f]{32}$/);
-    });
   });
 
   describe('Persistence', () => {

--- a/packages/xmr/src/xmr-wrapper.js
+++ b/packages/xmr/src/xmr-wrapper.js
@@ -239,16 +239,6 @@ export class XmrWrapper {
       }
     });
 
-    // CMS command: Screen Shot (alternative event name)
-    this.xmr.on('screenshot', async () => {
-      log.info('Received screenshot command from CMS');
-      try {
-        await this.player.captureScreenshot();
-      } catch (error) {
-        log.error('screenshot failed:', error);
-      }
-    });
-
     // CMS command: Criteria Update
     this.xmr.on('criteriaUpdate', async (data) => {
       log.info('Received criteriaUpdate command:', data);

--- a/packages/xmr/src/xmr-wrapper.test.js
+++ b/packages/xmr/src/xmr-wrapper.test.js
@@ -222,13 +222,6 @@ describe('XmrWrapper', () => {
         expect(mockPlayer.captureScreenshot).toHaveBeenCalled();
       });
 
-      it('should handle screenshot command (alternative)', async () => {
-        xmrInstance.simulateCommand('screenshot');
-        await vi.runAllTimersAsync();
-
-        expect(mockPlayer.captureScreenshot).toHaveBeenCalled();
-      });
-
       it('should handle screenShot failure gracefully', async () => {
         mockPlayer.captureScreenshot.mockRejectedValue(new Error('Screenshot failed'));
         const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,7 +187,7 @@ importers:
         specifier: ^1.4.1
         version: 1.4.1
       nanoevents:
-        specifier: ^9.0.0
+        specifier: ^9.1.0
         version: 9.1.0
       xml2js:
         specifier: ^0.6.2


### PR DESCRIPTION
## Summary

- Remove `Config.hash()` method — duplicate of exported `fnvHash()`
- Remove duplicate `screenshot` handler in xmr-wrapper (keep `screenShot`, CMS convention)
- Unify nanoevents `^9.0.0` → `^9.1.0` in PWA package (matches core + renderer)
- Remove 8 tests that tested removed code

## Test plan

- [x] All 1534 tests pass

Closes #245