### PR TITLE
security: pin GitHub Actions to SHA digests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   publish:
-    uses: xibo-players/.github/.github/workflows/publish-npm.yml@main
+    uses: xibo-players/.github/.github/workflows/publish-npm.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
     with:
       publish-command: 'pnpm --filter @xiboplayer/pwa build && pnpm -r publish --no-git-checks --access public'
 
@@ -24,7 +24,7 @@ jobs:
   release:
     needs: publish
     if: startsWith(github.ref, 'refs/tags/')
-    uses: xibo-players/.github/.github/workflows/create-release.yml@main
+    uses: xibo-players/.github/.github/workflows/create-release.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
     with:
       package-name: 'xiboplayer-sdk'
       description: 'xiboplayer SDK monorepo — @xiboplayer/* npm packages published together at matching versions.'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   unit:
-    uses: xibo-players/.github/.github/workflows/test.yml@main
+    uses: xibo-players/.github/.github/workflows/test.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
     with:
       lint-command: 'pnpm lint'
       typecheck: true
@@ -19,7 +19,7 @@ jobs:
   integration:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     needs: unit
-    uses: xibo-players/.github/.github/workflows/integration-test.yml@main
+    uses: xibo-players/.github/.github/workflows/integration-test.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
     with:
       cms-url: 'https://xibo-dev.superpantalles.com'
     secrets:


### PR DESCRIPTION
Closes #334. Pins 4 internal reusable workflow references to full commit SHAs with inline version comments. See xiboplayer-kiosk#29 and xiboplayer-kiosk#48 for the reference pattern.