### PR TITLE
chore: remove unused xml2js and nanoevents from pwa

### DIFF
--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -26,14 +26,11 @@
     "@xiboplayer/utils": "workspace:*",
     "@xiboplayer/xmds": "workspace:*",
     "@xiboplayer/xmr": "workspace:*",
-    "html2canvas": "^1.4.1",
-    "nanoevents": "^9.1.0",
-    "xml2js": "^0.6.2"
+    "html2canvas": "^1.4.1"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.0",
     "@types/node": "^25.5.0",
-    "@types/xml2js": "^0.4.14",
     "typescript": "^6.0.2",
     "vite": "^8.0.3"
   },


### PR DESCRIPTION
Closes #316. Zero imports found. 1744 tests pass.