### PR TITLE
feat: shared content cache across player instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ Thumbs.db
 # Coverage
 coverage/
 .npmrc
+
+# Playwright
+test-results/
+playwright-report/

--- a/packages/pwa/e2e/controls.spec.ts
+++ b/packages/pwa/e2e/controls.spec.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2024-2026 Pau Aliagas <linuxnow@gmail.com>
+/**
+ * Keyboard and mouse control tests.
+ *
+ * Config is injected by the test proxy server (pwaConfig).
+ */
+import { test, expect } from '@playwright/test';
+import { mockCms } from './helpers/mock-cms';
+
+test.describe('Keyboard controls', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockCms(page, { displayName: 'E2E Controls Test' });
+    await page.goto('/player/');
+    // Wait for player to initialize
+    await page.waitForTimeout(3_000);
+  });
+
+  test('D key toggles debug overlay', async ({ page }) => {
+    await page.keyboard.press('d');
+    await page.waitForTimeout(500);
+
+    const overlay = page.locator('#overlay');
+    const count = await overlay.count();
+
+    if (count > 0) {
+      const hasVisible = await overlay.evaluate((el) => el.classList.contains('visible'));
+      expect(typeof hasVisible).toBe('boolean');
+    }
+
+    // Press D again to toggle off
+    await page.keyboard.press('d');
+  });
+
+  test('S key opens setup overlay when setupKey is enabled', async ({ page }) => {
+    await page.keyboard.press('s');
+    await page.waitForTimeout(1_000);
+
+    // The setup overlay creates a gate card with #gate-key input
+    const gateKey = page.locator('#gate-key');
+    const isSetupVisible = await gateKey.isVisible().catch(() => false);
+
+    if (isSetupVisible) {
+      // Close with Escape
+      await page.keyboard.press('Escape');
+      await page.waitForTimeout(500);
+      const stillVisible = await gateKey.isVisible().catch(() => false);
+      expect(stillVisible).toBe(false);
+    }
+  });
+});

--- a/packages/pwa/e2e/helpers/mock-cms.ts
+++ b/packages/pwa/e2e/helpers/mock-cms.ts
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2024-2026 Pau Aliagas <linuxnow@gmail.com>
+/**
+ * CMS response mocking utilities for Playwright tests.
+ *
+ * Intercepts XMDS SOAP requests at /xmds-proxy and returns canned responses.
+ * Also intercepts REST API v2 requests for protocol auto-detection.
+ *
+ * Config injection is handled by the test proxy server (see test-server.js),
+ * which passes pwaConfig to the proxy's startServer().
+ */
+import type { Page, Route } from '@playwright/test';
+
+/** SOAP envelope wrapper */
+function soapEnvelope(body: string): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>${body}</soap:Body>
+</soap:Envelope>`;
+}
+
+/** RegisterDisplay READY response */
+function registerDisplayResponse(displayName: string): string {
+  return soapEnvelope(`
+    <RegisterDisplayResponse xmlns="urn:xmds">
+      <RegisterDisplayResult><![CDATA[<display status="0" code="READY" message="Display is active and ready to start."
+        version="4" localDate="2026-03-20 12:00:00"
+        displayName="${displayName}"
+        screenShotRequested="0"
+        screenShotSize="200"
+        maxConcurrentDownloads="2"
+        collectInterval="900"
+        xmrChannel="test-channel"
+        xmrPubUrl=""
+        latitude="0.0" longitude="0.0"
+        />]]></RegisterDisplayResult>
+    </RegisterDisplayResponse>`);
+}
+
+/** RequiredFiles -- empty (no files to download) */
+function requiredFilesResponse(): string {
+  return soapEnvelope(`
+    <RequiredFilesResponse xmlns="urn:xmds">
+      <RequiredFilesResult><![CDATA[<files></files>]]></RequiredFilesResult>
+    </RequiredFilesResponse>`);
+}
+
+/** Schedule -- single default layout (layoutId=1) */
+function scheduleResponse(): string {
+  return soapEnvelope(`
+    <ScheduleResponse xmlns="urn:xmds">
+      <ScheduleResult><![CDATA[<schedule>
+        <default file="1.xlf" />
+      </schedule>]]></ScheduleResult>
+    </ScheduleResponse>`);
+}
+
+/** Minimal XLF layout with a single clock widget */
+export const TEST_LAYOUT_XLF = `<?xml version="1.0" encoding="UTF-8"?>
+<layout schemaVersion="3" width="1920" height="1080" background="#000000"
+        layoutId="1" status="1" duration="10">
+  <region id="r1" width="1920" height="1080" top="0" left="0">
+    <media id="w1" type="clock" duration="10" render="native">
+      <options>
+        <theme>1</theme>
+        <format>[HH:mm:ss]</format>
+      </options>
+    </media>
+  </region>
+</layout>`;
+
+/**
+ * Extract the SOAP action from a request body.
+ * Handles both `<RegisterDisplay xmlns="urn:xmds"` and `<tns:RegisterDisplay>` formats.
+ */
+export function extractAction(body: string): string | null {
+  // Try tns-prefixed format: <tns:RegisterDisplay>
+  const prefixed = body.match(/<tns:(\w+)>/);
+  if (prefixed) return prefixed[1];
+  // Fallback: <RegisterDisplay xmlns="urn:xmds"
+  const direct = body.match(/<(\w+)\s+xmlns="urn:xmds"/);
+  return direct ? direct[1] : null;
+}
+
+/**
+ * Install CMS mock routes on a Playwright page.
+ * Intercepts /xmds-proxy (SOAP) and /api/v2 (REST) requests.
+ */
+export async function mockCms(page: Page, options?: { displayName?: string }) {
+  const displayName = options?.displayName ?? 'Test Display';
+
+  // Mock XMDS SOAP proxy -- match URL path, ignore query params
+  await page.route((url) => url.pathname === '/xmds-proxy', async (route: Route) => {
+    const body = route.request().postData() ?? '';
+    const action = extractAction(body);
+
+    let response: string;
+    switch (action) {
+      case 'RegisterDisplay':
+        response = registerDisplayResponse(displayName);
+        break;
+      case 'RequiredFiles':
+        response = requiredFilesResponse();
+        break;
+      case 'Schedule':
+        response = scheduleResponse();
+        break;
+      case 'SubmitStats':
+      case 'SubmitLog':
+      case 'MediaInventory':
+      case 'NotifyStatus':
+      case 'ReportFaults':
+        response = soapEnvelope(`<${action}Response xmlns="urn:xmds"><${action}Result>true</${action}Result></${action}Response>`);
+        break;
+      default:
+        response = soapEnvelope(`<GenericResponse xmlns="urn:xmds"><Result>ok</Result></GenericResponse>`);
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/xml; charset=utf-8',
+      body: response,
+    });
+  });
+
+  // Mock REST API v2 probe (returns 404 so player falls back to SOAP)
+  await page.route('**/api/v2/player/**', async (route: Route) => {
+    await route.fulfill({ status: 404, body: 'Not found' });
+  });
+
+  // Mock layout XLF file request
+  await page.route('**/player/api/layouts/1', async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/xml',
+      body: TEST_LAYOUT_XLF,
+    });
+  });
+}

--- a/packages/pwa/e2e/helpers/test-server.js
+++ b/packages/pwa/e2e/helpers/test-server.js
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2024-2026 Pau Aliagas <linuxnow@gmail.com>
+/**
+ * Standalone test server script.
+ * Starts the proxy server serving the PWA dist for e2e tests.
+ * Invoked by playwright.config.ts webServer.command.
+ *
+ * When TEST_INJECT_CONFIG=1 is set, the proxy injects CMS config into
+ * index.html so the player skips the setup screen — used by player.spec tests.
+ */
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { startServer } from '../../../../packages/proxy/src/index.js';
+import { computeCmsId } from '../../../../packages/utils/src/config.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PWA_DIST = path.resolve(__dirname, '../../dist');
+const PORT = parseInt(process.env.TEST_PORT || '18765', 10);
+
+// Default test CMS config — proxy will inject this into index.html
+const cmsUrl = `http://localhost:${PORT}`;
+const pwaConfig = {
+  cmsUrl,
+  cmsKey: 'test-key-12345',
+  displayName: 'E2E Test Display',
+  hardwareKey: 'test-hardware-key-e2e',
+  cmsId: computeCmsId(cmsUrl),
+  transport: 'xmds',
+  controls: {
+    keyboard: { enabled: true, setupKey: true },
+    mouse: { statusBarOnHover: true },
+  },
+};
+
+startServer({
+  port: PORT,
+  pwaPath: PWA_DIST,
+  appVersion: '0.0.0-test',
+  pwaConfig,
+  relaxSslCerts: false,
+}).then(({ port }) => {
+  console.log(`Test server ready on port ${port}`);
+});

--- a/packages/pwa/e2e/player.spec.ts
+++ b/packages/pwa/e2e/player.spec.ts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2024-2026 Pau Aliagas <linuxnow@gmail.com>
+/**
+ * Player lifecycle tests -- config injection, collection cycle, rendering.
+ *
+ * The test server (webServer in playwright.config.ts) passes pwaConfig to the
+ * proxy, which injects CMS config into index.html before inline scripts run.
+ * This is the same mechanism used in production (Electron / proxy).
+ */
+import { test, expect } from '@playwright/test';
+import { mockCms, extractAction } from './helpers/mock-cms';
+
+const CMS_CONFIG = { displayName: 'E2E Test Display' };
+
+test.describe('Player with config', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockCms(page, CMS_CONFIG);
+  });
+
+  test('does not redirect to setup when config is injected', async ({ page }) => {
+    await page.goto('/player/');
+    await page.waitForTimeout(2_000);
+    expect(page.url()).not.toContain('setup.html');
+    expect(page.url()).toContain('/player');
+  });
+
+  test('player-container is present and visible', async ({ page }) => {
+    await page.goto('/player/');
+    const container = page.locator('#player-container');
+    await expect(container).toBeVisible();
+  });
+
+  test('registers with CMS via XMDS', async ({ page }) => {
+    const xmdsRequests: string[] = [];
+    page.on('request', (req) => {
+      if (req.url().includes('xmds-proxy')) {
+        const body = req.postData() ?? '';
+        const action = extractAction(body);
+        if (action) xmdsRequests.push(action);
+      }
+    });
+
+    await page.goto('/player/');
+
+    await expect(async () => {
+      expect(xmdsRequests).toContain('RegisterDisplay');
+    }).toPass({ timeout: 15_000 });
+  });
+
+  test('fetches schedule after registration', async ({ page }) => {
+    const xmdsRequests: string[] = [];
+    page.on('request', (req) => {
+      if (req.url().includes('xmds-proxy')) {
+        const body = req.postData() ?? '';
+        const action = extractAction(body);
+        if (action) xmdsRequests.push(action);
+      }
+    });
+
+    await page.goto('/player/');
+
+    await expect(async () => {
+      expect(xmdsRequests).toContain('RegisterDisplay');
+      expect(xmdsRequests).toContain('Schedule');
+    }).toPass({ timeout: 15_000 });
+  });
+
+  test('status bar shows version and CMS info on hover', async ({ page }) => {
+    await page.goto('/player/');
+    await page.waitForTimeout(5_000);
+
+    const configInfo = page.locator('#config-info');
+    await page.hover('body', { position: { x: 10, y: 10 } });
+
+    await expect(configInfo).toBeVisible({ timeout: 5_000 });
+    const text = await configInfo.textContent();
+    expect(text).toContain('CMS:');
+  });
+});

--- a/packages/pwa/e2e/setup.spec.ts
+++ b/packages/pwa/e2e/setup.spec.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2024-2026 Pau Aliagas <linuxnow@gmail.com>
+/**
+ * Setup screen tests -- verifies the player shows setup when unconfigured.
+ *
+ * Note: the test proxy server injects config by default. These tests either
+ * navigate directly to setup.html or clear localStorage to simulate no config.
+ */
+import { test, expect } from '@playwright/test';
+
+test.describe('Setup screen', () => {
+  test('redirects to setup.html when no config is present', async ({ page }) => {
+    // Clear config injected by proxy: intercept the page, run before scripts
+    await page.addInitScript(() => localStorage.clear());
+
+    // Navigate — should redirect to setup.html since localStorage is empty
+    await page.goto('/player/');
+    await page.waitForURL('**/setup.html**', { timeout: 5_000 });
+
+    expect(page.url()).toContain('setup.html');
+  });
+
+  test('setup page shows CMS URL and CMS Key fields', async ({ page }) => {
+    await page.goto('/player/setup.html');
+
+    await expect(page.locator('#cms-url')).toBeVisible();
+    await expect(page.locator('#cms-key')).toBeVisible();
+    await expect(page.locator('#display-name')).toBeVisible();
+  });
+
+  test('setup page has Xibo Player branding', async ({ page }) => {
+    await page.goto('/player/setup.html');
+
+    await expect(page).toHaveTitle(/Xibo Player Setup/);
+  });
+});

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -10,7 +10,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@xiboplayer/cache": "workspace:*",
@@ -30,6 +31,7 @@
     "xml2js": "^0.6.2"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@types/node": "^22.10.5",
     "@types/xml2js": "^0.4.14",
     "typescript": "^5.6.3",

--- a/packages/pwa/playwright.config.ts
+++ b/packages/pwa/playwright.config.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2024-2026 Pau Aliagas <linuxnow@gmail.com>
+import { defineConfig } from '@playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PORT = 18765; // Non-conflicting test port
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  retries: 0,
+  use: {
+    baseURL: `http://localhost:${PORT}`,
+    headless: true,
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+    serviceWorkers: 'block', // Block SW so page.route() intercepts all requests
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium' },
+    },
+  ],
+  webServer: {
+    command: `node ${path.resolve(__dirname, 'e2e/helpers/test-server.js')}`,
+    port: PORT,
+    reuseExistingServer: false,
+    timeout: 15_000,
+    env: { TEST_PORT: String(PORT) },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,6 +193,9 @@ importers:
         specifier: ^0.6.2
         version: 0.6.2
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.58.2
+        version: 1.58.2
       '@types/node':
         specifier: ^22.10.5
         version: 22.19.13


### PR DESCRIPTION
## Summary

- Use shared `dataDir` (`~/.local/share/xiboplayer/cache/`) for ContentStore media cache
- All instances on the same machine share one cache — avoids duplicate downloads for video walls
- Browser data (localStorage, IndexedDB, Service Worker) remains instance-specific
- Safe: ContentStore uses atomic writes (temp file + rename)
- Per-CMS isolation via `{cmsId}` subdirectory within the shared cache

Closes #277

## Changes

- **Chromium** `server.js`: `dataDir` → `~/.local/share/xiboplayer/cache/`
- **Electron** `main.js`: `dataDir` → `~/.local/share/xiboplayer/cache/`

## Test plan

- [ ] Multi-instance: verify shared cache directory used
- [ ] Content downloaded once, visible to all instances
- [ ] No file corruption under concurrent access