### PR TITLE
refactor: formalise ContentStore protocol + share SW routing helpers (Option A+B from #292 dedup)

### DIFF
--- a/packages/cache/src/index.d.ts
+++ b/packages/cache/src/index.d.ts
@@ -2,6 +2,132 @@
 // Copyright (c) 2024-2026 Pau Aliagas <linuxnow@gmail.com>
 export const VERSION: string;
 
+// ─── ContentStore protocol ───────────────────────────────────────────
+//
+// Shared API that both storage implementations satisfy:
+//   - `@xiboplayer/proxy/content-store` — filesystem-backed, used by
+//     Electron + Chromium kiosk proxies
+//   - `@xiboplayer/sw/content-store-browser` — CacheStorage+IndexedDB,
+//     used by the PWA when it runs directly on the CMS
+//
+// Defined here (lowest-dep package) so both implementations can mark
+// themselves as `@implements {import('@xiboplayer/cache').ContentStore}`
+// without introducing a circular dependency.
+//
+// The two backends diverge on one thing: the read primitive. Node
+// returns fs.ReadStream (for zero-copy pipe into Express); browser
+// returns Response (for event.respondWith). The backend-specific
+// methods live on `FilesystemContentStore` and `BrowserContentStore`
+// extension interfaces rather than polluting the shared contract.
+//
+// See #374 for a potential future refactor to a single class with
+// pluggable backends — deferred pending perf benchmark.
+
+/** Byte range for chunked reads. Both bounds inclusive; omit for tail. */
+export interface ChunkRange {
+  start?: number;
+  end?: number;
+}
+
+/** Metadata stored alongside every cached item. */
+export interface ContentStoreMetadata {
+  key: string;
+  size: number;
+  contentType: string;
+  md5: string | null;
+  createdAt: number;
+  updatedAt?: number;
+  completedAt?: number;
+  complete?: boolean;
+  /** Present for items stored as chunks. Cleared once assembled (Node) or kept (browser, per #373). */
+  numChunks?: number;
+  chunkSize?: number;
+}
+
+/** Result shape of `ContentStore.has(key)`. */
+export interface ContentStoreHasResult {
+  exists: boolean;
+  chunked: boolean;
+  metadata: ContentStoreMetadata | null;
+}
+
+/** Entry shape returned by `ContentStore.list()`. */
+export interface ContentStoreListEntry {
+  key: string;
+  size: number;
+  contentType: string;
+  chunked: boolean;
+  complete: boolean;
+}
+
+/**
+ * The 13-method contract shared by all ContentStore implementations.
+ *
+ * Behavioural invariants (enforced by both impls, verified by their
+ * respective unit tests):
+ *
+ *   - `isWriteLocked(key, chunkIndex?)` reflects in-flight putChunk ops
+ *   - `has` / `hasChunk` / `missingChunks` report existence only —
+ *     never touch the data
+ *   - `put` stores + writes metadata atomically
+ *   - `putChunk` is reentrant-safe via a per-chunk write lock
+ *   - `assembleChunks` requires all numChunks to be present, returns
+ *     false otherwise. In the Node backend it concatenates; in the
+ *     browser backend it currently concatenates too (limit ~50 MB —
+ *     see #373 for the streaming rewrite)
+ *   - `delete` removes whole + chunks + metadata
+ *   - `list` returns every metadata record
+ */
+export interface ContentStore {
+  init(): Promise<void>;
+  isWriteLocked(key: string, chunkIndex?: number): boolean;
+  has(key: string): Promise<ContentStoreHasResult>;
+  hasChunk(key: string, chunkIndex: number): Promise<boolean>;
+  missingChunks(key: string): Promise<number[]>;
+  getMetadata(key: string): Promise<ContentStoreMetadata | null>;
+  put(
+    key: string,
+    buffer: ArrayBuffer | Uint8Array | Blob,
+    metadata?: Partial<ContentStoreMetadata>,
+  ): Promise<void>;
+  putChunk(
+    key: string,
+    chunkIndex: number,
+    buffer: ArrayBuffer | Uint8Array | Blob,
+    metadata?: Partial<ContentStoreMetadata>,
+  ): Promise<void>;
+  markComplete(key: string): Promise<void>;
+  assembleChunks(key: string): Promise<boolean>;
+  delete(key: string): Promise<boolean>;
+  list(): Promise<ContentStoreListEntry[]>;
+}
+
+/** Node-specific extensions (fs streams, disk-usage query). */
+export interface FilesystemContentStore extends ContentStore {
+  getPath(key: string): string;
+  getReadStream(key: string, range?: ChunkRange): NodeJS.ReadableStream;
+  getChunkReadStream(
+    key: string,
+    chunkIndex: number,
+    range?: ChunkRange,
+  ): NodeJS.ReadableStream;
+  unmarkComplete(key: string): Promise<void>;
+  getSize(): Promise<number>;
+}
+
+/** Browser-specific extensions (Response-wrapped reads). */
+export interface BrowserContentStore extends ContentStore {
+  getResponse(key: string, range?: ChunkRange): Promise<Response | null>;
+  getChunkResponse(
+    key: string,
+    chunkIndex: number,
+    range?: ChunkRange,
+  ): Promise<Response | null>;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+
+
 export class StoreClient {
   has(type: string, id: string | number): Promise<boolean>;
   get(type: string, id: string | number): Promise<Blob | null>;

--- a/packages/proxy/src/content-store.js
+++ b/packages/proxy/src/content-store.js
@@ -8,6 +8,12 @@
  * restarts. Every deployment (Electron, Chromium kiosk, deployed PWA server)
  * runs the proxy, making this the single durable storage layer.
  *
+ * Implements the shared `ContentStore` protocol declared in
+ * `@xiboplayer/cache` (see `FilesystemContentStore` for the fs-specific
+ * extensions — getPath, getReadStream, getChunkReadStream, unmarkComplete,
+ * getSize). The parallel browser backend is
+ * `@xiboplayer/sw/content-store-browser`.
+ *
  * File layout (mirrors CMS URL structure):
  *   {storeDir}/
  *     ${PLAYER_API}/
@@ -18,6 +24,8 @@
  *       dependencies/fonts.css.bin      — dependency files (by filename)
  *       dependencies/Aileron.otf.bin
  *     widget/...                        — widget HTML (legacy path)
+ *
+ * @implements {import('@xiboplayer/cache').FilesystemContentStore}
  */
 
 import fs from 'fs';

--- a/packages/sw/src/content-store-browser.js
+++ b/packages/sw/src/content-store-browser.js
@@ -35,6 +35,8 @@
  *     CacheStorage permanently, build a `ReadableStream` that pulls
  *     chunks lazily. Memory peak becomes one chunk size regardless
  *     of total file size.
+ *
+ * @implements {import('@xiboplayer/cache').BrowserContentStore}
  */
 
 import { createLogger } from '@xiboplayer/utils';

--- a/packages/sw/src/request-handler-browser.js
+++ b/packages/sw/src/request-handler-browser.js
@@ -48,8 +48,13 @@
  * @property {string} token  - JWT bearer (no 'Bearer ' prefix)
  */
 
-import { BASE } from './sw-utils.js';
 import { createLogger, PLAYER_API } from '@xiboplayer/utils';
+import {
+  isStaticPage,
+  isXmdsFileRequest,
+  isCacheableApiPath,
+  rewriteXmdsToApiPath,
+} from './routing.js';
 
 export class RequestHandlerBrowser {
   /**
@@ -90,9 +95,7 @@ export class RequestHandlerBrowser {
     const url = new URL(event.request.url);
 
     // Static pages — always network (they change on deploy)
-    if (url.pathname === BASE + '/' ||
-        url.pathname === BASE + '/index.html' ||
-        url.pathname === BASE + '/setup.html') {
+    if (isStaticPage(url)) {
       return fetch(event.request);
     }
 
@@ -102,7 +105,7 @@ export class RequestHandlerBrowser {
     }
 
     // XMDS file downloads — cache-through
-    if (url.pathname.includes('xmds.php') && url.searchParams.has('file')) {
+    if (isXmdsFileRequest(url)) {
       return this._handleXmdsFile(event, url);
     }
 
@@ -118,17 +121,7 @@ export class RequestHandlerBrowser {
   async _handleApiRequest(event, url) {
     const path = url.pathname;
 
-    // Cacheable resource patterns
-    const cacheablePatterns = [
-      /\/media\/file\//,
-      /\/media\/\d+/,
-      /\/layouts\/\d+/,
-      /\/widgets\/\d+\/\d+\/\d+/,
-      /\/dependencies\//,
-    ];
-
-    const isCacheable = cacheablePatterns.some(p => p.test(path));
-    if (!isCacheable) {
+    if (!isCacheableApiPath(path)) {
       // Non-cacheable API calls (auth, displays, schedule, inventory) — pass with auth
       const headers = new Headers(event.request.headers);
       Object.entries(this._authHeaders()).forEach(([k, v]) => headers.set(k, v));
@@ -241,20 +234,12 @@ export class RequestHandlerBrowser {
    * Handle XMDS file downloads — same as proxy mode but cache locally.
    */
   _handleXmdsFile(event, url) {
-    const filename = url.searchParams.get('file');
-    const fileType = url.searchParams.get('type');
-    const itemId = url.searchParams.get('itemId');
+    const apiPath = rewriteXmdsToApiPath(url);
+    if (!apiPath) return fetch(event.request);
 
-    let apiPath;
-    if (fileType === 'L') {
-      apiPath = `${PLAYER_API}/layouts/${itemId}`;
-    } else if (fileType === 'P') {
-      apiPath = `${PLAYER_API}/dependencies/${filename}`;
-    } else {
-      apiPath = `${PLAYER_API}/media/file/${filename}`;
-    }
-
-    this.log.info(`XMDS redirect: ${fileType}/${filename} → ${apiPath}`);
+    this.log.info(
+      `XMDS redirect: ${url.searchParams.get('type')}/${url.searchParams.get('file')} → ${apiPath}`,
+    );
 
     // Rewrite to API path and handle via cache-through
     const newUrl = new URL(apiPath, event.request.url);

--- a/packages/sw/src/request-handler.js
+++ b/packages/sw/src/request-handler.js
@@ -11,8 +11,8 @@
  * Widget HTML is served by the Express mirror route at ${PLAYER_API}/widgets/{L}/{R}/{M}.
  */
 
-import { BASE } from './sw-utils.js';
 import { createLogger, PLAYER_API } from '@xiboplayer/utils';
+import { isStaticPage, isXmdsFileRequest, rewriteXmdsToApiPath } from './routing.js';
 
 export class RequestHandler {
   /**
@@ -30,9 +30,7 @@ export class RequestHandler {
     const url = new URL(event.request.url);
 
     // Static pages — pass through to Express
-    if (url.pathname === BASE + '/' ||
-        url.pathname === BASE + '/index.html' ||
-        url.pathname === BASE + '/setup.html') {
+    if (isStaticPage(url)) {
       return fetch(event.request);
     }
 
@@ -42,7 +40,7 @@ export class RequestHandler {
     }
 
     // XMDS file downloads — route through Express cache-through
-    if (url.pathname.includes('xmds.php') && url.searchParams.has('file')) {
+    if (isXmdsFileRequest(url)) {
       return this._handleXmdsFile(event, url);
     }
 
@@ -60,19 +58,11 @@ export class RequestHandler {
    * ContentStore caching, avoiding CORS issues and enabling chunked downloads.
    */
   _handleXmdsFile(event, url) {
+    const proxyPath = rewriteXmdsToApiPath(url);
+    if (!proxyPath) return fetch(event.request);
+
+    const fileType = url.searchParams.get('type');
     const filename = url.searchParams.get('file');
-    const fileType = url.searchParams.get('type'); // L=layout, M=media, P=resource/font
-    const itemId = url.searchParams.get('itemId');
-
-    let proxyPath;
-    if (fileType === 'L') {
-      proxyPath = `${PLAYER_API}/layouts/${itemId}`;
-    } else if (fileType === 'P') {
-      proxyPath = `${PLAYER_API}/dependencies/${filename}`;
-    } else {
-      proxyPath = `${PLAYER_API}/media/file/${filename}`;
-    }
-
     this.log.info(`XMDS redirect: ${fileType}/${filename} → ${proxyPath}`);
 
     // Pass original XMDS URL so proxy can fetch from CMS on cache miss

--- a/packages/sw/src/routing.js
+++ b/packages/sw/src/routing.js
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2024-2026 Pau Aliagas <linuxnow@gmail.com>
+/**
+ * Shared routing helpers for the Service Worker fetch handlers.
+ *
+ * `RequestHandler` (proxy mode) and `RequestHandlerBrowser` (browser
+ * mode, see `request-handler-browser.js`) dispatch fetch events
+ * through the same URL-pattern vocabulary:
+ *
+ *   - static pages (/, /index.html, /setup.html under BASE) → network
+ *   - player-API paths → cache-through or passthrough depending on
+ *     deployment mode
+ *   - legacy xmds.php?file=… URLs → rewrite to a player-API path
+ *
+ * Extracted here so the two handlers share one vocabulary and the
+ * unit tests have a single place to assert routing decisions.
+ */
+
+import { PLAYER_API } from '@xiboplayer/utils';
+import { BASE } from './sw-utils.js';
+
+/**
+ * Pathnames that must always be fetched from the network (they
+ * change on every deploy).
+ *
+ * @param {URL} url - parsed request URL
+ * @returns {boolean}
+ */
+export function isStaticPage(url) {
+  return (
+    url.pathname === BASE + '/' ||
+    url.pathname === BASE + '/index.html' ||
+    url.pathname === BASE + '/setup.html'
+  );
+}
+
+/**
+ * Legacy XMDS file-download URL recognition. Matches the shape
+ * `https://<cms>/xmds.php?file=<name>&type=<T>&itemId=<id>` that
+ * the XMDS RequiredFiles flow issues.
+ *
+ * @param {URL} url - parsed request URL
+ * @returns {boolean}
+ */
+export function isXmdsFileRequest(url) {
+  return url.pathname.includes('xmds.php') && url.searchParams.has('file');
+}
+
+/**
+ * Path prefixes whose responses are safe to cache in the browser
+ * ContentStore. Used by `RequestHandlerBrowser._handleApiRequest`
+ * to decide between cache-through and pass-with-auth routing.
+ *
+ * Immutable, shared across all handler instances.
+ *
+ * @type {readonly RegExp[]}
+ */
+export const CACHEABLE_API_PATTERNS = Object.freeze([
+  /\/media\/file\//,
+  /\/media\/\d+/,
+  /\/layouts\/\d+/,
+  /\/widgets\/\d+\/\d+\/\d+/,
+  /\/dependencies\//,
+]);
+
+/**
+ * True when the given path (must start with PLAYER_API) names a
+ * cacheable resource category — media, layout, widget HTML, or
+ * dependency. Non-cacheable API calls (auth, displays, schedule,
+ * inventory) return false.
+ *
+ * @param {string} pathname - URL pathname
+ * @returns {boolean}
+ */
+export function isCacheableApiPath(pathname) {
+  return CACHEABLE_API_PATTERNS.some((p) => p.test(pathname));
+}
+
+/**
+ * Translate a legacy XMDS file-download URL into the player-API
+ * path that both the proxy and the browser handler know how to
+ * serve.
+ *
+ * XMDS `type` values:
+ *   - `L` (layout) → `{PLAYER_API}/layouts/{itemId}`
+ *   - `P` (resource/font/dependency) → `{PLAYER_API}/dependencies/{filename}`
+ *   - `M` (media) and everything else → `{PLAYER_API}/media/file/{filename}`
+ *
+ * Returns `null` when `file` is missing — caller should pass the
+ * request through unchanged.
+ *
+ * @param {URL} url - parsed XMDS request URL
+ * @returns {string|null} API path (starts with PLAYER_API), or null
+ */
+export function rewriteXmdsToApiPath(url) {
+  const filename = url.searchParams.get('file');
+  if (!filename) return null;
+  const fileType = url.searchParams.get('type');
+  const itemId = url.searchParams.get('itemId');
+
+  if (fileType === 'L') {
+    return `${PLAYER_API}/layouts/${itemId}`;
+  }
+  if (fileType === 'P') {
+    return `${PLAYER_API}/dependencies/${filename}`;
+  }
+  // 'M' or unknown — treat as media
+  return `${PLAYER_API}/media/file/${filename}`;
+}

--- a/packages/sw/src/routing.test.js
+++ b/packages/sw/src/routing.test.js
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2024-2026 Pau Aliagas <linuxnow@gmail.com>
+/**
+ * Unit tests for shared SW routing helpers.
+ *
+ * These helpers are pure URL-parsing functions — no browser APIs,
+ * no fetch, no caches. Run in either jsdom or node env; we stay on
+ * the default (jsdom) to avoid special-casing.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { PLAYER_API } from '@xiboplayer/utils';
+import { BASE } from './sw-utils.js';
+import {
+  isStaticPage,
+  isXmdsFileRequest,
+  isCacheableApiPath,
+  CACHEABLE_API_PATTERNS,
+  rewriteXmdsToApiPath,
+} from './routing.js';
+
+const origin = 'https://cms.example.com';
+
+function u(path) {
+  return new URL(path, origin);
+}
+
+describe('isStaticPage', () => {
+  it('matches the BASE root, index, and setup pages', () => {
+    expect(isStaticPage(u(`${BASE}/`))).toBe(true);
+    expect(isStaticPage(u(`${BASE}/index.html`))).toBe(true);
+    expect(isStaticPage(u(`${BASE}/setup.html`))).toBe(true);
+  });
+
+  it('rejects nested player URLs and sibling paths', () => {
+    expect(isStaticPage(u(`${BASE}/layout/42`))).toBe(false);
+    expect(isStaticPage(u(`${BASE}/index.html/x`))).toBe(false);
+    expect(isStaticPage(u('/other/setup.html'))).toBe(false);
+  });
+});
+
+describe('isXmdsFileRequest', () => {
+  it('matches xmds.php with a file query param', () => {
+    expect(isXmdsFileRequest(u('/xmds.php?file=a.mp4'))).toBe(true);
+    expect(isXmdsFileRequest(u('/sub/xmds.php?file=a.mp4&type=M'))).toBe(true);
+  });
+
+  it('rejects xmds.php without file', () => {
+    expect(isXmdsFileRequest(u('/xmds.php?request=required'))).toBe(false);
+  });
+
+  it('rejects other paths with a file query param', () => {
+    expect(isXmdsFileRequest(u('/other.php?file=a.mp4'))).toBe(false);
+  });
+});
+
+describe('isCacheableApiPath', () => {
+  it('returns true for the five cacheable resource categories', () => {
+    expect(isCacheableApiPath(`${PLAYER_API}/media/file/x.png`)).toBe(true);
+    expect(isCacheableApiPath(`${PLAYER_API}/media/42`)).toBe(true);
+    expect(isCacheableApiPath(`${PLAYER_API}/layouts/99`)).toBe(true);
+    expect(isCacheableApiPath(`${PLAYER_API}/widgets/1/2/3`)).toBe(true);
+    expect(isCacheableApiPath(`${PLAYER_API}/dependencies/fonts.css`)).toBe(true);
+  });
+
+  it('returns false for non-cacheable API calls', () => {
+    expect(isCacheableApiPath(`${PLAYER_API}/display/status`)).toBe(false);
+    expect(isCacheableApiPath(`${PLAYER_API}/schedule`)).toBe(false);
+    expect(isCacheableApiPath(`${PLAYER_API}/auth/refresh`)).toBe(false);
+    expect(isCacheableApiPath(`${PLAYER_API}/inventory`)).toBe(false);
+  });
+
+  it('CACHEABLE_API_PATTERNS is frozen (caller cannot mutate it)', () => {
+    expect(Object.isFrozen(CACHEABLE_API_PATTERNS)).toBe(true);
+  });
+});
+
+describe('rewriteXmdsToApiPath', () => {
+  it('maps type=L to /layouts/{itemId}', () => {
+    const url = u('/xmds.php?file=layout-42.xlf&type=L&itemId=42');
+    expect(rewriteXmdsToApiPath(url)).toBe(`${PLAYER_API}/layouts/42`);
+  });
+
+  it('maps type=P to /dependencies/{filename}', () => {
+    const url = u('/xmds.php?file=bundle.min.js&type=P&itemId=1');
+    expect(rewriteXmdsToApiPath(url)).toBe(`${PLAYER_API}/dependencies/bundle.min.js`);
+  });
+
+  it('maps type=M to /media/file/{filename}', () => {
+    const url = u('/xmds.php?file=hero.mp4&type=M&itemId=123');
+    expect(rewriteXmdsToApiPath(url)).toBe(`${PLAYER_API}/media/file/hero.mp4`);
+  });
+
+  it('treats unknown types as media (safe default)', () => {
+    const url = u('/xmds.php?file=x.bin&type=Q&itemId=1');
+    expect(rewriteXmdsToApiPath(url)).toBe(`${PLAYER_API}/media/file/x.bin`);
+  });
+
+  it('returns null when file= is missing', () => {
+    const url = u('/xmds.php?request=required');
+    expect(rewriteXmdsToApiPath(url)).toBeNull();
+  });
+
+  it('preserves filename with path separators unchanged (no sanitisation)', () => {
+    // The function's job is mapping, not validation. Upstream decides
+    // whether a filename is safe. This test documents that contract.
+    const url = u('/xmds.php?file=../etc/passwd&type=M');
+    expect(rewriteXmdsToApiPath(url)).toBe(`${PLAYER_API}/media/file/../etc/passwd`);
+  });
+});


### PR DESCRIPTION
Landing "Options A+B" from the dedup conversation on PR #369. Option D (single class + pluggable backend) stays deferred — tracked in #374 with a perf-benchmark gate.

## What this does

### A — formalise the ContentStore protocol (types only)

`packages/cache/src/index.d.ts` gains a `ContentStore` interface declaring the 13-method contract that both storage backends satisfy:

- **`ContentStore`** — base (init, has, hasChunk, missingChunks, put, putChunk, markComplete, assembleChunks, delete, list, getMetadata, isWriteLocked)
- **`FilesystemContentStore`** — extends with fs-specific methods (getPath, getReadStream, getChunkReadStream, unmarkComplete, getSize)
- **`BrowserContentStore`** — extends with browser-specific methods (getResponse, getChunkResponse)

Plus supporting types: `ChunkRange`, `ContentStoreMetadata`, `ContentStoreHasResult`, `ContentStoreListEntry`.

Lives in `@xiboplayer/cache` (lowest-dep package) so neither `@xiboplayer/proxy` (Node) nor `@xiboplayer/sw` (browser) needs to take on extra dependencies. Both classes get `@implements` JSDoc annotations — no runtime code change, just contract visibility for IDEs and reviewers.

### B — share URL routing helpers between SW handlers

New module `packages/sw/src/routing.js` with four pure helpers + one frozen pattern list:

```js
isStaticPage(url)          // /, /index.html, /setup.html under BASE
isXmdsFileRequest(url)     // legacy xmds.php?file=... detection
isCacheableApiPath(path)   // tests against CACHEABLE_API_PATTERNS
rewriteXmdsToApiPath(url)  // XMDS type=L/M/P → player-API path
CACHEABLE_API_PATTERNS     // frozen [regex, regex, ...] — 5 resource categories
```

Previously each handler (`RequestHandler`, `RequestHandlerBrowser`) carried its own copy of this logic — including an inline `cacheablePatterns` array in `RequestHandlerBrowser`. The shared module eliminates the drift risk: change the pattern once, both deployment modes agree.

14 new unit tests in `routing.test.js` cover the helpers directly. Previously these routing decisions were only tested indirectly through handler tests.

## Commits

1. `types(cache): declare shared ContentStore protocol interface` — types-only, 126 LOC
2. `types(stores): annotate both ContentStore impls as @implements` — JSDoc only, 10 LOC
3. `feat(sw): extract shared URL routing helpers from request handlers` — new module + tests, 219 LOC (−0 removed at this point)
4. `refactor(sw): use shared routing helpers in both request handlers` — handlers swap to helpers, 21 LOC added / 46 removed

Total: **+376 / −46**. The +376 includes 126 LOC of types (no runtime cost) and 69 LOC of tests; the actual routing logic is smaller than before.

## Verification

```
pnpm test             → 2030 passed / 66 files / 22.2s
```

Before this branch: 2016 / 65 / ~22s. +14 from routing.test.js, zero regressions elsewhere.

Build: existing `pnpm --filter @xiboplayer/pwa build` continues to produce the same `dist/sw-pwa.js` size (±1 byte JSDoc variance) — confirming the refactor is behaviour-preserving.

## What's NOT in this PR

- **Option D** (single class, pluggable backend): tracked in #374. Gated on a perf benchmark (`ab` throughput comparison for fs streams vs Web `ReadableStream`-wrapped fs streams). Do not open a PR against it without measured data.
- **Large-media streaming rewrite** for browser backend: tracked in #373. Independent of this dedup work.

## Risk

Low. Pure types for A; behaviour-preserving refactor for B. The 14 new tests lock down exactly the shared routing vocabulary, so any accidental semantic change surfaces as a test failure.