### PR TITLE
refactor: consolidate GPU detection and memory tuning in shared module

### DIFF
--- a/packages/proxy/src/hardware.js
+++ b/packages/proxy/src/hardware.js
@@ -72,11 +72,9 @@ export function selectGPU(gpus, preference) {
     const displayGPUs = gpus.filter(g => g.hasDisplay);
     const renderOnly = gpus.filter(g => !g.hasDisplay);
     if (displayGPUs.length > 0 && renderOnly.length > 0) {
-      displayGPUs.sort((a, b) => b.rank - a.rank);
-      return displayGPUs[0];
+      return [...displayGPUs].sort((a, b) => b.rank - a.rank)[0];
     }
-    gpus.sort((a, b) => b.rank - a.rank);
-    return gpus[0] || null;
+    return [...gpus].sort((a, b) => b.rank - a.rank)[0] || null;
   }
   if (preference.startsWith('/dev/dri/')) {
     return gpus.find(g => g.renderNode === preference) || null;
@@ -106,4 +104,46 @@ export function getMemoryTuning() {
   }
 
   return { totalRAM_GB, cpuCount, maxOldSpaceMB, rasterThreads };
+}
+
+/**
+ * Generate Chromium/Electron GPU and memory flags.
+ * This is the single source of truth — both Electron and Chromium should use this.
+ *
+ * @param {object} [options]
+ * @param {string} [options.gpuPreference='auto'] - GPU selection preference
+ * @returns {{gpu: object|null, memory: object, flags: string[], env: object}}
+ */
+export function getHardwareConfig(options = {}) {
+  const gpus = detectGPUs();
+  const gpu = gpus.length > 0 ? selectGPU(gpus, options.gpuPreference) : null;
+  const memory = getMemoryTuning();
+
+  const flags = [
+    '--ignore-gpu-blocklist',
+    '--enable-gpu-rasterization',
+    '--enable-zero-copy',
+    `--num-raster-threads=${memory.rasterThreads}`,
+    `--js-flags=--max-old-space-size=${memory.maxOldSpaceMB}`,
+    '--enable-features=CanvasOopRasterization,VaapiVideoDecoder,VaapiVideoEncoder',
+    '--disable-gpu-watchdog',
+    '--disable-background-timer-throttling',
+  ];
+
+  const env = {};
+
+  if (gpu) {
+    flags.push(`--render-node-override=${gpu.renderNode}`);
+    if (gpu.vaDriver) {
+      env.LIBVA_DRIVER_NAME = gpu.vaDriver;
+    }
+  }
+
+  return {
+    gpus,
+    gpu,
+    memory,
+    flags,
+    env,
+  };
 }

--- a/packages/proxy/src/index.js
+++ b/packages/proxy/src/index.js
@@ -5,4 +5,4 @@ export { ContentStore } from './content-store.js';
 export { attachSyncRelay } from './sync-relay.js';
 export { getLanIp, advertiseSyncService, discoverSyncLead } from './discovery.js';
 export { migrateContentCache } from './migrate-cache.js';
-export { detectGPUs, selectGPU, getMemoryTuning, GPU_VENDORS } from './hardware.js';
+export { detectGPUs, selectGPU, getMemoryTuning, getHardwareConfig, GPU_VENDORS } from './hardware.js';

--- a/packages/proxy/src/proxy.js
+++ b/packages/proxy/src/proxy.js
@@ -22,6 +22,7 @@ import { createLogger, registerLogSink, PLAYER_API, setPlayerApi, computeCmsId }
 import { ContentStore } from './content-store.js';
 import { attachSyncRelay } from './sync-relay.js';
 import { getLanIp, advertiseSyncService, discoverSyncLead } from './discovery.js';
+import { getHardwareConfig } from './hardware.js';
 
 const SKIP_HEADERS = ['transfer-encoding', 'connection', 'content-encoding', 'content-length'];
 
@@ -223,6 +224,14 @@ export function createProxyApp({ pwaPath, appVersion = '0.0.0', pwaConfig, confi
     }
 
     res.json({ ok: true });
+  });
+
+  // ─── GET /system/hardware — GPU detection + memory tuning ────
+  // Used by Chromium's launch-kiosk.sh to get GPU flags and memory config
+  // from the shared Node.js module instead of duplicating in bash.
+  app.get('/system/hardware', (_req, res) => {
+    const config = getHardwareConfig({ gpuPreference: _req.query.gpu });
+    res.json(config);
   });
 
   // ─── GET /system/lan-ip — return this machine's LAN IPv4 ────


### PR DESCRIPTION
Shared source of truth for GPU detection + memory tuning in @xiboplayer/proxy.

- Fix selectGPU sort mutation (spread copy)
- New getHardwareConfig() returns GPU, memory, flags, env in one call
- New /system/hardware proxy endpoint for Chromium bash bridge
- 1744 tests pass

Electron and Chromium should migrate to importing from this module.

Refs #322