### PR TITLE
feat(proxy): CJS bridge for @xiboplayer/proxy/hardware — refs #324

### DIFF
--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -8,7 +8,10 @@
     ".": "./src/index.js",
     "./cli": "./bin/cli.js",
     "./relay": "./src/sync-relay.js",
-    "./hardware": "./src/hardware.js"
+    "./hardware": {
+      "import": "./src/hardware.js",
+      "require": "./src/hardware.cjs"
+    }
   },
   "bin": {
     "xiboplayer-proxy": "./bin/cli.js",

--- a/packages/proxy/src/hardware.cjs
+++ b/packages/proxy/src/hardware.cjs
@@ -22,9 +22,18 @@ const path = require('path');
 const os = require('os');
 
 const GPU_VENDORS = {
-  '0x10de': { name: 'nvidia', label: 'NVIDIA', rank: 3, vaDriver: 'nvidia' },
-  '0x1002': { name: 'amd', label: 'AMD', rank: 2, vaDriver: 'radeonsi' },
-  '0x8086': { name: 'intel', label: 'Intel', rank: 1, vaDriver: 'iHD' },
+  '0x10de': { name: 'nvidia', label: 'NVIDIA', rank: 3, vaDriver: 'nvidia',   isVirtual: false },
+  '0x1002': { name: 'amd',    label: 'AMD',    rank: 2, vaDriver: 'radeonsi', isVirtual: false },
+  '0x8086': { name: 'intel',  label: 'Intel',  rank: 1, vaDriver: 'iHD',      isVirtual: false },
+  // Virtual GPUs — detection finds them (they expose a DRM render
+  // node) but hardware-accelerated Electron/Chromium ops fail at
+  // runtime with EACCES on DRM_IOCTL_MODE_CREATE_DUMB. Ranked -1 so
+  // real GPUs always win on hybrid setups. Consumers that care can
+  // check `gpu.isVirtual` and skip --render-node-override so the
+  // software-rendering path kicks in.
+  '0x1af4': { name: 'virtio', label: 'virtio-GPU',  rank: -1, vaDriver: null, isVirtual: true },
+  '0x1234': { name: 'qemu',   label: 'QEMU VGA',    rank: -1, vaDriver: null, isVirtual: true },
+  '0x15ad': { name: 'vmware', label: 'VMware SVGA', rank: -1, vaDriver: null, isVirtual: true },
 };
 
 /**
@@ -78,6 +87,7 @@ function detectGPUs() {
         label: vendor,
         rank: 0,
         vaDriver: null,
+        isVirtual: false,
       };
       gpus.push({
         card,

--- a/packages/proxy/src/hardware.cjs
+++ b/packages/proxy/src/hardware.cjs
@@ -1,43 +1,201 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (c) 2024-2026 Pau Aliagas <linuxnow@gmail.com>
 /**
- * CommonJS bridge for `@xiboplayer/proxy/hardware`.
+ * @xiboplayer/proxy/hardware — Shared GPU detection and memory tuning
  *
- * Electron's main process loads as CJS; the SDK package is ESM. This
- * bridge lets Electron do:
+ * CJS source of truth (Strategy C from #324). Used directly from
+ * Electron's CJS main process:
  *
- *     const { detectGPUs, selectBestGPU, getGpuFlags } =
+ *     const { detectGPUs, getHardwareConfig } =
  *       require('@xiboplayer/proxy/hardware');
  *
- * …without each Electron release duplicating the 200+ lines of
- * detection logic from `hardware.js`.
+ * ESM consumers import the thin wrapper at `./hardware.js`, which
+ * re-exports from this file via `createRequire`.
  *
- * Not yet implemented. The three viable strategies (see #324 for
- * the design conversation) are:
- *
- *   (a) Convert `xiboplayer-electron/src/main.js` to ESM (Electron
- *       28+ supports ESM main-process). Then this file is unneeded.
- *   (b) Build-time compile `hardware.js` to CJS and emit here.
- *   (c) Rewrite `hardware.js` as pure-Node-core CJS and have the
- *       ESM entry wrap it.
- *
- * None are done yet — throw loudly so anyone who adopts this before
- * the rewrite discovers the gap immediately rather than at runtime
- * on a kiosk in the field.
+ * Reads /sys/class/drm to detect GPUs, selects the best one, and
+ * provides adaptive memory tuning based on available RAM.
  */
 'use strict';
 
-function notImplemented() {
-  throw new Error(
-    '@xiboplayer/proxy/hardware CJS bridge not implemented yet — ' +
-      'see xibo-players/xiboplayer#324. Use the ESM entry via dynamic ' +
-      'import from an Electron ESM main, or wait for the rewrite.',
-  );
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const GPU_VENDORS = {
+  '0x10de': { name: 'nvidia', label: 'NVIDIA', rank: 3, vaDriver: 'nvidia' },
+  '0x1002': { name: 'amd', label: 'AMD', rank: 2, vaDriver: 'radeonsi' },
+  '0x8086': { name: 'intel', label: 'Intel', rank: 1, vaDriver: 'iHD' },
+};
+
+/**
+ * Detect all GPUs via /sys/class/drm.
+ * @returns {Array<{card: string, vendor: string, device: string, driver: string, renderNode: string, hasDisplay: boolean, name: string, label: string, rank: number, vaDriver: string|null}>}
+ */
+function detectGPUs() {
+  const gpus = [];
+  try {
+    const drmEntries = fs.readdirSync('/sys/class/drm');
+    const cards = drmEntries.filter((d) => /^card\d+$/.test(d));
+    for (const card of cards) {
+      const devPath = `/sys/class/drm/${card}/device`;
+      let vendor;
+      let device;
+      let driver;
+      try {
+        vendor = fs.readFileSync(`${devPath}/vendor`, 'utf8').trim();
+        device = fs.readFileSync(`${devPath}/device`, 'utf8').trim();
+      } catch (_) {
+        continue;
+      }
+      try {
+        driver = path.basename(fs.readlinkSync(`${devPath}/driver`));
+      } catch (_) {
+        driver = 'unknown';
+      }
+
+      const cardRealPath = fs.realpathSync(devPath);
+      let renderNode = null;
+      for (const rn of drmEntries.filter((d) => d.startsWith('renderD'))) {
+        try {
+          if (fs.realpathSync(`/sys/class/drm/${rn}/device`) === cardRealPath) {
+            renderNode = `/dev/dri/${rn}`;
+            break;
+          }
+        } catch (_) {
+          // unreachable renderD — skip
+        }
+      }
+      if (!renderNode) continue;
+
+      const hasDisplay = drmEntries.some(
+        (d) =>
+          d.startsWith(`${card}-`) &&
+          /-(DP|HDMI|eDP|VGA|DVI|DSI|LVDS)/.test(d),
+      );
+
+      const info = GPU_VENDORS[vendor] || {
+        name: 'unknown',
+        label: vendor,
+        rank: 0,
+        vaDriver: null,
+      };
+      gpus.push({
+        card,
+        vendor,
+        device,
+        driver,
+        renderNode,
+        hasDisplay,
+        ...info,
+      });
+    }
+  } catch (_) {
+    // /sys/class/drm unreadable — empty list
+  }
+  return gpus;
+}
+
+/**
+ * Select the best GPU from detected list.
+ * On hybrid systems, prefers the GPU with display connectors.
+ * @param {Array} gpus - From detectGPUs()
+ * @param {string} [preference='auto'] - 'auto', 'nvidia', 'intel', 'amd', or '/dev/dri/renderDNNN'
+ */
+function selectGPU(gpus, preference) {
+  if (!preference || preference === 'auto') {
+    const displayGPUs = gpus.filter((g) => g.hasDisplay);
+    const renderOnly = gpus.filter((g) => !g.hasDisplay);
+    if (displayGPUs.length > 0 && renderOnly.length > 0) {
+      return [...displayGPUs].sort((a, b) => b.rank - a.rank)[0];
+    }
+    return [...gpus].sort((a, b) => b.rank - a.rank)[0] || null;
+  }
+  if (preference.startsWith('/dev/dri/')) {
+    return gpus.find((g) => g.renderNode === preference) || null;
+  }
+  return gpus.find((g) => g.name === preference.toLowerCase()) || null;
+}
+
+/**
+ * Adaptive memory tuning — scale V8 heap and raster threads to hardware.
+ * @returns {{totalRAM_GB: number, cpuCount: number, maxOldSpaceMB: number, rasterThreads: number}}
+ */
+function getMemoryTuning() {
+  const totalRAM_GB = Math.round(os.totalmem() / (1024 ** 3));
+  const cpuCount = os.cpus().length;
+  let maxOldSpaceMB;
+  let rasterThreads;
+
+  if (totalRAM_GB <= 1) {
+    maxOldSpaceMB = 128;
+    rasterThreads = 1;
+  } else if (totalRAM_GB <= 2) {
+    maxOldSpaceMB = 192;
+    rasterThreads = 2;
+  } else if (totalRAM_GB <= 4) {
+    maxOldSpaceMB = 256;
+    rasterThreads = Math.min(cpuCount, 2);
+  } else if (totalRAM_GB <= 8) {
+    maxOldSpaceMB = 512;
+    rasterThreads = Math.min(cpuCount, 4);
+  } else {
+    maxOldSpaceMB = 768;
+    rasterThreads = Math.min(cpuCount, 4);
+  }
+
+  return { totalRAM_GB, cpuCount, maxOldSpaceMB, rasterThreads };
+}
+
+/**
+ * Generate Chromium/Electron GPU and memory flags.
+ * This is the single source of truth — both Electron and Chromium should use this.
+ *
+ * @param {object} [options]
+ * @param {string} [options.gpuPreference='auto'] - GPU selection preference
+ * @returns {{gpus: Array, gpu: object|null, memory: object, flags: string[], env: object}}
+ */
+function getHardwareConfig(options = {}) {
+  const gpus = detectGPUs();
+  const gpu = gpus.length > 0 ? selectGPU(gpus, options.gpuPreference) : null;
+  const memory = getMemoryTuning();
+
+  const flags = [
+    '--ignore-gpu-blocklist',
+    '--enable-gpu-rasterization',
+    '--enable-zero-copy',
+    `--num-raster-threads=${memory.rasterThreads}`,
+    `--js-flags=--max-old-space-size=${memory.maxOldSpaceMB}`,
+    '--default-tile-width=512',
+    '--default-tile-height=512',
+    '--renderer-process-limit=1',
+    '--gpu-rasterization-msaa-sample-count=0',
+    '--enable-features=CanvasOopRasterization,VaapiVideoDecoder,VaapiVideoEncoder',
+    '--disable-gpu-watchdog',
+    '--disable-background-timer-throttling',
+  ];
+
+  const env = {};
+
+  if (gpu) {
+    flags.push(`--render-node-override=${gpu.renderNode}`);
+    if (gpu.vaDriver) {
+      env.LIBVA_DRIVER_NAME = gpu.vaDriver;
+    }
+  }
+
+  return {
+    gpus,
+    gpu,
+    memory,
+    flags,
+    env,
+  };
 }
 
 module.exports = {
-  detectGPUs: notImplemented,
-  selectBestGPU: notImplemented,
-  getGpuFlags: notImplemented,
-  getAdaptiveMemoryFlags: notImplemented,
+  GPU_VENDORS,
+  detectGPUs,
+  selectGPU,
+  getMemoryTuning,
+  getHardwareConfig,
 };

--- a/packages/proxy/src/hardware.cjs
+++ b/packages/proxy/src/hardware.cjs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2024-2026 Pau Aliagas <linuxnow@gmail.com>
+/**
+ * CommonJS bridge for `@xiboplayer/proxy/hardware`.
+ *
+ * Electron's main process loads as CJS; the SDK package is ESM. This
+ * bridge lets Electron do:
+ *
+ *     const { detectGPUs, selectBestGPU, getGpuFlags } =
+ *       require('@xiboplayer/proxy/hardware');
+ *
+ * …without each Electron release duplicating the 200+ lines of
+ * detection logic from `hardware.js`.
+ *
+ * Not yet implemented. The three viable strategies (see #324 for
+ * the design conversation) are:
+ *
+ *   (a) Convert `xiboplayer-electron/src/main.js` to ESM (Electron
+ *       28+ supports ESM main-process). Then this file is unneeded.
+ *   (b) Build-time compile `hardware.js` to CJS and emit here.
+ *   (c) Rewrite `hardware.js` as pure-Node-core CJS and have the
+ *       ESM entry wrap it.
+ *
+ * None are done yet — throw loudly so anyone who adopts this before
+ * the rewrite discovers the gap immediately rather than at runtime
+ * on a kiosk in the field.
+ */
+'use strict';
+
+function notImplemented() {
+  throw new Error(
+    '@xiboplayer/proxy/hardware CJS bridge not implemented yet — ' +
+      'see xibo-players/xiboplayer#324. Use the ESM entry via dynamic ' +
+      'import from an Electron ESM main, or wait for the rewrite.',
+  );
+}
+
+module.exports = {
+  detectGPUs: notImplemented,
+  selectBestGPU: notImplemented,
+  getGpuFlags: notImplemented,
+  getAdaptiveMemoryFlags: notImplemented,
+};

--- a/packages/proxy/src/hardware.js
+++ b/packages/proxy/src/hardware.js
@@ -1,153 +1,28 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (c) 2024-2026 Pau Aliagas <linuxnow@gmail.com>
 /**
- * @xiboplayer/proxy/hardware — Shared GPU detection and memory tuning
+ * @xiboplayer/proxy/hardware — ESM wrapper around the CJS source of truth.
  *
- * Used by both Electron (import directly) and Chromium (via CLI bridge).
- * Reads /sys/class/drm to detect GPUs, selects the best one, and
- * provides adaptive memory tuning based on available RAM.
- */
-
-import fs from 'fs';
-import path from 'path';
-import os from 'os';
-
-export const GPU_VENDORS = {
-  '0x10de': { name: 'nvidia', label: 'NVIDIA', rank: 3, vaDriver: 'nvidia' },
-  '0x1002': { name: 'amd', label: 'AMD', rank: 2, vaDriver: 'radeonsi' },
-  '0x8086': { name: 'intel', label: 'Intel', rank: 1, vaDriver: 'iHD' },
-};
-
-/**
- * Detect all GPUs via /sys/class/drm.
- * @returns {Array<{card: string, vendor: string, device: string, driver: string, renderNode: string, hasDisplay: boolean, name: string, label: string, rank: number, vaDriver: string|null}>}
- */
-export function detectGPUs() {
-  const gpus = [];
-  try {
-    const drmEntries = fs.readdirSync('/sys/class/drm');
-    const cards = drmEntries.filter(d => /^card\d+$/.test(d));
-    for (const card of cards) {
-      const devPath = `/sys/class/drm/${card}/device`;
-      let vendor, device, driver;
-      try {
-        vendor = fs.readFileSync(`${devPath}/vendor`, 'utf8').trim();
-        device = fs.readFileSync(`${devPath}/device`, 'utf8').trim();
-      } catch (_) { continue; }
-      try {
-        driver = path.basename(fs.readlinkSync(`${devPath}/driver`));
-      } catch (_) { driver = 'unknown'; }
-
-      const cardRealPath = fs.realpathSync(devPath);
-      let renderNode = null;
-      for (const rn of drmEntries.filter(d => d.startsWith('renderD'))) {
-        try {
-          if (fs.realpathSync(`/sys/class/drm/${rn}/device`) === cardRealPath) {
-            renderNode = `/dev/dri/${rn}`;
-            break;
-          }
-        } catch (_) {}
-      }
-      if (!renderNode) continue;
-
-      const hasDisplay = drmEntries.some(d =>
-        d.startsWith(`${card}-`) && /-(DP|HDMI|eDP|VGA|DVI|DSI|LVDS)/.test(d)
-      );
-
-      const info = GPU_VENDORS[vendor] || { name: 'unknown', label: vendor, rank: 0, vaDriver: null };
-      gpus.push({ card, vendor, device, driver, renderNode, hasDisplay, ...info });
-    }
-  } catch (_) {}
-  return gpus;
-}
-
-/**
- * Select the best GPU from detected list.
- * On hybrid systems, prefers the GPU with display connectors.
- * @param {Array} gpus - From detectGPUs()
- * @param {string} [preference='auto'] - 'auto', 'nvidia', 'intel', 'amd', or '/dev/dri/renderDNNN'
- */
-export function selectGPU(gpus, preference) {
-  if (!preference || preference === 'auto') {
-    const displayGPUs = gpus.filter(g => g.hasDisplay);
-    const renderOnly = gpus.filter(g => !g.hasDisplay);
-    if (displayGPUs.length > 0 && renderOnly.length > 0) {
-      return [...displayGPUs].sort((a, b) => b.rank - a.rank)[0];
-    }
-    return [...gpus].sort((a, b) => b.rank - a.rank)[0] || null;
-  }
-  if (preference.startsWith('/dev/dri/')) {
-    return gpus.find(g => g.renderNode === preference) || null;
-  }
-  return gpus.find(g => g.name === preference.toLowerCase()) || null;
-}
-
-/**
- * Adaptive memory tuning — scale V8 heap and raster threads to hardware.
- * @returns {{totalRAM_GB: number, cpuCount: number, maxOldSpaceMB: number, rasterThreads: number}}
- */
-export function getMemoryTuning() {
-  const totalRAM_GB = Math.round(os.totalmem() / (1024 ** 3));
-  const cpuCount = os.cpus().length;
-  let maxOldSpaceMB, rasterThreads;
-
-  if (totalRAM_GB <= 1) {
-    maxOldSpaceMB = 128; rasterThreads = 1;
-  } else if (totalRAM_GB <= 2) {
-    maxOldSpaceMB = 192; rasterThreads = 2;
-  } else if (totalRAM_GB <= 4) {
-    maxOldSpaceMB = 256; rasterThreads = Math.min(cpuCount, 2);
-  } else if (totalRAM_GB <= 8) {
-    maxOldSpaceMB = 512; rasterThreads = Math.min(cpuCount, 4);
-  } else {
-    maxOldSpaceMB = 768; rasterThreads = Math.min(cpuCount, 4);
-  }
-
-  return { totalRAM_GB, cpuCount, maxOldSpaceMB, rasterThreads };
-}
-
-/**
- * Generate Chromium/Electron GPU and memory flags.
- * This is the single source of truth — both Electron and Chromium should use this.
+ * Implementation lives in `./hardware.cjs` (required by Electron's CJS
+ * main process directly). This file re-exports from there so existing
+ * ESM consumers (proxy.js, bin/detect-hardware.js, @xiboplayer/proxy's
+ * index.js) keep working unchanged.
  *
- * @param {object} [options]
- * @param {string} [options.gpuPreference='auto'] - GPU selection preference
- * @returns {{gpu: object|null, memory: object, flags: string[], env: object}}
+ * Rationale (#324): we need ONE place for the GPU detection logic.
+ * Duplicating it in Electron wastes effort and drifts. The CJS side
+ * has to be the source of truth because Electron's main process is
+ * CJS; ESM consumers get a trivial wrapper here.
+ *
+ * @see hardware.cjs — actual implementation
  */
-export function getHardwareConfig(options = {}) {
-  const gpus = detectGPUs();
-  const gpu = gpus.length > 0 ? selectGPU(gpus, options.gpuPreference) : null;
-  const memory = getMemoryTuning();
 
-  const flags = [
-    '--ignore-gpu-blocklist',
-    '--enable-gpu-rasterization',
-    '--enable-zero-copy',
-    `--num-raster-threads=${memory.rasterThreads}`,
-    `--js-flags=--max-old-space-size=${memory.maxOldSpaceMB}`,
-    '--default-tile-width=512',
-    '--default-tile-height=512',
-    '--renderer-process-limit=1',
-    '--gpu-rasterization-msaa-sample-count=0',
-    '--enable-features=CanvasOopRasterization,VaapiVideoDecoder,VaapiVideoEncoder',
-    '--disable-gpu-watchdog',
-    '--disable-background-timer-throttling',
-  ];
+import { createRequire } from 'node:module';
 
-  const env = {};
+const require = createRequire(import.meta.url);
+const cjs = require('./hardware.cjs');
 
-  if (gpu) {
-    flags.push(`--render-node-override=${gpu.renderNode}`);
-    if (gpu.vaDriver) {
-      env.LIBVA_DRIVER_NAME = gpu.vaDriver;
-    }
-  }
-
-  return {
-    gpus,
-    gpu,
-    memory,
-    flags,
-    env,
-  };
-}
+export const GPU_VENDORS = cjs.GPU_VENDORS;
+export const detectGPUs = cjs.detectGPUs;
+export const selectGPU = cjs.selectGPU;
+export const getMemoryTuning = cjs.getMemoryTuning;
+export const getHardwareConfig = cjs.getHardwareConfig;


### PR DESCRIPTION
Draft PR tracking the #324 GPU detection dedup. **Targets \`devel\`**.

## Scope

\`xiboplayer-electron/src/main.js:81-100+\` duplicates the \`detectGPUs()\` function from \`@xiboplayer/proxy/hardware.js\`. The SDK is ESM; Electron's main process is CJS. Remove the duplicate.

## Plan

The decision between three strategies is pending (see #324 conversation). This PR's first commit scaffolds the hardware.cjs bridge + dual export so the route is wired, but the implementation is a not-implemented stub.

Next commits, depending on strategy chosen:

### Strategy A — Electron ESM main (preferred)

Convert \`xiboplayer-electron/src/main.js\` to ESM (Electron 28+ supports it). Delete \`hardware.cjs\`. Electron imports \`@xiboplayer/proxy/hardware\` as ESM directly. This is a cross-repo change — \`xiboplayer-electron\` PR paired with this one. Simplest long-term; highest one-time cost.

### Strategy B — build-time CJS bundle

Add a tiny build step (esbuild or similar) that emits \`hardware.cjs\` from \`hardware.js\`. Commit the generated file. Electron \`require\`s the generated bundle. Keeps ESM authoring; costs a build step.

### Strategy C — CJS source of truth

Rewrite \`hardware.js\` in pure-Node-core CJS (only uses \`fs\`, \`path\`, \`os\`). Have \`hardware.js\` be the ESM wrapper that re-exports. Electron requires the CJS; ESM consumers get the wrapper.

## Success criteria

- Electron \`require('@xiboplayer/proxy/hardware')\` returns the same functions as the ESM \`hardware.js\`
- \`xiboplayer-electron/src/main.js\` drops its local \`detectGPUs()\` + \`GPU_VENDORS\` copy
- All four inline GPU flags (gpu-rasterization, default-tile-width, renderer-process-limit, gpu-rasterization-msaa-sample-count) get set via the shared helper
- Electron RPM builds green on CI

## References

- #324 — design + ESM/CJS discussion
- \`@xiboplayer/proxy/hardware.js\` — the authoritative GPU detection code (Chromium kiosk already consumes it via CLI)