### PR TITLE
ci(publish): auto-fire GH Packages publish on every v* tag

### DIFF
--- a/.github/workflows/publish-to-gh-packages.yml
+++ b/.github/workflows/publish-to-gh-packages.yml
@@ -20,10 +20,14 @@ name: Publish to GitHub Packages
 #   updated separately to dual-publish on every future tag.
 #
 # Trigger:
-#   workflow_dispatch only — operator runs this once per major version
-#   bump (or once total to bootstrap). NOT auto-fired on tag push to
-#   avoid surprising drift on every release until publish.yml is
-#   updated to be dual-publish-aware.
+#   push.tags 'v*' (auto on every release tag, parallel with publish.yml's
+#   public-npm publish) + workflow_dispatch (manual backfill / re-publish).
+#
+#   Originally workflow_dispatch-only during bootstrapping; now that all
+#   17 SDK packages are live on GH Packages and the consumers (0cs-core,
+#   h1's deploy-smil-tools.yml) depend on them being there, we make it
+#   automatic so every future v* tag dual-publishes to public npm AND
+#   GH Packages without operator intervention.
 #
 # Idempotency:
 #   GH Packages refuses to re-publish the same name@version — the
@@ -41,6 +45,8 @@ name: Publish to GitHub Packages
 #   No external secret needed for the publish path itself.
 
 on:
+  push:
+    tags: ['v*']
   workflow_dispatch:
     inputs:
       ref:


### PR DESCRIPTION
## Summary

Make the GH Packages publish workflow **automatic on every release tag** instead of `workflow_dispatch` only. Closes the auto-publish gap from the 2026-05-07 distribution migration.

## Why

After today's migration arc:
- `xiboplayer/xiboplayer-smil-tools#36` — smil-tools v0.6.1 published to GH Packages
- `#394` + `#395` — bootstrap workflow added + pnpm version conflict fixed
- workflow_dispatch run `25519281203` — all 17 SDK packages live on GH Packages
- `zerosignage/0cs-core#154` — consumer migrated to npm-protocol via .npmrc
- `zerosignage/platform#610` — h1 deploy-smil-tools.yml rewritten to npm-install

…the operator decision (\"always use them; public npm was nice-to-have\") treats GH Packages as primary. Without this PR, every future SDK version bump would require operator-triggered workflow_dispatch — friction that defeats the goal of standardization.

## What changes

`.github/workflows/publish-to-gh-packages.yml`:

```diff
 on:
+  push:
+    tags: ['v*']
   workflow_dispatch:
```

Plus updated header comment explaining the new trigger model.

## Result

Every future `v*` tag fires BOTH:

| Workflow | Target | Trigger |
|---|---|---|
| `publish.yml` (existing) | public npm registry.npmjs.org | `push.tags: ['v*']` |
| `publish-to-gh-packages.yml` (this workflow) | GH Packages npm.pkg.github.com | `push.tags: ['v*']` ← NEW |

Both run in parallel, both use `GITHUB_TOKEN`, both are idempotent. `workflow_dispatch` retained for manual backfill / re-publish of an older tag.

## Test plan

- [ ] Merge this PR
- [ ] Next time the SDK is tagged (e.g. v0.7.24), both workflows should fire automatically and complete successfully
- [ ] Verify GH Packages shows the new version at github.com/orgs/xiboplayer/packages?package_type=npm

If the dual-publish on tag becomes problematic (e.g. one registry is flaky and we want manual control), trivially revertible by removing the `push.tags:` block.

## Out of scope

- Form-factor repo CI workflows (xiboplayer-electron, chromium, kiosk, etc.) need separate updates to consume from GH Packages — tracked at `zerosignage/platform#621`.
- Eventually retiring public npm publishing entirely (operator decision, not yet — keep "nice-to-have" for OSS visibility).

## Refs

- `xiboplayer/xiboplayer-smil-tools#36`
- `#394` (bootstrap workflow), `#395` (pnpm version fix)
- `zerosignage/0cs-core#154` (consumer migrated)
- `zerosignage/platform#610` (h1 transition)
- `zerosignage/platform#621` (long-tail playbook + form-factor CI)