### PR TITLE
[NIGHTLY-TEST-QUALITY] stats: replace real sleeps with fake Date (refs #350)

### DIFF
--- a/packages/stats/src/log-reporter.test.js
+++ b/packages/stats/src/log-reporter.test.js
@@ -4,13 +4,14 @@
  * Tests for LogReporter and formatLogs
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { LogReporter, formatLogs, formatFaults } from './log-reporter.js';
 
 describe('LogReporter', () => {
   let reporter;
 
   beforeEach(async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
     reporter = new LogReporter();
     await reporter.init();
     await reporter.clearAllLogs();
@@ -21,6 +22,7 @@ describe('LogReporter', () => {
       await reporter.clearAllLogs();
       reporter.db.close();
     }
+    vi.useRealTimers();
   });
 
   describe('constructor and initialization', () => {
@@ -269,8 +271,8 @@ describe('LogReporter', () => {
       // Report first fault
       await reporter.reportFault('TEST_FAULT', 'First', 1); // 1ms cooldown
 
-      // Wait for cooldown to expire
-      await new Promise(resolve => setTimeout(resolve, 10));
+      // Advance fake clock past cooldown (no real wait)
+      vi.setSystemTime(Date.now() + 10);
 
       await reporter.reportFault('TEST_FAULT', 'Second', 1);
 
@@ -302,9 +304,9 @@ describe('LogReporter', () => {
 
     it('should respect limit parameter', async () => {
       await reporter.reportFault('FAULT_1', 'Fault 1', 1);
-      await new Promise(r => setTimeout(r, 5));
+      vi.setSystemTime(Date.now() + 5);
       await reporter.reportFault('FAULT_2', 'Fault 2', 1);
-      await new Promise(r => setTimeout(r, 5));
+      vi.setSystemTime(Date.now() + 5);
       await reporter.reportFault('FAULT_3', 'Fault 3', 1);
 
       const faults = await reporter.getFaultsForSubmission(2);

--- a/packages/stats/src/stats-collector.test.js
+++ b/packages/stats/src/stats-collector.test.js
@@ -4,13 +4,14 @@
  * Tests for StatsCollector and formatStats
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { StatsCollector, formatStats } from './stats-collector.js';
 
 describe('StatsCollector', () => {
   let collector;
 
   beforeEach(async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
     collector = new StatsCollector();
     await collector.init();
     await collector.clearAllStats();
@@ -21,6 +22,7 @@ describe('StatsCollector', () => {
       await collector.clearAllStats();
       collector.db.close();
     }
+    vi.useRealTimers();
   });
 
   describe('constructor and initialization', () => {
@@ -84,8 +86,8 @@ describe('StatsCollector', () => {
     it('should end tracking a layout', async () => {
       await collector.startLayout(123, 456);
 
-      // Wait a bit to ensure duration > 0
-      await new Promise(resolve => setTimeout(resolve, 100));
+      // Advance fake clock 100ms to ensure duration > 0 (no real wait)
+      vi.setSystemTime(Date.now() + 100);
 
       await collector.endLayout(123, 456);
 
@@ -114,8 +116,8 @@ describe('StatsCollector', () => {
     it('should calculate duration correctly', async () => {
       await collector.startLayout(123, 456);
 
-      // Wait 1 second
-      await new Promise(resolve => setTimeout(resolve, 1000));
+      // Advance fake clock 1 second (no real wait)
+      vi.setSystemTime(Date.now() + 1000);
 
       await collector.endLayout(123, 456);
 
@@ -160,7 +162,7 @@ describe('StatsCollector', () => {
     it('should end tracking a widget', async () => {
       await collector.startWidget(111, 123, 456);
 
-      await new Promise(resolve => setTimeout(resolve, 100));
+      vi.setSystemTime(Date.now() + 100);
 
       await collector.endWidget(111, 123, 456);
 


### PR DESCRIPTION
## Summary

Eliminates 5 real-wall-clock `setTimeout` sleeps from the `@xiboplayer/stats` test suite by faking only `Date` with vitest and advancing it manually. No production-code changes.

Refs #350 (Category A — duration checks). First PR in the series; follow-ups will handle `sync`, `proxy`, `cache`, `core`, `xmds`, `datasource`.

## Why fake `Date` only

`vitest.setup.js` imports `fake-indexeddb/auto`. Faking `setTimeout`/`setInterval` with `vi.useFakeTimers()` defaults would deadlock the IndexedDB shim. Passing `{ toFake: ['Date'] }` fakes only the `Date` constructor and `Date.now()`, which is all we need because `stats-collector.js` computes durations from `new Date()` differences and `log-reporter.js` uses `Date.now()` for fault cooldown dedup.

## Changes

- `packages/stats/src/stats-collector.test.js`
  - `beforeEach` → `vi.useFakeTimers({ toFake: ['Date'] })`; `afterEach` → `vi.useRealTimers()`
  - `should end tracking a layout` — 100ms real sleep → `vi.setSystemTime(Date.now() + 100)`
  - `should calculate duration correctly` — **1-second** real sleep → fake 1 s advance
  - `should end tracking a widget` — 100ms sleep → fake 100ms
- `packages/stats/src/log-reporter.test.js`
  - Same fake-timer scaffolding
  - `should allow same fault after cooldown expires` — 10ms sleep → 10ms fake
  - `should respect limit parameter` — two 5ms sleeps → two fake advances

## Verification

Full suite before and after, from repo root:

\`\`\`
# Before (origin/main @ 1fcada2)
Test Files  62 passed (62)
     Tests  1982 passed (1982)
  Duration  20.39s

# After (this branch)
Test Files  62 passed (62)
     Tests  1982 passed (1982)
  Duration  18.96s — 19.57s   (~1.3s saved, as expected: 1000+100+100+100+10+5+5 ms)
\`\`\`

No test count change. No production code change. Runs deterministic — no dependency on CI machine speed for the sub-second duration assertions.

## Out of scope (follow-ups tracked in #350)

- Category B: fake-timer conflicts inside `sync-manager.test.js`, `sync-relay.test.js` — needs different approach (fake-timer-aware replacement of the local `tick()` helper)
- Category C: WS handshake waits in `ws-transport.test.js`, mDNS discovery in `proxy/discovery.test.js` — need event-based replacements, not time-based
- `cache/download-manager.test.js`, `core/data-connectors.test.js`, `datasource/datasource-client.test.js`, `xmds/protocol-detector.test.js` — same pattern as this PR, separate change per package to keep PRs reviewable

## Checklist

- [x] Full suite green (1982/1982)
- [x] Only test files touched
- [x] No new dependencies
- [x] Uses existing vitest APIs (`vi.useFakeTimers`, `vi.setSystemTime`)
- [x] No `console.log` added
- [ ] Re-review after #350 follow-ups to confirm the pattern is consistent across packages