### PR TITLE
[NIGHTLY-TEST-QUALITY] fix: standalone per-package `vitest` runs (closes #362)

### DIFF
--- a/packages/core/vitest.config.js
+++ b/packages/core/vitest.config.js
@@ -5,6 +5,11 @@ export default defineConfig({
     // Environment
     environment: 'jsdom', // Browser-like environment
 
+    // Share the monorepo root setup (fake-indexeddb/auto, fetch stub,
+    // jsdom polyfills) so `pnpm --filter @xiboplayer/core test` works
+    // the same way as root-level `pnpm test`.
+    setupFiles: [new URL('../../vitest.setup.js', import.meta.url).pathname],
+
     // Test files
     include: ['src/**/*.test.js'],
     exclude: ['node_modules', 'dist'],

--- a/packages/stats/vitest.config.js
+++ b/packages/stats/vitest.config.js
@@ -3,6 +3,10 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     globals: true,
-    environment: 'jsdom'
+    environment: 'jsdom',
+    // Share the monorepo root setup (fake-indexeddb/auto, fetch stub,
+    // jsdom polyfills) so `pnpm --filter @xiboplayer/stats test` works
+    // the same way as the root-level `pnpm test`.
+    setupFiles: [new URL('../../vitest.setup.js', import.meta.url).pathname]
   }
 });

--- a/packages/xmds/vitest.config.js
+++ b/packages/xmds/vitest.config.js
@@ -3,6 +3,14 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'jsdom',
-    globals: true
+    globals: true,
+    environmentOptions: {
+      // xmds tests assert absolute URLs resolved from cms.example.com;
+      // without this, jsdom defaults to about:blank and URL() throws.
+      jsdom: { url: 'https://cms.example.com' }
+    },
+    // Share the monorepo root setup so `pnpm --filter @xiboplayer/xmds test`
+    // works standalone.
+    setupFiles: [new URL('../../vitest.setup.js', import.meta.url).pathname]
   }
 });

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -11,7 +11,11 @@ export default defineConfig({
     environmentOptions: {
       jsdom: { url: 'https://cms.example.com' }
     },
-    setupFiles: './vitest.setup.js',
+    // Absolute path: `./vitest.setup.js` would resolve relative to CWD,
+    // which breaks standalone package runs (`pnpm --filter X test` from
+    // `packages/X/`). Using the config file's own URL anchors the path
+    // to this config regardless of where vitest is invoked.
+    setupFiles: [new URL('./vitest.setup.js', import.meta.url).pathname],
     exclude: [
       '**/node_modules/**',
       '**/dist/**',


### PR DESCRIPTION
## Summary

Fixes #362 — \`pnpm --filter @xiboplayer/<pkg> test\` now works for every testable package. Zero production code change.

## Root cause

Root \`vitest.config.js\` declared \`setupFiles: './vitest.setup.js'\`. Vitest resolved this relative to the **process CWD**, so running \`pnpm --filter @xiboplayer/cache test\` (CWD = \`packages/cache/\`) looked for a non-existent \`packages/cache/vitest.setup.js\`.

Packages that carried their own \`vitest.config.js\` (stats, xmds, core) silently dropped the root setup entirely, missing \`fake-indexeddb/auto\`, the \`fetch\` mock, the jsdom \`cms.example.com\` URL, and the \`Element.prototype.animate\` polyfill.

## Changes

- **root `vitest.config.js`**: \`setupFiles\` → \`[new URL('./vitest.setup.js', import.meta.url).pathname]\` (absolute path, CWD-independent)
- **`packages/stats/vitest.config.js`**: add \`setupFiles\` pointing at the root via \`../../vitest.setup.js\` (same URL-anchored approach)
- **`packages/xmds/vitest.config.js`**: add \`setupFiles\` + \`environmentOptions.jsdom.url = 'https://cms.example.com'\` (xmds URL-assertion tests require this origin)
- **`packages/core/vitest.config.js`**: add \`setupFiles\`

## Verification

Root suite (baseline preserved):

\`\`\`
 Test Files  62 passed (62)
      Tests  1982 passed (1982)
  Duration  19.20s
\`\`\`

Every standalone package (after change):

\`\`\`
stats:      101 passed
xmds:       152 passed | 21 skipped (173)
core:       259 passed
cache:      114 passed
renderer:   273 passed
schedule:   182 passed
sync:        71 passed
utils:      301 passed
datasource:  66 passed
proxy:       66 passed
xmr:         81 passed
expr:        92 passed
settings:    44 passed
\`\`\`

## Notes for reviewer

- \`packages/renderer/vitest.config.js\` already used \`'../../vitest.setup.js'\` but as a **relative string** — it happened to work because vitest resolves relative paths in a local config file against the config file's directory when the file is explicit. The URL-anchored form here is equivalent and more obviously correct; I did not touch renderer to keep the diff minimal.
- \`packages/settings/vitest.config.js\` uses a local \`./vitest.setup.js\` (different file on purpose — it's the settings-specific dev boot). Left alone.
- \`packages/cms-testing\` explicitly sets \`setupFiles: []\` to opt out (API integration tests against a real CMS). Left alone.

## Checklist

- [x] Root suite still green (1982/1982)
- [x] All 13 testable packages green standalone
- [x] No production code changes
- [x] No new dependencies
- [x] No `console.log` added