### PR TITLE
fix(publish): drop explicit pnpm version (packageManager in package.json wins)

### DIFF
--- a/.github/workflows/publish-to-gh-packages.yml
+++ b/.github/workflows/publish-to-gh-packages.yml
@@ -65,8 +65,9 @@ jobs:
           fetch-depth: 1
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+        # Explicit version omitted — packageManager in package.json
+        # (pnpm@10.27.0) is the authoritative source. Setting version:
+        # here in addition causes ERR_PNPM_BAD_PM_VERSION.
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Trivial follow-up to #394 — pnpm/action-setup@v4 errors with ERR_PNPM_BAD_PM_VERSION when both `version:` input and `packageManager` field are set. Letting the action read from `packageManager` resolves it.

Verified at workflow run https://github.com/xiboplayer/xiboplayer/actions/runs/25519153956 — failure was 'Multiple versions of pnpm specified'.