### PR TITLE
fix(pwa): no space in 'xiboplayer' logo, replace PWA tagline

### DIFF
--- a/packages/pwa/setup.html
+++ b/packages/pwa/setup.html
@@ -291,8 +291,8 @@
 <body>
   <div class="container">
     <div class="logo">
-      <div class="logo-text"><span>xibo</span> player</div>
-      <div class="logo-sub">PWA Digital Signage</div>
+      <div class="logo-text"><span>xibo</span>player</div>
+      <div class="logo-sub">Open source digital signage</div>
     </div>
 
     <!-- Phase 0: Unlock gate (reconfiguration only) -->

--- a/packages/pwa/src/setup-overlay.ts
+++ b/packages/pwa/src/setup-overlay.ts
@@ -145,9 +145,9 @@ export class SetupOverlay {
     this.gateCard.innerHTML = `
       <div style="text-align: center; margin-bottom: 32px;">
         <div style="font-size: 36px; font-weight: 700; color: #fff; letter-spacing: -0.5px;">
-          <span style="color: #0097D8;">xibo</span> player
+          <span style="color: #0097D8;">xibo</span>player
         </div>
-        <div style="font-size: 14px; color: #888; margin-top: 4px;">PWA Digital Signage</div>
+        <div style="font-size: 14px; color: #888; margin-top: 4px;">Open source digital signage</div>
       </div>
       <div style="font-size: 18px; font-weight: 600; color: #fff; margin-bottom: 8px; text-align: center;">
         Reconfigure Display


### PR DESCRIPTION
Two setup-UI fixes:

- **'xibo player' → 'xiboplayer'** (no space between cyan and white spans; brand is one word)
- **'PWA Digital Signage' → 'Open source digital signage'** (tagline emphasises OSS values, not implementation tech)

Fixes both canonical locations:
- `packages/pwa/setup.html` (static page)
- `packages/pwa/src/setup-overlay.ts` (gateCard during reconfigure)

dist/ will regenerate on next pnpm build.