### PR TITLE
ci(www): dispatch website regen after SDK publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,3 +66,34 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload "${GITHUB_REF_NAME}" xiboplayer-sdk-sbom.cdx.json --clobber
+
+  dispatch-www:
+    name: Trigger xiboplayer-www regeneration
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send repository_dispatch to xiboplayer-www
+        env:
+          GH_TOKEN: ${{ secrets.WWW_DISPATCH_TOKEN }}
+          GITHUB_REF: ${{ github.ref }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::warning::WWW_DISPATCH_TOKEN not set — skipping www regen trigger."
+            exit 0
+          fi
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            VER="${GITHUB_REF#refs/tags/v}"
+          else
+            VER=$(npm view @xiboplayer/pwa version 2>/dev/null || echo 'unknown')
+          fi
+          echo "Firing repository_dispatch sdk-published to xiboplayer-www with version=$VER"
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/xibo-players/xiboplayer-www/dispatches \
+            -f event_type=sdk-published \
+            -f "client_payload[version]=${VER}" \
+            -f "client_payload[source]=xiboplayer-sdk" \
+            -f "client_payload[tag]=${GITHUB_REF}"
+          echo "Dispatch fired"


### PR DESCRIPTION
Adds a dispatch-www job to publish.yml so the website regenerates after every successful npm publish. Same pattern as the kiosk image.yml dispatch. Uses WWW_DISPATCH_TOKEN org secret.