### PR TITLE
test(timeline-overlay): state-transition coverage (closes #359)

### DIFF
--- a/packages/pwa/src/timeline-overlay.test.ts
+++ b/packages/pwa/src/timeline-overlay.test.ts
@@ -208,6 +208,91 @@ describe('TimelineOverlay', () => {
     });
   });
 
+  // ── State transitions (refs #359, #253 remaining, #231 regression) ─
+
+  describe('state transitions', () => {
+    it('keeps current layout visible when timeline array is empty on next tick', () => {
+      // Reproduces the xiboplayer#253 remaining item: "no upcoming layouts"
+      // shown despite a layout playing. If currentLayoutId is set, the
+      // empty-state placeholder MUST NOT render.
+      vi.useFakeTimers();
+      const overlay = new TimelineOverlay(true);
+      overlay.update([makeEntry({ layoutFile: '42.xlf', duration: 30 })], 42, 30);
+
+      // Next tick from the scheduler: timeline empty (e.g. end of queue),
+      // but the current layout is still playing.
+      overlay.update([], 42, 30);
+
+      const html = getOverlayEl()!.innerHTML;
+      expect(html).not.toContain('no upcoming layouts');
+      expect(html).toContain('#42');
+      overlay.destroy();
+    });
+
+    it('shows previousLayout then currentLayoutId after a transition', () => {
+      vi.useFakeTimers();
+      const overlay = new TimelineOverlay(true);
+
+      // First layout renders
+      overlay.update([makeEntry({ layoutFile: '100.xlf', duration: 30 })], 100, 30);
+
+      // 30s later, second layout takes over
+      vi.advanceTimersByTime(30_000);
+      overlay.update([makeEntry({ layoutFile: '200.xlf', duration: 60 })], 200, 60);
+
+      const html = getOverlayEl()!.innerHTML;
+      expect(html).toContain('#100'); // previous (strikethrough)
+      expect(html).toContain('#200'); // current
+      // Header count: 1 previous + 1 current = 2
+      expect(html).toContain('2 scheduled');
+      overlay.destroy();
+    });
+
+    it('does not regress to "no upcoming" after setOffline(true)', () => {
+      vi.useFakeTimers();
+      const overlay = new TimelineOverlay(true);
+      overlay.update([makeEntry({ layoutFile: '42.xlf', duration: 30 })], 42, 30);
+
+      overlay.setOffline(true);
+
+      const html = getOverlayEl()!.innerHTML;
+      expect(html).toContain('OFFLINE');
+      expect(html).not.toContain('no upcoming layouts');
+      expect(html).toContain('#42');
+      overlay.destroy();
+    });
+
+    it('resets layoutStartedAt on same-id replay (regression guard for #231)', () => {
+      // Same-layout replays (494 → 494) must reset the countdown clock,
+      // otherwise the timeline overlay freezes at 0 after the first cycle.
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-04-17T10:00:00Z'));
+      const overlay = new TimelineOverlay(true);
+
+      // First play of layout 42: 30s duration
+      overlay.update([makeEntry({ layoutFile: '42.xlf', duration: 30 })], 42, 30);
+
+      // 25s later, 5s remaining — render should show ~5s remaining
+      vi.advanceTimersByTime(25_000);
+      overlay['render']();
+      const midHtml = getOverlayEl()!.innerHTML;
+      // Current layout countdown formatted as "5s" (non-breaking spaces pad
+      // the duration column, so allow up to ~200 chars of padding/markup
+      // between "#42" and the countdown value).
+      expect(midHtml).toMatch(/#42[\s\S]{0,200}5s/);
+
+      // Same-layout replay at t+30s. `layoutStartedAt` must reset.
+      vi.advanceTimersByTime(5_000);
+      overlay.update([makeEntry({ layoutFile: '42.xlf', duration: 30 })], 42, 30);
+
+      // Immediately after the replay-triggered update, the full 30s
+      // should be shown again, not the stale countdown value.
+      const replayHtml = getOverlayEl()!.innerHTML;
+      expect(replayHtml).toMatch(/#42[\s\S]{0,200}(30s|29s)/);
+      overlay.destroy();
+    });
+  });
+
   // ── setOffline ────────────────────────────────────────────
 
   describe('setOffline', () => {


### PR DESCRIPTION
## Summary

Closes #359. Adds 4 tests covering the timeline-overlay state transitions that were previously only covered by a single static-empty-state test.

The xiboplayer#253 closing comment left the checklist item:

> Timeline overlay shows "no upcoming layouts" despite layouts playing

open but with no regression surface. This PR makes the state-transition contract testable without yet changing the production code (see below — current code appears to handle these cases correctly; the tests lock it in so a future refactor can't silently break them).

## Tests added (`packages/pwa/src/timeline-overlay.test.ts`)

1. **`keeps current layout visible when timeline array is empty on next tick`** — direct regression guard for #253's remaining item. Sets currentLayoutId, then pushes an empty timeline, verifies "no upcoming layouts" placeholder does NOT render.
2. **`shows previousLayout then currentLayoutId after a transition`** — calls `update()` with two different layoutIds 30 s apart, asserts both are rendered (previous strikethrough + current highlight) and the header says "2 scheduled".
3. **`does not regress to "no upcoming" after setOffline(true)`** — calls setOffline(true) while a layout is playing; OFFLINE badge appears but current layout stays visible.
4. **`resets layoutStartedAt on same-id replay (regression guard for #231)`** — plays layout 42, advances 25 s, verifies countdown shows ~5 s, then same-id replay at t+30 s, verifies countdown resets to ~30 s.

Tests use `vi.useFakeTimers` + `vi.advanceTimersByTime` + `vi.setSystemTime` — no real waits.

## Verification

Before (origin/main @ 01f5c22):
\`\`\`
Test Files  63 passed (63)   Tests  1989 passed (1989)
\`\`\`

After:
\`\`\`
Test Files  63 passed (63)   Tests  1993 passed (1993)   (+4)
\`\`\`

All 4 new tests green; no existing test affected.

## Risk

Zero. Single test file addition. No production code touched. No new dependencies.

## Notes for reviewer

The regex bound `{0,200}` in test 4 is deliberate — the HTML between `#42` and the countdown value is padded with `&nbsp;` entities (one per column-alignment space) plus assorted style markup. A tight regex like `{0,40}` breaks on the padding; a loose `{0,200}` matches the whole current-layout `<div>` without depending on exact styling. If we extract the countdown into a data attribute later, these can be simplified.