### PR TITLE
fix: EventEmitter.once() wrapper leak and broken player meta-package exports

### DIFF
--- a/packages/player/src/index.js
+++ b/packages/player/src/index.js
@@ -7,5 +7,5 @@ export { CacheManager, StoreClient, DownloadManager } from '@xiboplayer/cache';
 export { ScheduleManager } from '@xiboplayer/schedule';
 export { XmdsClient } from '@xiboplayer/xmds';
 export { XmrWrapper } from '@xiboplayer/xmr';
-export { registerServiceWorker, unregisterServiceWorker } from '@xiboplayer/sw';
-export { createLogger, EventEmitter, Config } from '@xiboplayer/utils';
+export { RequestHandler, MessageHandler } from '@xiboplayer/sw';
+export { createLogger, EventEmitter, config } from '@xiboplayer/utils';

--- a/packages/utils/src/event-emitter.js
+++ b/packages/utils/src/event-emitter.js
@@ -29,8 +29,8 @@ export class EventEmitter {
    */
   once(event, callback) {
     const wrapper = (...args) => {
-      callback(...args);
       this.off(event, wrapper);
+      callback(...args);
     };
     this.on(event, wrapper);
   }


### PR DESCRIPTION
## Summary
1. **EventEmitter.once()**: Move `this.off()` before `callback()` — if callback throws, wrapper was never removed (memory leak, "once" became "always")
2. **@xiboplayer/player exports**: Replace non-existent `registerServiceWorker`/`unregisterServiceWorker` with actual sw exports (`RequestHandler`, `MessageHandler`). Replace non-existent `Config` class with `config` singleton.

## Test plan
- [x] All 1744 tests pass
- [ ] `import { RequestHandler } from '@xiboplayer/player'` resolves
- [ ] `once()` listener that throws is still removed after first emit

Closes #315, closes #313