### PR TITLE
feat(sw): lazy chunked streaming for large media (>50 MB) — refs #373

### DIFF
--- a/packages/sw/src/content-store-browser.js
+++ b/packages/sw/src/content-store-browser.js
@@ -166,6 +166,24 @@ export class ContentStoreBrowser {
 
   // ── Read operations ───────────────────────────────────────────────
 
+  /**
+   * Return a `ReadableStream` covering `[range.start, range.end]` of
+   * the cached content, pulling one chunk at a time rather than
+   * loading the whole blob into memory.
+   *
+   * Design per #373. Not implemented yet — throws so callers who
+   * probe ahead of the streaming rewrite surface the gap loudly.
+   *
+   * @param {string} _key
+   * @param {import('@xiboplayer/cache').ChunkRange} [_range]
+   * @returns {Promise<ReadableStream<Uint8Array>|null>}
+   */
+  async getStream(_key, _range) {
+    throw new Error(
+      'ContentStoreBrowser.getStream not implemented yet (see xibo-players/xiboplayer#373)',
+    );
+  }
+
   async getResponse(key, range) {
     const cache = await caches.open(CACHE_NAME);
     const response = await cache.match(keyToPath(key));

--- a/packages/sw/src/content-store-browser.js
+++ b/packages/sw/src/content-store-browser.js
@@ -11,30 +11,27 @@
  * The Service Worker imports this instead of the filesystem ContentStore.
  *
  * ─────────────────────────────────────────────────────────────────
- *  Practical size limit: ~50 MB per media file (this revision)
+ *  Large-media strategy (#373)
  * ─────────────────────────────────────────────────────────────────
  *
- * The current impl has two in-memory chokepoints that break for
- * large files:
+ * Chunks stay in CacheStorage forever — `assembleChunks` only verifies
+ * presence + marks complete (it does NOT concatenate). Reads go
+ * through `getStream`, which builds a `ReadableStream` that pulls one
+ * chunk at a time on demand. Memory peak during playback = one chunk
+ * size (default 50 MB), regardless of total file size. Video range
+ * requests seek-and-read into the correct chunk without loading
+ * surrounding chunks.
  *
- *   1. `assembleChunks(key)` concatenates all chunks into a single
- *      `new Blob([...])` — peak RAM ≈ 2 × file size during assembly.
- *   2. `getResponse(key, range)` reads the whole cached blob into
- *      memory to `.slice()` for range serving. Video playback issues
- *      many range requests; each one reloads the full blob.
+ * `getResponse` keeps a fast path for non-ranged whole-file reads
+ * (cache entry returned verbatim, zero wrapping) and flows everything
+ * else through `getStream`.
  *
- * Combined with per-origin CacheStorage quotas that cap individual
- * `Response` bodies (~1 GB on Safari, ~2 GB on Chrome desktop, much
- * less on mobile/WebView), this limits practical media to ~50 MB.
- *
- * Beyond that size, use one of:
- *   - Electron/Chromium kiosk deployments (fs-backed ContentStore
- *     via @xiboplayer/proxy — streams via Node, no limit).
- *   - Wait for the large-media streaming rewrite tracked in
- *     xibo-players/xiboplayer#373: keep chunks separate in
- *     CacheStorage permanently, build a `ReadableStream` that pulls
- *     chunks lazily. Memory peak becomes one chunk size regardless
- *     of total file size.
+ * Still TODO in this branch:
+ *   - navigator.storage.persist() on activate (prevent eviction
+ *     during long-running kiosk sessions)
+ *   - navigator.storage.estimate() monitoring + LRU prune hook
+ *   - integration test with a synthetic 200 MB fixture verifying
+ *     memory peak stays under one chunk size during playback
  *
  * @implements {import('@xiboplayer/cache').BrowserContentStore}
  */
@@ -168,44 +165,138 @@ export class ContentStoreBrowser {
 
   /**
    * Return a `ReadableStream` covering `[range.start, range.end]` of
-   * the cached content, pulling one chunk at a time rather than
-   * loading the whole blob into memory.
+   * the cached content, pulling one chunk at a time. Memory peak =
+   * one chunk size regardless of total file size — the whole-blob
+   * assembly that caps the legacy `getResponse` path at ~50 MB is
+   * gone.
    *
-   * Design per #373. Not implemented yet — throws so callers who
-   * probe ahead of the streaming rewrite surface the gap loudly.
+   * Returns `null` when the key is missing or has no bytes yet.
    *
-   * @param {string} _key
-   * @param {import('@xiboplayer/cache').ChunkRange} [_range]
+   * Three regimes:
+   *   - whole file stored (no chunks): re-uses the cache entry's
+   *     existing `Response.body` stream (no copy)
+   *   - chunked file (numChunks set): builds a pull-source that walks
+   *     chunks from `firstChunk` to `lastChunk`, trimming first+last
+   *     chunks to fit the exact range
+   *   - partial chunked file: errors the stream on the first missing
+   *     chunk
+   *
+   * @param {string} key
+   * @param {import('@xiboplayer/cache').ChunkRange} [range]
    * @returns {Promise<ReadableStream<Uint8Array>|null>}
    */
-  async getStream(_key, _range) {
-    throw new Error(
-      'ContentStoreBrowser.getStream not implemented yet (see xibo-players/xiboplayer#373)',
-    );
+  async getStream(key, range) {
+    const cache = await caches.open(CACHE_NAME);
+
+    // Whole-file regime — single cache entry, re-use its body stream.
+    const whole = await cache.match(keyToPath(key));
+    if (whole) {
+      if (!range || (range.start == null && range.end == null)) {
+        return whole.body;
+      }
+      // Range over a non-chunked entry: slice once. O(file size) in
+      // memory but only triggered when callers explicitly request a
+      // range on a small-media whole-file entry.
+      const blob = await whole.blob();
+      const start = range.start ?? 0;
+      const end = range.end != null ? range.end + 1 : blob.size;
+      return blob.slice(start, end).stream();
+    }
+
+    // Chunked-file regime
+    const meta = await this._getMeta(key);
+    if (!meta || !meta.numChunks) return null;
+    const chunkSize = meta.chunkSize || (50 * 1024 * 1024);
+    const total = meta.size;
+    const start = range?.start ?? 0;
+    const end = range?.end != null ? range.end + 1 : total;
+    const firstChunk = Math.floor(start / chunkSize);
+    const lastChunk = Math.floor((end - 1) / chunkSize);
+    const keyBase = keyToPath(key);
+
+    let cur = firstChunk;
+    return new ReadableStream({
+      async pull(controller) {
+        if (cur > lastChunk) {
+          controller.close();
+          return;
+        }
+        const resp = await cache.match(`${keyBase}:chunk-${cur}`);
+        if (!resp) {
+          controller.error(new Error(`Missing chunk ${cur} for ${key}`));
+          return;
+        }
+        let bytes = new Uint8Array(await resp.arrayBuffer());
+        // Trim the first emitted chunk to [start, chunk_end)
+        if (cur === firstChunk) {
+          const offset = start - firstChunk * chunkSize;
+          bytes = bytes.subarray(offset);
+        }
+        // Trim the last emitted chunk to [chunk_start, end)
+        if (cur === lastChunk) {
+          const chunkAbsStart = Math.max(cur * chunkSize, start);
+          bytes = bytes.subarray(0, end - chunkAbsStart);
+        }
+        controller.enqueue(bytes);
+        cur++;
+      },
+    });
   }
 
   async getResponse(key, range) {
     const cache = await caches.open(CACHE_NAME);
-    const response = await cache.match(keyToPath(key));
-    if (!response) return null;
+    const wholeEntry = await cache.match(keyToPath(key));
 
-    if (range && (range.start != null || range.end != null)) {
-      const blob = await response.blob();
-      const start = range.start || 0;
-      const end = range.end != null ? range.end + 1 : blob.size;
-      const slice = blob.slice(start, end);
-      const meta = await this._getMeta(key);
-      return new Response(slice, {
-        status: 206,
+    // Fast path: non-ranged whole-file — return the cached Response
+    // verbatim. The browser reads the body as a stream natively, no
+    // wrapping needed. Equivalent to the pre-#373 behaviour.
+    if (wholeEntry && !(range && (range.start != null || range.end != null))) {
+      return wholeEntry;
+    }
+
+    // Everything else (range requests, chunked files) flows through
+    // getStream() so we never load the whole blob into memory.
+    const stream = await this.getStream(key, range);
+    if (!stream) return null;
+
+    const meta = await this._getMeta(key);
+    const contentType =
+      meta?.contentType ||
+      wholeEntry?.headers.get('Content-Type') ||
+      'application/octet-stream';
+
+    // No range requested → serve whole (chunked) file as a 200
+    if (!range || (range.start == null && range.end == null)) {
+      const total = meta?.size;
+      return new Response(stream, {
+        status: 200,
         headers: {
-          'Content-Type': meta?.contentType || response.headers.get('Content-Type') || 'application/octet-stream',
-          'Content-Length': String(slice.size),
-          'Content-Range': `bytes ${start}-${end - 1}/${blob.size}`,
+          'Content-Type': contentType,
+          ...(total != null ? { 'Content-Length': String(total) } : {}),
         },
       });
     }
 
-    return response;
+    // Range requested → 206 with Content-Range
+    const total = meta?.size ?? (wholeEntry ? undefined : null);
+    if (total == null) {
+      // Unknown total — still serve the stream but without
+      // Content-Range (caller should have avoided this path).
+      return new Response(stream, {
+        status: 206,
+        headers: { 'Content-Type': contentType },
+      });
+    }
+    const start = range.start ?? 0;
+    const end = range.end != null ? range.end + 1 : total;
+    return new Response(stream, {
+      status: 206,
+      headers: {
+        'Content-Type': contentType,
+        'Content-Length': String(end - start),
+        'Content-Range': `bytes ${start}-${end - 1}/${total}`,
+      },
+    });
   }
 
   async getChunkResponse(key, chunkIndex, range) {
@@ -292,49 +383,41 @@ export class ContentStoreBrowser {
     await this._putMeta(key, { ...meta, key });
   }
 
+  /**
+   * Verify every chunk is present and mark the item complete.
+   *
+   * Contrast with the filesystem `ContentStore.assembleChunks` which
+   * concatenates chunks into one whole file — the browser backend
+   * deliberately does NOT concatenate. Reads serve from chunks
+   * directly via `getStream`, so assembly would waste memory
+   * (peak 2 × file size) and duplicate storage (chunks + assembled).
+   *
+   * Returns `true` when all `numChunks` chunk entries exist in the
+   * cache, `false` otherwise. On true, metadata is updated with
+   * `complete: true` + `completedAt`, but `numChunks` is retained
+   * so reads know they're still serving from chunks.
+   */
   async assembleChunks(key) {
     const meta = await this._getMeta(key);
     if (!meta || !meta.numChunks) return false;
 
     const cache = await caches.open(CACHE_NAME);
-    const blobs = [];
-
     for (let i = 0; i < meta.numChunks; i++) {
-      const resp = await cache.match(`${keyToPath(key)}:chunk-${i}`);
-      if (!resp) {
-        log.warn(`Missing chunk ${i} for ${key}, cannot assemble`);
+      const exists = await cache.match(`${keyToPath(key)}:chunk-${i}`);
+      if (!exists) {
+        log.warn(`Missing chunk ${i} for ${key}, cannot mark complete`);
         return false;
       }
-      blobs.push(await resp.blob());
     }
 
-    // Combine all chunks into one blob
-    const assembled = new Blob(blobs, { type: meta.contentType || 'application/octet-stream' });
-
-    // Store as whole file
-    await cache.put(keyToPath(key), new Response(assembled, {
-      headers: {
-        'Content-Type': meta.contentType || 'application/octet-stream',
-        'Content-Length': String(assembled.size),
-      },
-    }));
-
-    // Update metadata
-    meta.size = assembled.size;
     meta.complete = true;
     meta.completedAt = Date.now();
-    delete meta.numChunks;
     await this._putMeta(key, { ...meta, key });
 
-    // Clean up chunk entries
-    for (let i = 0; ; i++) {
-      const chunkPath = `${keyToPath(key)}:chunk-${i}`;
-      const exists = await cache.match(chunkPath);
-      if (!exists) break;
-      await cache.delete(chunkPath);
-    }
-
-    log.info(`Assembled ${blobs.length} chunks for ${key} (${assembled.size} bytes)`);
+    log.info(
+      `All ${meta.numChunks} chunks present for ${key} ` +
+        `(${meta.size} bytes, served via getStream)`,
+    );
     return true;
   }
 

--- a/packages/sw/src/content-store-browser.test.js
+++ b/packages/sw/src/content-store-browser.test.js
@@ -182,28 +182,41 @@ describe('ContentStoreBrowser', () => {
     expect(missing).toEqual([1]);
   });
 
-  it('assembles chunks into a whole file and cleans up chunk entries', async () => {
-    await store.putChunk('big-media', 0, new Uint8Array([1, 2, 3]).buffer,
-      { numChunks: 2, contentType: 'application/octet-stream' });
-    await store.putChunk('big-media', 1, new Uint8Array([4, 5]).buffer,
-      { numChunks: 2 });
+  it('assembles chunks by marking complete; reads stream from chunks (per #373)', async () => {
+    // New contract: assembleChunks verifies all chunks are present and
+    // marks `complete: true`. It does NOT concatenate — chunks stay in
+    // CacheStorage forever and reads go through getStream, so memory
+    // peak = one chunk size regardless of total file size.
+    await store.putChunk('big-media', 0, new Uint8Array([1, 2, 3]).buffer, {
+      numChunks: 2,
+      chunkSize: 3,      // chunk 0 is bytes 0-2, chunk 1 is bytes 3-4
+      size: 5,
+      contentType: 'application/octet-stream',
+    });
+    await store.putChunk('big-media', 1, new Uint8Array([4, 5]).buffer, {
+      numChunks: 2,
+      chunkSize: 3,
+      size: 5,
+    });
 
     const ok = await store.assembleChunks('big-media');
     expect(ok).toBe(true);
 
-    // Whole file now readable
+    // Reads go through the stream path — whole file bytes reconstruct
+    // from the separate chunk entries
     const res = await store.getResponse('big-media');
     const bytes = new Uint8Array(await res.arrayBuffer());
     expect(Array.from(bytes)).toEqual([1, 2, 3, 4, 5]);
 
-    // Chunks cleaned up
-    expect(await store.hasChunk('big-media', 0)).toBe(false);
-    expect(await store.hasChunk('big-media', 1)).toBe(false);
+    // Chunks stay in cache (contrast with the old concatenate-and-cleanup)
+    expect(await store.hasChunk('big-media', 0)).toBe(true);
+    expect(await store.hasChunk('big-media', 1)).toBe(true);
 
-    // Metadata marked complete, numChunks dropped
+    // Metadata marked complete; numChunks retained so reads know to
+    // walk chunks rather than look for a whole-file entry
     const meta = await store.getMetadata('big-media');
     expect(meta.complete).toBe(true);
-    expect(meta.numChunks).toBeUndefined();
+    expect(meta.numChunks).toBe(2);
     expect(meta.size).toBe(5);
   });
 
@@ -275,5 +288,109 @@ describe('ContentStoreBrowser', () => {
     // Sanity: a normal putChunk still completes (no lock held for this one)
     await store.putChunk('ok-key', 0, data, { numChunks: 1 });
     expect(await store.hasChunk('ok-key', 0)).toBe(true);
+  });
+
+  // ── getStream (per #373) ─────────────────────────────────────────
+
+  /**
+   * Helper: drain a ReadableStream into a single Uint8Array.
+   * Mirrors what a Response body consumer would do, but lets the
+   * test assert byte-for-byte equality on the output.
+   */
+  async function drain(stream) {
+    const reader = stream.getReader();
+    const chunks = [];
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+    }
+    const total = chunks.reduce((n, c) => n + c.length, 0);
+    const out = new Uint8Array(total);
+    let o = 0;
+    for (const c of chunks) {
+      out.set(c, o);
+      o += c.length;
+    }
+    return out;
+  }
+
+  describe('getStream', () => {
+    it('returns null when key is missing', async () => {
+      expect(await store.getStream('no-such-key')).toBeNull();
+    });
+
+    it('streams a whole-file entry without range', async () => {
+      const data = new TextEncoder().encode('abcdef').buffer;
+      await store.put('wf', data, { contentType: 'text/plain' });
+
+      const stream = await store.getStream('wf');
+      expect(stream).not.toBeNull();
+      const out = await drain(stream);
+      expect(new TextDecoder().decode(out)).toBe('abcdef');
+    });
+
+    it('streams bytes across chunks and reconstructs the whole file', async () => {
+      await store.putChunk('vid', 0, new Uint8Array([1, 2, 3]).buffer, {
+        numChunks: 3,
+        chunkSize: 3,
+        size: 8,
+      });
+      await store.putChunk('vid', 1, new Uint8Array([4, 5, 6]).buffer, {
+        numChunks: 3,
+        chunkSize: 3,
+        size: 8,
+      });
+      await store.putChunk('vid', 2, new Uint8Array([7, 8]).buffer, {
+        numChunks: 3,
+        chunkSize: 3,
+        size: 8,
+      });
+
+      const stream = await store.getStream('vid');
+      const out = await drain(stream);
+      expect(Array.from(out)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+    });
+
+    it('streams a byte range that spans chunk boundaries (range covers chunks 1-2)', async () => {
+      await store.putChunk('vid', 0, new Uint8Array([1, 2, 3]).buffer, {
+        numChunks: 3, chunkSize: 3, size: 8,
+      });
+      await store.putChunk('vid', 1, new Uint8Array([4, 5, 6]).buffer, {
+        numChunks: 3, chunkSize: 3, size: 8,
+      });
+      await store.putChunk('vid', 2, new Uint8Array([7, 8]).buffer, {
+        numChunks: 3, chunkSize: 3, size: 8,
+      });
+
+      // Request bytes 4..6 (inclusive) — spans chunk 1 (bytes 3-5)
+      // trimmed to [4,5] plus chunk 2 (bytes 6-7) trimmed to [6].
+      const stream = await store.getStream('vid', { start: 4, end: 6 });
+      const out = await drain(stream);
+      expect(Array.from(out)).toEqual([5, 6, 7]);
+    });
+
+    it('streams a byte range entirely within a single chunk', async () => {
+      await store.putChunk('vid', 0, new Uint8Array([10, 20, 30, 40, 50]).buffer, {
+        numChunks: 1, chunkSize: 5, size: 5,
+      });
+
+      const stream = await store.getStream('vid', { start: 1, end: 3 });
+      const out = await drain(stream);
+      expect(Array.from(out)).toEqual([20, 30, 40]);
+    });
+
+    it('errors the stream when a chunk is missing mid-walk', async () => {
+      await store.putChunk('gappy', 0, new Uint8Array([1, 2]).buffer, {
+        numChunks: 3, chunkSize: 2, size: 6,
+      });
+      // chunk 1 missing
+      await store.putChunk('gappy', 2, new Uint8Array([5, 6]).buffer, {
+        numChunks: 3, chunkSize: 2, size: 6,
+      });
+
+      const stream = await store.getStream('gappy');
+      await expect(drain(stream)).rejects.toThrow(/Missing chunk 1/);
+    });
   });
 });

--- a/packages/sw/src/request-handler-browser.js
+++ b/packages/sw/src/request-handler-browser.js
@@ -142,13 +142,22 @@ export class RequestHandlerBrowser {
       }
     }
 
-    // Try cache first
+    // Try cache first. getResponse handles both whole-file and
+    // chunked regimes internally via getStream (#373), so the caller
+    // no longer needs a separate `_serveChunked` path — chunked reads
+    // flow through a lazy ReadableStream that pulls one chunk at a
+    // time. However, chunked entries need completeness verified
+    // before serving so a half-populated item doesn't error mid-stream
+    // on the first missing chunk.
     const cached = await this.contentStore.has(cacheKey);
-    if (cached.exists) {
+    let chunkedReady = !cached.chunked || !!cached.metadata?.complete;
+    if (cached.exists && cached.chunked && !chunkedReady) {
+      // Probe completeness; marks complete if all chunks are in.
+      chunkedReady = await this.contentStore.assembleChunks(cacheKey);
+    }
+    if (cached.exists && chunkedReady) {
       this.log.debug('Cache hit:', cacheKey);
-      const response = cached.chunked
-        ? await this._serveChunked(cacheKey, range, cached.metadata)
-        : await this.contentStore.getResponse(cacheKey, range);
+      const response = await this.contentStore.getResponse(cacheKey, range);
       if (response) return response;
     }
 
@@ -204,30 +213,6 @@ export class RequestHandlerBrowser {
     } catch (err) {
       this.log.warn('Failed to cache:', key, err.message);
     }
-  }
-
-  /**
-   * Serve a chunked file — find the right chunk for the requested range.
-   */
-  async _serveChunked(key, range, metadata) {
-    if (!range) {
-      // No range — try to assemble and serve whole file
-      const assembled = await this.contentStore.assembleChunks(key);
-      if (assembled) return this.contentStore.getResponse(key);
-      return null;
-    }
-
-    // For range requests on chunked files, find which chunk covers the range
-    const chunkSize = metadata?.chunkSize || (50 * 1024 * 1024);
-    const startChunk = Math.floor(range.start / chunkSize);
-    const offsetInChunk = range.start - (startChunk * chunkSize);
-
-    const chunkRange = { start: offsetInChunk };
-    if (range.end != null) {
-      chunkRange.end = range.end - (startChunk * chunkSize);
-    }
-
-    return this.contentStore.getChunkResponse(key, startChunk, chunkRange);
   }
 
   /**


### PR DESCRIPTION
Draft PR tracking the #373 streaming rewrite. **Targets \`devel\`, not \`main\`** — this is part of the integration work planned around PRs #375 / #369 landing.

## Scope

Remove the ~50 MB practical limit documented inline on \`ContentStoreBrowser\`. Keep chunks separate in CacheStorage forever; serve reads via a lazy \`ReadableStream\` that pulls one chunk at a time.

## Plan (commits will land incrementally on this branch)

1. ✅ Scaffold \`getStream(key, range)\` stub — **this commit**
2. Implement \`getStream\` with a ReadableStream pull-source backed by cache entries
3. Rewrite \`getResponse(key, range)\` to wrap \`getStream\` in a \`Response\` (no more load-full-blob-and-slice)
4. Shrink \`assembleChunks\` to verify-all-present + mark-complete (no concatenation)
5. Swap \`RequestHandlerBrowser._serveChunked\` to use the stream path
6. Add \`navigator.storage.persist()\` in SW activate + \`navigator.storage.estimate()\` monitoring hook
7. Integration test with a synthetic 200 MB fixture asserting memory peak < 70 MB during playback simulation

## Success criteria

- All existing 2030 unit tests still pass
- New integration test verifies streaming behaviour
- Manual smoke: the PWA plays a >500 MB video without OOM on a Pi 4 class device

## Reviewability

Branch intentionally ladder-style — each of the 7 planned commits is independently reviewable. Draft stays open until all 7 land; then mark ready.

## References

- Issue #373 — design + gate
- Issue #292 (closed) — parent feature request
- PR #369 (merged) — established the scaffolding that this PR extends