### PR TITLE
chore: rename xibo-players GH org references → xiboplayer

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,6 +1,6 @@
 # Xiboplayer Codebase Audit — 2026-03-14
 
-Comprehensive audit across all repos: xiboplayer (monorepo), xiboplayer-chromium, xiboplayer-electron, xibo-players.github.io, xiboplayer-www.
+Comprehensive audit across all repos: xiboplayer (monorepo), xiboplayer-chromium, xiboplayer-electron, xiboplayer.github.io, xiboplayer-www.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -155,9 +155,9 @@ Layout features: proportional scaling with ResizeObserver, overlay support (z-in
 | Player | Platform | Install |
 |--------|----------|---------|
 | [xiboplayer-pwa](packages/pwa) | Any browser | Hosted on your CMS |
-| [xiboplayer-electron](https://github.com/xibo-players/xiboplayer-electron) | Fedora / Ubuntu | `dnf install xiboplayer-electron` |
-| [xiboplayer-chromium](https://github.com/xibo-players/xiboplayer-chromium) | Fedora / Ubuntu | `dnf install xiboplayer-chromium` |
-| [xiboplayer-kiosk](https://github.com/xibo-players/xiboplayer-kiosk) | Fedora / Ubuntu | `dnf install xiboplayer-kiosk` |
+| [xiboplayer-electron](https://github.com/xiboplayer/xiboplayer-electron) | Fedora / Ubuntu | `dnf install xiboplayer-electron` |
+| [xiboplayer-chromium](https://github.com/xiboplayer/xiboplayer-chromium) | Fedora / Ubuntu | `dnf install xiboplayer-chromium` |
+| [xiboplayer-kiosk](https://github.com/xiboplayer/xiboplayer-kiosk) | Fedora / Ubuntu | `dnf install xiboplayer-kiosk` |
 
 RPM and DEB packages are available from [dl.xiboplayer.org](https://dl.xiboplayer.org).
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "AGPL-3.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/xibo-players/xiboplayer.git"
+    "url": "git+https://github.com/xiboplayer/xiboplayer.git"
   },
   "homepage": "https://xiboplayer.org"
 }

--- a/packages/cache/README.md
+++ b/packages/cache/README.md
@@ -234,4 +234,4 @@ new CacheAnalyzer(storeClient, { threshold: 80 })
 
 ---
 
-[xiboplayer.org](https://xiboplayer.org) · **Part of the [XiboPlayer SDK](https://github.com/xibo-players/xiboplayer)**
+[xiboplayer.org](https://xiboplayer.org) · **Part of the [XiboPlayer SDK](https://github.com/xiboplayer/xiboplayer)**

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -38,7 +38,7 @@
   "license": "AGPL-3.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/xibo-players/xiboplayer.git",
+    "url": "git+https://github.com/xiboplayer/xiboplayer.git",
     "directory": "packages/cache"
   },
   "homepage": "https://xiboplayer.org"

--- a/packages/cms-testing/package.json
+++ b/packages/cms-testing/package.json
@@ -32,7 +32,7 @@
   "license": "AGPL-3.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/xibo-players/xiboplayer.git",
+    "url": "git+https://github.com/xiboplayer/xiboplayer.git",
     "directory": "packages/cms-testing"
   },
   "homepage": "https://xiboplayer.org"

--- a/packages/core/CAMPAIGNS.md
+++ b/packages/core/CAMPAIGNS.md
@@ -251,4 +251,4 @@ Potential improvements:
 
 - Xibo CMS Campaigns: https://xibosignage.com/docs/setup/campaigns
 - XMDS Protocol: https://github.com/xibosignage/xibo/blob/master/lib/XTR/ScheduleParser.php
-- Electron Player: https://github.com/xibo-players/xiboplayer-electron
+- Electron Player: https://github.com/xiboplayer/xiboplayer-electron

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -275,4 +275,4 @@ new PlayerCore({
 
 ---
 
-[xiboplayer.org](https://xiboplayer.org) · **Part of the [XiboPlayer SDK](https://github.com/xibo-players/xiboplayer)**
+[xiboplayer.org](https://xiboplayer.org) · **Part of the [XiboPlayer SDK](https://github.com/xiboplayer/xiboplayer)**

--- a/packages/core/docs/ARCHITECTURE.md
+++ b/packages/core/docs/ARCHITECTURE.md
@@ -300,12 +300,12 @@ Each platform is a separate repository that depends on the SDK packages via npm:
 
 | Platform | Repository | Description |
 |----------|-----------|-------------|
-| PWA | [xiboplayer-pwa](https://github.com/xibo-players/xiboplayer-pwa) | Browser-based, installable PWA |
-| Electron | [xiboplayer-electron](https://github.com/xibo-players/xiboplayer-electron) | Desktop kiosk wrapper with CORS handling |
-| Chromium | [xiboplayer-chromium](https://github.com/xibo-players/xiboplayer-chromium) | Chromium kiosk RPM for Linux |
-| Chrome | [xiboplayer-chrome](https://github.com/xibo-players/xiboplayer-chrome) | Chrome extension |
-| Android | [xiboplayer-android](https://github.com/xibo-players/xiboplayer-android) | TWA wrapper for Android |
-| webOS | [xiboplayer-webos](https://github.com/xibo-players/xiboplayer-webos) | LG webOS signage |
+| PWA | [xiboplayer-pwa](https://github.com/xiboplayer/xiboplayer-pwa) | Browser-based, installable PWA |
+| Electron | [xiboplayer-electron](https://github.com/xiboplayer/xiboplayer-electron) | Desktop kiosk wrapper with CORS handling |
+| Chromium | [xiboplayer-chromium](https://github.com/xiboplayer/xiboplayer-chromium) | Chromium kiosk RPM for Linux |
+| Chrome | [xiboplayer-chrome](https://github.com/xiboplayer/xiboplayer-chrome) | Chrome extension |
+| Android | [xiboplayer-android](https://github.com/xiboplayer/xiboplayer-android) | TWA wrapper for Android |
+| webOS | [xiboplayer-webos](https://github.com/xiboplayer/xiboplayer-webos) | LG webOS signage |
 
 ## Communication Protocols
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,7 +45,7 @@
   "license": "AGPL-3.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/xibo-players/xiboplayer.git",
+    "url": "git+https://github.com/xiboplayer/xiboplayer.git",
     "directory": "packages/core"
   },
   "homepage": "https://xiboplayer.org"

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -25,7 +25,7 @@
   "license": "AGPL-3.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/xibo-players/xiboplayer.git",
+    "url": "git+https://github.com/xiboplayer/xiboplayer.git",
     "directory": "packages/crypto"
   },
   "homepage": "https://xiboplayer.org"

--- a/packages/datasource/package.json
+++ b/packages/datasource/package.json
@@ -35,7 +35,7 @@
   "license": "AGPL-3.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/xibo-players/xiboplayer.git",
+    "url": "git+https://github.com/xiboplayer/xiboplayer.git",
     "directory": "packages/datasource"
   },
   "homepage": "https://xiboplayer.org"

--- a/packages/docs/AUDIT.md
+++ b/packages/docs/AUDIT.md
@@ -59,10 +59,10 @@ All handlers implemented: `collectNow`, `screenShot`, `licenceCheck`, `changeLay
 | Default layout fallback | ✅ | — |
 | Geo-fencing (haversine + browser Geolocation) | ✅ | — |
 | Criteria evaluation (5 metrics + custom props) | ✅ | — |
-| Weather criteria | ✅ | [#73](https://github.com/xibo-players/xiboplayer/issues/73) ✓ |
-| Recurrence patterns (daily/weekly/monthly) | ✅ | [#80](https://github.com/xibo-players/xiboplayer/issues/80) ✓ (PR #90) |
-| Adspace exchange / SSP ads | ❌ | [#84](https://github.com/xibo-players/xiboplayer/issues/84) |
-| Layout interleaving (weighted SoV) | ✅ | [#78](https://github.com/xibo-players/xiboplayer/issues/78) ✓ |
+| Weather criteria | ✅ | [#73](https://github.com/xiboplayer/xiboplayer/issues/73) ✓ |
+| Recurrence patterns (daily/weekly/monthly) | ✅ | [#80](https://github.com/xiboplayer/xiboplayer/issues/80) ✓ (PR #90) |
+| Adspace exchange / SSP ads | ❌ | [#84](https://github.com/xiboplayer/xiboplayer/issues/84) |
+| Layout interleaving (weighted SoV) | ✅ | [#78](https://github.com/xiboplayer/xiboplayer/issues/78) ✓ |
 
 ### Renderer (renderer-lite vs XLR)
 
@@ -80,8 +80,8 @@ All handlers implemented: `collectNow`, `screenShot`, `licenceCheck`, `changeLay
 | Time-gating (schedule-aware regions) | ✅ | ❌ | Our win |
 | Cycle playback (auto-replay) | ✅ | ❌ | Our win |
 | Element reuse (toggle visibility) | ✅ | ❌ | Our win — avoids DOM churn |
-| Image scaletype options | ✅ | ✅ | [#74](https://github.com/xibo-players/xiboplayer/issues/74) ✓ (PR #89) |
-| Default transition (instant toggle) | ✅ | ✅ | [#83](https://github.com/xibo-players/xiboplayer/issues/83) ✓ (already existed) |
+| Image scaletype options | ✅ | ✅ | [#74](https://github.com/xiboplayer/xiboplayer/issues/74) ✓ (PR #89) |
+| Default transition (instant toggle) | ✅ | ✅ | [#83](https://github.com/xiboplayer/xiboplayer/issues/83) ✓ (already existed) |
 | Drawer regions | ❌ | ✅ | Not planned (XLR-specific) |
 
 ### Stats and Reporting
@@ -95,8 +95,8 @@ All handlers implemented: `collectNow`, `screenShot`, `licenceCheck`, `changeLay
 | Fault deduplication (5-min cooldown) | ✅ | — |
 | Replay-safe tracking | ✅ | — |
 | Quota-exceeded cleanup | ✅ | — |
-| Widget engagement tracking | ✅ | [#77](https://github.com/xibo-players/xiboplayer/issues/77) ✓ (already existed) |
-| BroadcastChannel transport | N/A | [#82](https://github.com/xibo-players/xiboplayer/issues/82) ✓ (not needed) |
+| Widget engagement tracking | ✅ | [#77](https://github.com/xiboplayer/xiboplayer/issues/77) ✓ (already existed) |
+| BroadcastChannel transport | N/A | [#82](https://github.com/xiboplayer/xiboplayer/issues/82) ✓ (not needed) |
 
 ## SDK vs Upstream Players
 
@@ -106,12 +106,12 @@ All handlers implemented: `collectNow`, `screenShot`, `licenceCheck`, `changeLay
 |-----------|:---:|:----:|-----|
 | XMDS methods | 14/14 | 14/14 | — |
 | XMR handlers | 13/13 | 13/13 | — |
-| Retry-After (429) | ✅ | ✅ | [#70](https://github.com/xibo-players/xiboplayer/issues/70) ✓ (PR #86) |
-| Fault reporting agent | ✅ | ✅ | [#71](https://github.com/xibo-players/xiboplayer/issues/71) ✓ (PR #87) |
-| Unsafe layout blacklist | ✅ | ✅ | [#72](https://github.com/xibo-players/xiboplayer/issues/72) ✓ (PR #88) |
-| NotifyStatus fields | ✅ | ✅ | [#76](https://github.com/xibo-players/xiboplayer/issues/76) ✓ (PR #89) |
-| Layout interleaving | ✅ | ✅ | [#78](https://github.com/xibo-players/xiboplayer/issues/78) ✓ |
-| Download window enforcement | ✅ | ✅ | [#81](https://github.com/xibo-players/xiboplayer/issues/81) ✓ (PR #90) |
+| Retry-After (429) | ✅ | ✅ | [#70](https://github.com/xiboplayer/xiboplayer/issues/70) ✓ (PR #86) |
+| Fault reporting agent | ✅ | ✅ | [#71](https://github.com/xiboplayer/xiboplayer/issues/71) ✓ (PR #87) |
+| Unsafe layout blacklist | ✅ | ✅ | [#72](https://github.com/xiboplayer/xiboplayer/issues/72) ✓ (PR #88) |
+| NotifyStatus fields | ✅ | ✅ | [#76](https://github.com/xiboplayer/xiboplayer/issues/76) ✓ (PR #89) |
+| Layout interleaving | ✅ | ✅ | [#78](https://github.com/xiboplayer/xiboplayer/issues/78) ✓ |
+| Download window enforcement | ✅ | ✅ | [#81](https://github.com/xiboplayer/xiboplayer/issues/81) ✓ (PR #90) |
 | Shell/RS232 commands | N/A | ✅ | Browser sandbox |
 | Parallel downloads | ✅ (4 chunks) | ❌ (sequential) | Our advantage |
 | Bundle size | ~500KB | ~50MB | Our advantage |
@@ -120,9 +120,9 @@ All handlers implemented: `collectNow`, `screenShot`, `licenceCheck`, `changeLay
 
 | Capability | SDK | Electron (upstream) | Gap |
 |-----------|:---:|:---:|-----|
-| Scheduled commands | ✅ | ✅ | [#79](https://github.com/xibo-players/xiboplayer/issues/79) ✓ (already existed) |
-| Widget duration webhooks | ✅ | ✅ | [#79](https://github.com/xibo-players/xiboplayer/issues/79) ✓ (already existed) |
-| Event stats | ✅ | ✅ | [#79](https://github.com/xibo-players/xiboplayer/issues/79) ✓ (already existed) |
+| Scheduled commands | ✅ | ✅ | [#79](https://github.com/xiboplayer/xiboplayer/issues/79) ✓ (already existed) |
+| Widget duration webhooks | ✅ | ✅ | [#79](https://github.com/xiboplayer/xiboplayer/issues/79) ✓ (already existed) |
+| Event stats | ✅ | ✅ | [#79](https://github.com/xiboplayer/xiboplayer/issues/79) ✓ (already existed) |
 | Web Crypto (RSA) | ✅ | ✅ | — |
 
 ### vs Arexibo (Rust Player)
@@ -144,31 +144,31 @@ All 15 issues resolved. 8 implemented via PRs #86–#90, 5 already existed, 2 cl
 
 | # | Issue | Resolution | PR |
 |---|-------|-----------|-----|
-| 1 | [#70](https://github.com/xibo-players/xiboplayer/issues/70) | ✅ HTTP 429 Retry-After + HTTP-date parsing | #86 |
-| 2 | [#71](https://github.com/xibo-players/xiboplayer/issues/71) | ✅ Periodic fault reporting agent (60s timer) | #87 |
-| 3 | [#72](https://github.com/xibo-players/xiboplayer/issues/72) | ✅ Layout blacklisting (threshold + auto-reset) | #88 |
+| 1 | [#70](https://github.com/xiboplayer/xiboplayer/issues/70) | ✅ HTTP 429 Retry-After + HTTP-date parsing | #86 |
+| 2 | [#71](https://github.com/xiboplayer/xiboplayer/issues/71) | ✅ Periodic fault reporting agent (60s timer) | #87 |
+| 3 | [#72](https://github.com/xiboplayer/xiboplayer/issues/72) | ✅ Layout blacklisting (threshold + auto-reset) | #88 |
 
 ### Moderate — All Resolved
 
 | # | Issue | Resolution | PR |
 |---|-------|-----------|-----|
-| 4 | [#73](https://github.com/xibo-players/xiboplayer/issues/73) | ✅ Already implemented (weather → criteria) | — |
-| 5 | [#74](https://github.com/xibo-players/xiboplayer/issues/74) | ✅ Image/video scaletype mapping | #89 |
-| 6 | [#75](https://github.com/xibo-players/xiboplayer/issues/75) | ✅ BlackList via REST transport | #89 |
-| 7 | [#76](https://github.com/xibo-players/xiboplayer/issues/76) | ✅ NotifyStatus enrichment | #89 |
-| 8 | [#77](https://github.com/xibo-players/xiboplayer/issues/77) | ✅ Already implemented (recordEvent) | — |
-| 9 | [#78](https://github.com/xibo-players/xiboplayer/issues/78) | ✅ Already implemented (interleaveLayouts) | — |
-| 10 | [#79](https://github.com/xibo-players/xiboplayer/issues/79) | ✅ Already implemented in PWA | — |
+| 4 | [#73](https://github.com/xiboplayer/xiboplayer/issues/73) | ✅ Already implemented (weather → criteria) | — |
+| 5 | [#74](https://github.com/xiboplayer/xiboplayer/issues/74) | ✅ Image/video scaletype mapping | #89 |
+| 6 | [#75](https://github.com/xiboplayer/xiboplayer/issues/75) | ✅ BlackList via REST transport | #89 |
+| 7 | [#76](https://github.com/xiboplayer/xiboplayer/issues/76) | ✅ NotifyStatus enrichment | #89 |
+| 8 | [#77](https://github.com/xiboplayer/xiboplayer/issues/77) | ✅ Already implemented (recordEvent) | — |
+| 9 | [#78](https://github.com/xiboplayer/xiboplayer/issues/78) | ✅ Already implemented (interleaveLayouts) | — |
+| 10 | [#79](https://github.com/xiboplayer/xiboplayer/issues/79) | ✅ Already implemented in PWA | — |
 
 ### Minor — 4 Resolved, 1 Remaining
 
 | # | Issue | Resolution | PR |
 |---|-------|-----------|-----|
-| 11 | [#80](https://github.com/xibo-players/xiboplayer/issues/80) | ✅ Day + Month recurrence patterns | #90 |
-| 12 | [#81](https://github.com/xibo-players/xiboplayer/issues/81) | ✅ Download window enforcement in PlayerCore | #90 |
-| 13 | [#82](https://github.com/xibo-players/xiboplayer/issues/82) | ✅ Closed — fire-and-forget pattern sufficient | — |
-| 14 | [#83](https://github.com/xibo-players/xiboplayer/issues/83) | ✅ Already implemented (instant opacity fallback) | — |
-| 15 | [#84](https://github.com/xibo-players/xiboplayer/issues/84) | ✅ Closed — CMS API undocumented/unstable; stub sufficient | — |
+| 11 | [#80](https://github.com/xiboplayer/xiboplayer/issues/80) | ✅ Day + Month recurrence patterns | #90 |
+| 12 | [#81](https://github.com/xiboplayer/xiboplayer/issues/81) | ✅ Download window enforcement in PlayerCore | #90 |
+| 13 | [#82](https://github.com/xiboplayer/xiboplayer/issues/82) | ✅ Closed — fire-and-forget pattern sufficient | — |
+| 14 | [#83](https://github.com/xiboplayer/xiboplayer/issues/83) | ✅ Already implemented (instant opacity fallback) | — |
+| 15 | [#84](https://github.com/xiboplayer/xiboplayer/issues/84) | ✅ Closed — CMS API undocumented/unstable; stub sufficient | — |
 
 ## renderer-lite Advantages
 

--- a/packages/docs/DEPLOYMENT.md
+++ b/packages/docs/DEPLOYMENT.md
@@ -24,7 +24,7 @@ different host or `localhost`.
 ## Build
 
 ```bash
-git clone https://github.com/xibo-players/xiboplayer.git
+git clone https://github.com/xiboplayer/xiboplayer.git
 cd xiboplayer
 pnpm install
 pnpm --filter @xiboplayer/pwa build    # Production bundle → packages/pwa/dist/
@@ -53,7 +53,7 @@ For local or kiosk deployments where same-origin hosting isn't available,
 use the Electron wrapper. It injects CORS headers at the Chromium session
 level, allowing the PWA to connect to any remote CMS.
 
-See [xiboplayer-electron](https://github.com/xibo-players/xiboplayer-electron).
+See [xiboplayer-electron](https://github.com/xiboplayer/xiboplayer-electron).
 
 ## Development
 

--- a/packages/docs/QUICKSTART.md
+++ b/packages/docs/QUICKSTART.md
@@ -20,7 +20,7 @@ at the Chromium session level.
 ## Build
 
 ```bash
-git clone https://github.com/xibo-players/xiboplayer.git
+git clone https://github.com/xiboplayer/xiboplayer.git
 cd xiboplayer
 pnpm install
 pnpm --filter @xiboplayer/pwa build    # Production bundle → packages/pwa/dist/
@@ -55,7 +55,7 @@ The player should start downloading files and displaying layouts.
 
 ## Alternative: Electron (for kiosk/desktop)
 
-See [xiboplayer-electron](https://github.com/xibo-players/xiboplayer-electron).
+See [xiboplayer-electron](https://github.com/xiboplayer/xiboplayer-electron).
 
 Electron can connect to any remote CMS — no same-origin restriction.
 
@@ -77,4 +77,4 @@ Electron can connect to any remote CMS — no same-origin restriction.
 ## Next Steps
 
 - See [DEPLOYMENT.md](./DEPLOYMENT.md) for complete deployment guide
-- See [xiboplayer-electron](https://github.com/xibo-players/xiboplayer-electron) for Electron/kiosk setup
+- See [xiboplayer-electron](https://github.com/xiboplayer/xiboplayer-electron) for Electron/kiosk setup

--- a/packages/docs/STATUS.md
+++ b/packages/docs/STATUS.md
@@ -113,7 +113,7 @@ Code analysis of upstream Xibo player repositories confirmed:
 - **Arexibo**: 2 automated tests only (basic XMDS parsing)
 - **XiboPlayer**: 1614 tests across 49 test files, covering core, renderer, cache, schedule, xmds, xmr, stats, settings, sync, and crypto packages
 
-Features present in upstream that we do not implement: RS-232 serial (hardware limitation), PowerPoint rendering (COM automation, Windows-only), AXE/SSP ad integration (stub only), CMS tag-based schedule criteria. See [FEATURE_COMPARISON.md](https://github.com/xibo-players/xibo-players.github.io/blob/main/docs/FEATURE_COMPARISON.md) for full details.
+Features present in upstream that we do not implement: RS-232 serial (hardware limitation), PowerPoint rendering (COM automation, Windows-only), AXE/SSP ad integration (stub only), CMS tag-based schedule criteria. See [FEATURE_COMPARISON.md](https://github.com/xiboplayer/xiboplayer.github.io/blob/main/docs/FEATURE_COMPARISON.md) for full details.
 
 ## What Works
 
@@ -226,7 +226,7 @@ Features present in upstream that we do not implement: RS-232 serial (hardware l
 All 15 audit issues resolved (PRs #86–#90). 8 implemented, 5 closed as already done, 2 closed as not needed.
 
 ### Closed
-- [#84](https://github.com/xibo-players/xiboplayer/issues/84) Adspace exchange / SSP ad rotation — closed, CMS API undocumented/unstable; `isSspEnabled` stub sufficient
+- [#84](https://github.com/xiboplayer/xiboplayer/issues/84) Adspace exchange / SSP ad rotation — closed, CMS API undocumented/unstable; `isSspEnabled` stub sufficient
 
 ### Not Applicable (Browser Sandbox)
 - Shell commands (use HTTP commands instead)

--- a/packages/expr/package.json
+++ b/packages/expr/package.json
@@ -31,7 +31,7 @@
   "license": "AGPL-3.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/xibo-players/xiboplayer.git",
+    "url": "git+https://github.com/xiboplayer/xiboplayer.git",
     "directory": "packages/expr"
   },
   "homepage": "https://xiboplayer.org",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -31,7 +31,7 @@
   "license": "AGPL-3.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/xibo-players/xiboplayer.git",
+    "url": "git+https://github.com/xiboplayer/xiboplayer.git",
     "directory": "packages/player"
   },
   "homepage": "https://xiboplayer.org"

--- a/packages/proxy/README.md
+++ b/packages/proxy/README.md
@@ -118,4 +118,4 @@ Creates the app and starts listening. Returns `Promise<{ server, port }>`.
 
 ---
 
-[xiboplayer.org](https://xiboplayer.org) · **Part of the [XiboPlayer SDK](https://github.com/xibo-players/xiboplayer)**
+[xiboplayer.org](https://xiboplayer.org) · **Part of the [XiboPlayer SDK](https://github.com/xiboplayer/xiboplayer)**

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -39,7 +39,7 @@
   "license": "AGPL-3.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/xibo-players/xiboplayer.git",
+    "url": "git+https://github.com/xiboplayer/xiboplayer.git",
     "directory": "packages/proxy"
   },
   "homepage": "https://xiboplayer.org"

--- a/packages/pwa/README.md
+++ b/packages/pwa/README.md
@@ -1,6 +1,6 @@
 # xiboplayer PWA
 
-Lightweight PWA Xibo digital signage player built on the [`@xiboplayer` SDK](https://github.com/xibo-players/xiboplayer). Part of the SDK monorepo at `packages/pwa/`.
+Lightweight PWA Xibo digital signage player built on the [`@xiboplayer` SDK](https://github.com/xiboplayer/xiboplayer). Part of the SDK monorepo at `packages/pwa/`.
 
 ## CMS Communication
 

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -40,7 +40,7 @@
   "license": "AGPL-3.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/xibo-players/xiboplayer.git",
+    "url": "git+https://github.com/xiboplayer/xiboplayer.git",
     "directory": "packages/pwa"
   },
   "homepage": "https://xiboplayer.org"

--- a/packages/renderer/README.md
+++ b/packages/renderer/README.md
@@ -268,4 +268,4 @@ new RendererLite(config, container, options?)
 
 ---
 
-[xiboplayer.org](https://xiboplayer.org) · **Part of the [XiboPlayer SDK](https://github.com/xibo-players/xiboplayer)**
+[xiboplayer.org](https://xiboplayer.org) · **Part of the [XiboPlayer SDK](https://github.com/xiboplayer/xiboplayer)**

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -37,7 +37,7 @@
   "license": "AGPL-3.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/xibo-players/xiboplayer.git",
+    "url": "git+https://github.com/xiboplayer/xiboplayer.git",
     "directory": "packages/renderer"
   },
   "homepage": "https://xiboplayer.org"

--- a/packages/schedule/README.md
+++ b/packages/schedule/README.md
@@ -305,4 +305,4 @@ No external dependencies -- fully self-contained scheduling engine.
 
 ---
 
-[xiboplayer.org](https://xiboplayer.org) · **Part of the [XiboPlayer SDK](https://github.com/xibo-players/xiboplayer)**
+[xiboplayer.org](https://xiboplayer.org) · **Part of the [XiboPlayer SDK](https://github.com/xiboplayer/xiboplayer)**

--- a/packages/schedule/docs/XIBO_CAMPAIGNS_AND_PRIORITY.md
+++ b/packages/schedule/docs/XIBO_CAMPAIGNS_AND_PRIORITY.md
@@ -518,7 +518,7 @@ All players maintain full backward compatibility:
 - [Xibo Manual - Campaigns](https://xibosignage.com/manual/en/media_module_campaigns.html)
 
 ### Implementation Branches
-- **PWA**: `feature/pwa-campaigns` in [xiboplayer repo](https://github.com/xibo-players/xiboplayer)
+- **PWA**: `feature/pwa-campaigns` in [xiboplayer repo](https://github.com/xiboplayer/xiboplayer)
 - **Arexibo**: `feature/arx-dayparting` in [arexibo repo](https://github.com/linuxnow/arexibo)
 
 ### Related Documentation

--- a/packages/schedule/package.json
+++ b/packages/schedule/package.json
@@ -36,7 +36,7 @@
   "license": "AGPL-3.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/xibo-players/xiboplayer.git",
+    "url": "git+https://github.com/xiboplayer/xiboplayer.git",
     "directory": "packages/schedule"
   },
   "homepage": "https://xiboplayer.org"

--- a/packages/settings/README.md
+++ b/packages/settings/README.md
@@ -135,4 +135,4 @@ Extends EventEmitter -- supports `on()`, `off()`, `emit()`.
 
 ---
 
-[xiboplayer.org](https://xiboplayer.org) · **Part of the [XiboPlayer SDK](https://github.com/xibo-players/xiboplayer)**
+[xiboplayer.org](https://xiboplayer.org) · **Part of the [XiboPlayer SDK](https://github.com/xiboplayer/xiboplayer)**

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -32,7 +32,7 @@
   "license": "AGPL-3.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/xibo-players/xiboplayer.git",
+    "url": "git+https://github.com/xiboplayer/xiboplayer.git",
     "directory": "packages/settings"
   },
   "homepage": "https://xiboplayer.org"

--- a/packages/stats/README.md
+++ b/packages/stats/README.md
@@ -192,4 +192,4 @@ new LogReporter(cmsId?)
 
 ---
 
-[xiboplayer.org](https://xiboplayer.org) · **Part of the [XiboPlayer SDK](https://github.com/xibo-players/xiboplayer)**
+[xiboplayer.org](https://xiboplayer.org) · **Part of the [XiboPlayer SDK](https://github.com/xiboplayer/xiboplayer)**

--- a/packages/stats/package.json
+++ b/packages/stats/package.json
@@ -32,7 +32,7 @@
   "license": "AGPL-3.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/xibo-players/xiboplayer.git",
+    "url": "git+https://github.com/xiboplayer/xiboplayer.git",
     "directory": "packages/stats"
   },
   "homepage": "https://xiboplayer.org"

--- a/packages/sw/README.md
+++ b/packages/sw/README.md
@@ -97,4 +97,4 @@ const config = calculateChunkConfig();
 
 ---
 
-[xiboplayer.org](https://xiboplayer.org) · **Part of the [XiboPlayer SDK](https://github.com/xibo-players/xiboplayer)**
+[xiboplayer.org](https://xiboplayer.org) · **Part of the [XiboPlayer SDK](https://github.com/xiboplayer/xiboplayer)**

--- a/packages/sw/package.json
+++ b/packages/sw/package.json
@@ -32,7 +32,7 @@
   "license": "AGPL-3.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/xibo-players/xiboplayer.git",
+    "url": "git+https://github.com/xiboplayer/xiboplayer.git",
     "directory": "packages/sw"
   },
   "homepage": "https://xiboplayer.org"

--- a/packages/sync/README.md
+++ b/packages/sync/README.md
@@ -450,4 +450,4 @@ This package is deliberately **not**:
 
 ---
 
-[xiboplayer.org](https://xiboplayer.org) · **Part of the [XiboPlayer SDK](https://github.com/xibo-players/xiboplayer)**
+[xiboplayer.org](https://xiboplayer.org) · **Part of the [XiboPlayer SDK](https://github.com/xiboplayer/xiboplayer)**

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -31,7 +31,7 @@
   "license": "AGPL-3.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/xibo-players/xiboplayer.git",
+    "url": "git+https://github.com/xiboplayer/xiboplayer.git",
     "directory": "packages/sync"
   },
   "homepage": "https://xiboplayer.org"

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -152,4 +152,4 @@ No external runtime dependencies.
 
 ---
 
-[xiboplayer.org](https://xiboplayer.org) · **Part of the [XiboPlayer SDK](https://github.com/xibo-players/xiboplayer)**
+[xiboplayer.org](https://xiboplayer.org) · **Part of the [XiboPlayer SDK](https://github.com/xiboplayer/xiboplayer)**

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -33,7 +33,7 @@
   "license": "AGPL-3.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/xibo-players/xiboplayer.git",
+    "url": "git+https://github.com/xiboplayer/xiboplayer.git",
     "directory": "packages/utils"
   },
   "homepage": "https://xiboplayer.org"

--- a/packages/xmds/README.md
+++ b/packages/xmds/README.md
@@ -207,4 +207,4 @@ const client = new RestClient({
 
 ---
 
-[xiboplayer.org](https://xiboplayer.org) · **Part of the [XiboPlayer SDK](https://github.com/xibo-players/xiboplayer)**
+[xiboplayer.org](https://xiboplayer.org) · **Part of the [XiboPlayer SDK](https://github.com/xiboplayer/xiboplayer)**

--- a/packages/xmds/package.json
+++ b/packages/xmds/package.json
@@ -33,7 +33,7 @@
   "license": "AGPL-3.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/xibo-players/xiboplayer.git",
+    "url": "git+https://github.com/xiboplayer/xiboplayer.git",
     "directory": "packages/xmds"
   },
   "homepage": "https://xiboplayer.org"

--- a/packages/xmr/README.md
+++ b/packages/xmr/README.md
@@ -139,4 +139,4 @@ with generic action dispatch and zero third-party dependencies (no luxon, no nan
 
 ---
 
-[xiboplayer.org](https://xiboplayer.org) · **Part of the [XiboPlayer SDK](https://github.com/xibo-players/xiboplayer)**
+[xiboplayer.org](https://xiboplayer.org) · **Part of the [XiboPlayer SDK](https://github.com/xiboplayer/xiboplayer)**

--- a/packages/xmr/package.json
+++ b/packages/xmr/package.json
@@ -30,7 +30,7 @@
   "license": "AGPL-3.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/xibo-players/xiboplayer.git",
+    "url": "git+https://github.com/xiboplayer/xiboplayer.git",
     "directory": "packages/xmr"
   },
   "homepage": "https://xiboplayer.org"


### PR DESCRIPTION
GH org renamed; GraphQL/workflow-context/npm-scope don't follow redirects. Pure rename sweep, symmetric diff. Companion sweep across all sibling repos.