### PR TITLE
fix(publish): dispatch URL + reusable SHA pin post org-rename

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,7 +91,7 @@ jobs:
             --method POST \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/xibo-players/xiboplayer-www/dispatches \
+            /repos/xiboplayer/xiboplayer-www/dispatches \
             -f event_type=sdk-published \
             -f "client_payload[version]=${VER}" \
             -f "client_payload[source]=xiboplayer-sdk" \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   publish:
-    uses: xiboplayer/.github/.github/workflows/publish-npm.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
+    uses: xiboplayer/.github/.github/workflows/publish-npm.yml@cb1cc4593f5292fa2d5bd9c69b2d5c49dddde55a  # main
     with:
       publish-command: 'pnpm --filter @xiboplayer/pwa build && pnpm -r publish --no-git-checks --access public'
 
@@ -24,7 +24,7 @@ jobs:
   release:
     needs: publish
     if: startsWith(github.ref, 'refs/tags/')
-    uses: xiboplayer/.github/.github/workflows/create-release.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
+    uses: xiboplayer/.github/.github/workflows/create-release.yml@cb1cc4593f5292fa2d5bd9c69b2d5c49dddde55a  # main
     with:
       package-name: 'xiboplayer-sdk'
       description: 'xiboplayer SDK monorepo — @xiboplayer/* npm packages published together at matching versions.'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   unit:
-    uses: xiboplayer/.github/.github/workflows/test.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
+    uses: xiboplayer/.github/.github/workflows/test.yml@cb1cc4593f5292fa2d5bd9c69b2d5c49dddde55a  # main
     with:
       lint-command: 'pnpm lint'
       typecheck: true
@@ -19,7 +19,7 @@ jobs:
   integration:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     needs: unit
-    uses: xiboplayer/.github/.github/workflows/integration-test.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
+    uses: xiboplayer/.github/.github/workflows/integration-test.yml@cb1cc4593f5292fa2d5bd9c69b2d5c49dddde55a  # main
     with:
       cms-url: 'https://xibo-dev.superpantalles.com'
     secrets:


### PR DESCRIPTION
Closes #410.

## Summary

Two commits:

1. **`d2428b0 fix(publish): patch xiboplayer-www dispatch URL to new org slug`**
   `publish.yml:94` — the `dispatch-www` job's `gh api --method POST /repos/xibo-players/xiboplayer-www/dispatches` had the old org slug. After the org rename GitHub returns 307; `gh api` doesn't follow on POST → silent fail → `xiboplayer-www` never regenerates on SDK tag push. One-line URL fix.
2. **`5842423 ci: bump xiboplayer/.github reusable pins past org-rename URL fix`**
   The 4 `uses:` refs in publish.yml + test.yml were already on the new org slug (patched by #398) but pinned to a pre-`c85d100` SHA. Bumped to `cb1cc4593f` (current dot-github main HEAD, includes c85d100 + #46 awscli fix). Not strictly load-bearing for the SDK (the reusables called from here don't have dispatch URL bugs at the pinned SHA) but keeps the fleet consistent.

## Test plan

- [ ] After merge: push a no-op SDK patch tag.
- [ ] Watch `Trigger xiboplayer-www regeneration` job — HTTP 204, no `documentation_url` string in log.
- [ ] `gh run list -R xiboplayer/xiboplayer-www --workflow build-image.yml --event repository_dispatch --limit 3` shows a new run within ~1 min of the tag push.

## Risk

Low. Two narrow changes:
- The URL fix is the inverse of a known-bad URL → known-good URL; if anything breaks, GitHub returns a 4xx and the step fails-loud (vs. today's silent success).
- The SHA bump is to the proven-stable HEAD of dot-github main; same SHA pattern as `arexibo` PR #68.

## Companion work

- `xiboplayer/.github` PR #46 (cleanup-releases awscli) — merged just before this branch was cut. `cb1cc4593f` includes that fix.
- `xiboplayer/arexibo` PR #68 (same SHA bump on a different consumer) — open.

This is the third repo getting the post-org-rename URL+SHA treatment; remaining form-factor repos (kiosk/electron/chromium/chrome/android/tizen/webos) follow the same pattern.