### PR TITLE
docs(test): flag the jsdom Response(Blob) trap in root vitest config (closes #371)

### DIFF
--- a/vitest.config.js
+++ b/vitest.config.js
@@ -4,6 +4,37 @@
 
 import { defineConfig } from 'vitest/config';
 
+// ─── jsdom Response(Blob) trap — read before adding fetch tests ────────
+//
+// The default `environment: 'jsdom'` below is correct for almost every
+// test in this monorepo BUT has one latent defect worth knowing about:
+// jsdom's `Response` polyfill stringifies `Blob` bodies instead of
+// reading their bytes.
+//
+//     // under jsdom:
+//     const blob = new Blob([new TextEncoder().encode('hello')]);
+//     const r = new Response(blob);
+//     await r.arrayBuffer();  // → 13 bytes of "[object Blob]"
+//                             //   NOT the 5 bytes of "hello"
+//
+// ArrayBuffer and Uint8Array bodies are fine — only Blob is broken.
+//
+// If your test wraps a `Blob` in a `Response` (common in Service
+// Worker / CacheStorage / chunk-assembly code), add this pragma at
+// the top of your test file:
+//
+//     // @vitest-environment node
+//
+// Node 18+ ships a compliant Response/Blob from undici. The pragma
+// overrides the jsdom default for that file only. See
+// `packages/sw/src/content-store-browser.test.js` +
+// `packages/sw/src/request-handler-browser.test.js` for examples.
+//
+// Tracking: xibo-players/xiboplayer#371. No existing test is silently
+// broken by this defect (audited 2026-04-17 — none of the current
+// fetch-using tests re-wrap Blob bodies in Response). It's a trap for
+// future tests, not an active bug.
+// ───────────────────────────────────────────────────────────────────
 export default defineConfig({
   test: {
     globals: true,


### PR DESCRIPTION
Closes #371. 30-line comment block above the root `vitest.config.js` `environment: 'jsdom'` line documenting the jsdom Response(Blob) defect and its workaround.

## Why

Surfaced while writing unit tests for PR #369. jsdom's `Response` polyfill stringifies `Blob` bodies:

```js
// under jsdom:
const blob = new Blob([new TextEncoder().encode('hello')]);
const r = new Response(blob);
await r.arrayBuffer();
// → 13 bytes of "[object Blob]", NOT the 5 bytes of "hello"
```

The failure mode is silent — no exception, just wrong bytes. A future test writer who hits this spends hours debugging "why is my code under test broken" before realising the environment is the problem.

## What the comment covers

- Minimal repro + explanation
- When to use `// @vitest-environment node` and what it costs (nothing — Node 18+ ships compliant Web APIs from undici)
- Pointers to two worked examples in the sw package
- Explicit audit note: no test is silently broken today (verified in the commit body)

## Audit

Searched all `*.test.*` files for `new Response` / `new Blob` / `globalThis.fetch` usage, then reviewed each jsdom-env file that touches Blob:

| file | usage | safe? |
|---|---|---|
| `packages/cache/src/cache-proxy.test.js` | `store.put('media', '42', new Blob(...))` then asserts sent headers | ✅ doesn't read bytes back through Response |
| `packages/core/src/player-core.test.js` | Blob in a mock return | ✅ not re-wrapped in Response |
| `packages/sw/src/sw-utils.test.js` | `extractRangeFromChunks([blob], ...)` | ✅ checks `.size`, not bytes via Response |
| `packages/utils/src/cms-api.test.js` | Blob in FormData uploads | ✅ sent to mocked fetch, not read back |
| Files already on `node` env (proxy, xmr, crypto, etc.) | various | ✅ safe by construction |

Conclusion: no active silent breakage. The defect is a trap for future tests, not an existing bug.

## Verification

`pnpm test` → 1993 passed (63 files, 21.2s). No change to behaviour.

## Risk

Zero. Comment-only change.